### PR TITLE
fix: Qt5 compatibility and auto-framing checkbox

### DIFF
--- a/src/gui/FilterPreviewWidget.cpp
+++ b/src/gui/FilterPreviewWidget.cpp
@@ -5,9 +5,20 @@
 #include <QVector2D>
 #include <QVideoFrame>
 #include <QtMath>
+#include <QtGlobal>
 #include <cmath>
 
 namespace {
+
+// Qt compatibility: flipped() added in Qt 5.10, mirrored() deprecated in Qt 6
+inline QImage flipVertical(const QImage &image)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+    return image.flipped(Qt::Vertical);
+#else
+    return image.mirrored(false, true);
+#endif
+}
 
 const char *kVertexShaderSource = R"(#version 330 core
 layout(location = 0) in vec2 a_position;
@@ -269,7 +280,7 @@ void FilterPreviewWidget::paintGL()
                      GL_RGBA, GL_UNSIGNED_BYTE, output.bits());
         m_framebuffer->release();
 
-        emit processedFrameReady(output.flipped(Qt::Vertical));
+        emit processedFrameReady(flipVertical(output));
         m_emitPending = false;
     }
 
@@ -382,7 +393,7 @@ void FilterPreviewWidget::uploadTextureIfNeeded()
         m_texture->bind();
     }
 
-    QImage glImage = m_currentImage.flipped(Qt::Vertical);
+    QImage glImage = flipVertical(m_currentImage);
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
     glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0,
                     frameSize.width(), frameSize.height(),

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -258,7 +258,11 @@ void TrackingControlWidget::updateFromState(const CameraController::CameraState 
     // 2. Not during user action AND
     // 3. Command completion timer has expired AND
     // 4. Camera is not settling
-    bool shouldBeChecked = (state.aiMode != Device::AiWorkModeNone);
+    // For Tiny2: aiMode determines tracking state
+    // For non-Tiny2 (original Tiny): use autoFramingEnabled flag
+    bool shouldBeChecked = m_tiny2Capabilities
+        ? (state.aiMode != Device::AiWorkModeNone)
+        : state.autoFramingEnabled;
     bool commandInFlight = m_commandTimer->isActive();
     bool isSettling = m_controller->isSettling();
 


### PR DESCRIPTION
## Summary

Two bug fixes:

### 1. Qt5 compatibility for QImage::flipped() (fixes #12)
- Added `flipVertical()` helper with compile-time Qt version check
- Uses `flipped(Qt::Vertical)` on Qt 5.10+
- Falls back to `mirrored(false, true)` on older Qt versions

### 2. Auto-framing checkbox state fix (relates to #5)
- For non-Tiny2 cameras (original Tiny/Tiny4K), checkbox state now uses `autoFramingEnabled` flag
- Previously used `aiMode` which isn't reliably updated for non-Tiny2 cameras

## Testing

- [x] Qt6 build - no warnings
- [x] Auto-framing checkbox tested on Tiny2 - working correctly

## Needs verification

- [ ] Qt5 build (older systems)
- [ ] Auto-framing on original Tiny/Tiny4K models (@samdark if you can test)