### PR TITLE
feat: snapshot capture with clipboard + configurable save path

### DIFF
--- a/src/common/Config.cpp
+++ b/src/common/Config.cpp
@@ -63,6 +63,7 @@ void Config::setDefaults()
     m_settings.virtualCameraEnabled = false;
     m_settings.virtualCameraDevice = "/dev/video42";
     m_settings.virtualCameraResolution = "match";
+    m_settings.snapshotDirectory = "";  // Empty = XDG Pictures default
 }
 
 std::string Config::getXdgConfigHome() const
@@ -186,7 +187,8 @@ bool Config::load(std::vector<ValidationError> &errors)
         "virtual_camera_enabled",
         "virtual_camera_device",
         "virtual_camera_resolution",
-        "white_balance_kelvin"
+        "white_balance_kelvin",
+        "snapshot_directory"
     };
 
     auto isPresetKey = [](const std::string &key) -> bool {
@@ -564,6 +566,8 @@ bool Config::parseLine(const std::string &line, int lineNumber, std::vector<Vali
             addError(InvalidValue, "virtual_camera_resolution must be 'match' or WIDTHxHEIGHT (e.g. 1280x720)");
             return false;
         }
+    } else if (key == "snapshot_directory") {
+        m_settings.snapshotDirectory = value;
     }
 
     return true;
@@ -789,6 +793,9 @@ bool Config::save()
     file << "virtual_camera_device=" << (m_settings.virtualCameraDevice.empty() ? "/dev/video42" : m_settings.virtualCameraDevice) << "\n";
     file << "# Set 'match' to follow the preview output, or WIDTHxHEIGHT (e.g. 1280x720)\n";
     file << "virtual_camera_resolution=" << (m_settings.virtualCameraResolution.empty() ? "match" : m_settings.virtualCameraResolution) << "\n";
+
+    file << "\n# Snapshot save directory (empty = ~/Pictures/obsbot-control/)\n";
+    file << "snapshot_directory=" << m_settings.snapshotDirectory << "\n";
 
     file.close();
     std::cout << "[Config] Configuration saved successfully to " << configPath << std::endl;

--- a/src/common/Config.h
+++ b/src/common/Config.h
@@ -76,6 +76,7 @@ public:
         bool virtualCameraEnabled;
         std::string virtualCameraDevice;
         std::string virtualCameraResolution;
+        std::string snapshotDirectory;    // Save path for snapshots (empty = XDG default)
     };
 
     Config();

--- a/src/gui/CameraPreviewWidget.cpp
+++ b/src/gui/CameraPreviewWidget.cpp
@@ -22,7 +22,6 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
-#include <memory>
 
 namespace {
 
@@ -211,10 +210,12 @@ void CameraPreviewWidget::captureSnapshot()
         return;
     }
 
-    auto conn = std::make_shared<QMetaObject::Connection>();
-    *conn = connect(m_filterPreviewWidget, &FilterPreviewWidget::processedFrameReady,
-                    this, [this, conn](const QImage &image) {
-                        disconnect(*conn);
+    // Cancel any pending snapshot before arming a new one
+    disconnect(m_snapshotConnection);
+
+    m_snapshotConnection = connect(m_filterPreviewWidget, &FilterPreviewWidget::processedFrameReady,
+                    this, [this](const QImage &image) {
+                        disconnect(m_snapshotConnection);
                         emit snapshotCaptured(image);
                     });
 }
@@ -249,6 +250,8 @@ void CameraPreviewWidget::startPreview()
 
 void CameraPreviewWidget::stopPreview()
 {
+    disconnect(m_snapshotConnection);
+
     if (m_videoSink) {
         disconnect(m_videoSink, nullptr, this, nullptr);
         delete m_videoSink;

--- a/src/gui/CameraPreviewWidget.cpp
+++ b/src/gui/CameraPreviewWidget.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <memory>
 
 namespace {
 
@@ -202,6 +203,20 @@ FilterPreviewWidget::VideoEffectsSettings CameraPreviewWidget::videoEffects() co
         return FilterPreviewWidget::VideoEffectsSettings::defaults();
     }
     return m_filterPreviewWidget->videoEffects();
+}
+
+void CameraPreviewWidget::captureSnapshot()
+{
+    if (!m_previewEnabled || !m_filterPreviewWidget) {
+        return;
+    }
+
+    auto conn = std::make_shared<QMetaObject::Connection>();
+    *conn = connect(m_filterPreviewWidget, &FilterPreviewWidget::processedFrameReady,
+                    this, [this, conn](const QImage &image) {
+                        disconnect(*conn);
+                        emit snapshotCaptured(image);
+                    });
 }
 
 void CameraPreviewWidget::startPreview()

--- a/src/gui/CameraPreviewWidget.h
+++ b/src/gui/CameraPreviewWidget.h
@@ -86,6 +86,7 @@ private:
 
     bool m_previewEnabled;
     bool m_isApplyingFormat;
+    QMetaObject::Connection m_snapshotConnection;
 };
 
 #endif // CAMERAPREVIEWWIDGET_H

--- a/src/gui/CameraPreviewWidget.h
+++ b/src/gui/CameraPreviewWidget.h
@@ -41,6 +41,7 @@ public:
     void setVirtualCameraStreamer(VirtualCameraStreamer *streamer);
     void setVideoEffects(const FilterPreviewWidget::VideoEffectsSettings &settings);
     FilterPreviewWidget::VideoEffectsSettings videoEffects() const;
+    void captureSnapshot();
 
 signals:
     void previewStateChanged(bool enabled);
@@ -48,6 +49,7 @@ signals:
     void previewStarted();  // Emitted when preview successfully starts
     void previewFailed(const QString &error);  // Emitted when preview fails to start
     void preferredFormatChanged(const QString &formatId);
+    void snapshotCaptured(const QImage &image);
 
 private slots:
     void onCameraError(QCamera::Error error);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -247,7 +247,7 @@ void MainWindow::setupUI()
     previewHeader->addStretch();
 
     m_snapshotButton = new QPushButton(tr("Snapshot"), m_previewCard);
-    m_snapshotButton->setObjectName("detachButton");
+    m_snapshotButton->setObjectName("snapshotButton");
     m_snapshotButton->setEnabled(false);
     previewHeader->addWidget(m_snapshotButton);
 
@@ -1721,22 +1721,18 @@ void MainWindow::onSnapshotCaptured(const QImage &image)
     }
 
     QDir dir(saveDir);
-    if (!dir.exists()) {
-        dir.mkpath(QStringLiteral("."));
+    if (!dir.exists() && !dir.mkpath(QStringLiteral("."))) {
+        m_statusLabel->setText(tr("Snapshot copied to clipboard (cannot create %1)").arg(saveDir));
+        return;
     }
 
     QString timestamp = QDateTime::currentDateTime().toString(QStringLiteral("yyyyMMdd_HHmmss"));
-    QString filePath = saveDir + QStringLiteral("/obsbot_") + timestamp + QStringLiteral(".png");
+    QString baseName = saveDir + QStringLiteral("/obsbot_") + timestamp;
+    QString filePath = baseName + QStringLiteral(".png");
 
     // Avoid overwriting if multiple snaps in the same second
-    if (QFile::exists(filePath)) {
-        for (int i = 1; i < 100; ++i) {
-            filePath = saveDir + QStringLiteral("/obsbot_") + timestamp
-                       + QStringLiteral("_") + QString::number(i) + QStringLiteral(".png");
-            if (!QFile::exists(filePath)) {
-                break;
-            }
-        }
+    for (int i = 1; QFile::exists(filePath) && i < 1000; ++i) {
+        filePath = baseName + QStringLiteral("_") + QString::number(i) + QStringLiteral(".png");
     }
 
     if (image.save(filePath, "PNG")) {

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -30,7 +30,12 @@
 #include <QColor>
 #include <QPalette>
 #include <QList>
+#include <QClipboard>
+#include <QDateTime>
+#include <QDir>
+#include <QFile>
 #include <QFileInfo>
+#include <QStandardPaths>
 #include <iostream>
 #include <array>
 #include <algorithm>
@@ -149,6 +154,7 @@ MainWindow::MainWindow(QWidget *parent)
     , m_virtualCameraDeviceEdit(nullptr)
     , m_virtualCameraResolutionCombo(nullptr)
     , m_virtualCameraStatusLabel(nullptr)
+    , m_snapshotDirectoryEdit(nullptr)
     , m_effectsWidget(nullptr)
     , m_virtualCameraStreamer(nullptr)
     , m_isApplyingStyle(false)
@@ -239,6 +245,11 @@ void MainWindow::setupUI()
     previewTitle->setObjectName("previewTitle");
     previewHeader->addWidget(previewTitle);
     previewHeader->addStretch();
+
+    m_snapshotButton = new QPushButton(tr("Snapshot"), m_previewCard);
+    m_snapshotButton->setObjectName("detachButton");
+    m_snapshotButton->setEnabled(false);
+    previewHeader->addWidget(m_snapshotButton);
 
     m_detachPreviewButton = new QPushButton(tr("Pop Out Preview"), m_previewCard);
     m_detachPreviewButton->setObjectName("detachButton");
@@ -431,6 +442,35 @@ void MainWindow::setupUI()
     virtualLayout->addWidget(virtualResolutionHint);
     scrollLayout->addWidget(virtualCameraGroup);
 
+    QGroupBox *snapshotGroup = new QGroupBox(tr("Snapshots"), scrollContent);
+    QVBoxLayout *snapshotLayout = new QVBoxLayout(snapshotGroup);
+    snapshotLayout->setContentsMargins(16, 16, 16, 16);
+    snapshotLayout->setSpacing(10);
+
+    QHBoxLayout *snapshotDirLayout = new QHBoxLayout();
+    snapshotDirLayout->setContentsMargins(0, 0, 0, 0);
+    snapshotDirLayout->setSpacing(8);
+
+    QLabel *snapshotDirLabel = new QLabel(tr("Save to"), snapshotGroup);
+    snapshotDirLayout->addWidget(snapshotDirLabel);
+
+    m_snapshotDirectoryEdit = new QLineEdit(snapshotGroup);
+    m_snapshotDirectoryEdit->setPlaceholderText(
+        QStandardPaths::writableLocation(QStandardPaths::PicturesLocation)
+        + QStringLiteral("/obsbot-control"));
+    connect(m_snapshotDirectoryEdit, &QLineEdit::editingFinished,
+            this, &MainWindow::onSnapshotDirectoryEdited);
+    snapshotDirLayout->addWidget(m_snapshotDirectoryEdit, 1);
+
+    snapshotLayout->addLayout(snapshotDirLayout);
+
+    QLabel *snapshotHint = new QLabel(tr("Snapshots are also copied to the clipboard. Leave blank for the default path shown above."), snapshotGroup);
+    snapshotHint->setWordWrap(true);
+    snapshotHint->setStyleSheet("color: palette(mid); font-size: 11px;");
+    snapshotLayout->addWidget(snapshotHint);
+
+    scrollLayout->addWidget(snapshotGroup);
+
     m_startMinimizedCheckbox = new QCheckBox(tr("Launch minimized / Close to tray"), scrollContent);
     m_startMinimizedCheckbox->setObjectName("footerCheckbox");
     connect(m_startMinimizedCheckbox, &QCheckBox::toggled,
@@ -462,6 +502,10 @@ void MainWindow::setupUI()
             this, &MainWindow::onPreviewFailed);
     connect(m_previewWidget, &CameraPreviewWidget::preferredFormatChanged,
             this, &MainWindow::onPreviewFormatChanged);
+    connect(m_snapshotButton, &QPushButton::clicked,
+            m_previewWidget, &CameraPreviewWidget::captureSnapshot);
+    connect(m_previewWidget, &CameraPreviewWidget::snapshotCaptured,
+            this, &MainWindow::onSnapshotCaptured);
 
     applyModernStyle();
     updateStatusBanner(false);
@@ -781,10 +825,12 @@ void MainWindow::updatePreviewControls()
             m_detachPreviewButton->blockSignals(false);
         }
         m_detachPreviewButton->setEnabled(false);
+        m_snapshotButton->setEnabled(false);
         m_detachPreviewButton->setText(tr("Pop Out Preview"));
         m_previewToggleButton->setText(tr("Start Preview"));
     } else {
         m_detachPreviewButton->setEnabled(true);
+        m_snapshotButton->setEnabled(true);
         if (m_detachPreviewButton->isChecked() != m_previewDetached) {
             m_detachPreviewButton->blockSignals(true);
             m_detachPreviewButton->setChecked(m_previewDetached);
@@ -1120,6 +1166,12 @@ void MainWindow::loadConfiguration()
         m_virtualCameraDeviceEdit->blockSignals(true);
         m_virtualCameraDeviceEdit->setText(QString::fromStdString(settings.virtualCameraDevice));
         m_virtualCameraDeviceEdit->blockSignals(false);
+    }
+
+    if (m_snapshotDirectoryEdit) {
+        m_snapshotDirectoryEdit->blockSignals(true);
+        m_snapshotDirectoryEdit->setText(QString::fromStdString(settings.snapshotDirectory));
+        m_snapshotDirectoryEdit->blockSignals(false);
     }
 
     m_settingsWidget->setWhiteBalanceKelvin(settings.whiteBalanceKelvin);
@@ -1648,4 +1700,56 @@ void MainWindow::onVideoEffectsChanged(const FilterPreviewWidget::VideoEffectsSe
         return;
     }
     m_previewWidget->setVideoEffects(settings);
+}
+
+void MainWindow::onSnapshotCaptured(const QImage &image)
+{
+    if (image.isNull()) {
+        return;
+    }
+
+    // Copy to clipboard
+    QClipboard *clipboard = QApplication::clipboard();
+    clipboard->setImage(image);
+
+    // Save to file
+    auto settings = m_controller->getConfig().getSettings();
+    QString saveDir = QString::fromStdString(settings.snapshotDirectory);
+    if (saveDir.isEmpty()) {
+        saveDir = QStandardPaths::writableLocation(QStandardPaths::PicturesLocation)
+                  + QStringLiteral("/obsbot-control");
+    }
+
+    QDir dir(saveDir);
+    if (!dir.exists()) {
+        dir.mkpath(QStringLiteral("."));
+    }
+
+    QString timestamp = QDateTime::currentDateTime().toString(QStringLiteral("yyyyMMdd_HHmmss"));
+    QString filePath = saveDir + QStringLiteral("/obsbot_") + timestamp + QStringLiteral(".png");
+
+    // Avoid overwriting if multiple snaps in the same second
+    if (QFile::exists(filePath)) {
+        for (int i = 1; i < 100; ++i) {
+            filePath = saveDir + QStringLiteral("/obsbot_") + timestamp
+                       + QStringLiteral("_") + QString::number(i) + QStringLiteral(".png");
+            if (!QFile::exists(filePath)) {
+                break;
+            }
+        }
+    }
+
+    if (image.save(filePath, "PNG")) {
+        m_statusLabel->setText(tr("Snapshot saved + copied to clipboard: %1").arg(filePath));
+    } else {
+        m_statusLabel->setText(tr("Snapshot copied to clipboard (file save failed)"));
+    }
+}
+
+void MainWindow::onSnapshotDirectoryEdited()
+{
+    auto settings = m_controller->getConfig().getSettings();
+    settings.snapshotDirectory = m_snapshotDirectoryEdit->text().trimmed().toStdString();
+    m_controller->getConfig().setSettings(settings);
+    m_controller->saveConfig();
 }

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -62,6 +62,8 @@ private slots:
     void onVirtualCameraResolutionChanged(int index);
     void onVirtualCameraError(const QString &message);
     void onVideoEffectsChanged(const FilterPreviewWidget::VideoEffectsSettings &settings);
+    void onSnapshotCaptured(const QImage &image);
+    void onSnapshotDirectoryEdited();
 
 private:
     void setupUI();
@@ -86,6 +88,7 @@ private:
     // UI
     QPushButton *m_previewToggleButton;
     QPushButton *m_detachPreviewButton;
+    QPushButton *m_snapshotButton;
     QPushButton *m_reconnectButton;
     QLabel *m_deviceInfoLabel;
     QLabel *m_cameraWarningLabel;  // Warning for camera in use
@@ -104,6 +107,7 @@ private:
     QLineEdit *m_virtualCameraDeviceEdit;
     QComboBox *m_virtualCameraResolutionCombo;
     QLabel *m_virtualCameraStatusLabel;
+    QLineEdit *m_snapshotDirectoryEdit;
 
     // Control widgets
     TrackingControlWidget *m_trackingWidget;


### PR DESCRIPTION
## Summary
- Snapshot button in the preview header captures the current frame (with GPU filters applied)
- Every snapshot copies to system clipboard AND saves as PNG
- Save directory configurable via `snapshot_directory` in settings.conf (or the new UI field)
- Default: `~/Pictures/obsbot-control/` (XDG Pictures)
- Filenames: `obsbot_YYYYMMDD_HHmmss.png` with collision avoidance

## Test plan
- [ ] Start preview, click Snapshot — verify file appears in `~/Pictures/obsbot-control/`
- [ ] Paste in an image editor — verify clipboard has the snapshot
- [ ] Apply a Creative FX filter, snap again — verify filter is baked into the saved image
- [ ] Set custom `snapshot_directory` in the UI — verify saves redirect
- [ ] Upgrade from previous config (no `snapshot_directory` key) — verify no validation errors