### PR TITLE
fix(cli): resolve device detection race condition

### DIFF
--- a/src/cli/meet2_test.cpp
+++ b/src/cli/meet2_test.cpp
@@ -67,9 +67,17 @@ int main(int argc, char **argv)
     Devices::get().setDevChangedCallback(onDevChanged, nullptr);
     Devices::get().setEnableMdnsScan(false);  // USB only
 
-    // Wait for device detection
+    // Wait for device detection with timeout
     cout << "Waiting for OBSBOT camera..." << endl;
-    this_thread::sleep_for(chrono::seconds(3));
+    const int timeout_seconds = 10;
+    for (int i = 0; i < timeout_seconds * 10; i++) {
+        if (device_connected) {
+            // Give a moment for device list to be populated after callback
+            this_thread::sleep_for(chrono::milliseconds(200));
+            break;
+        }
+        this_thread::sleep_for(chrono::milliseconds(100));
+    }
 
     auto dev_list = Devices::get().getDevList();
     if (dev_list.empty()) {


### PR DESCRIPTION
## Summary

Fixes the CLI race condition where "No OBSBOT devices found!" was printed even when a device was connected.

**Before:** Fixed 3-second sleep, then check device list (race condition)
**After:** Poll for device callback, then check device list

## Changes

- Replace `sleep_for(3s)` with polling loop (100ms intervals, 10s timeout)
- Wait for `device_connected` callback flag before checking device list
- Add 200ms grace period after callback for list population

## Testing

Tested on Meet2 - device detection now waits for callback before proceeding.

## Related

- Reported in #8 (Tiny 2 Lite) - device was detected but list was checked too early
- Should help any camera with slower initialization