### PR TITLE
feat: V4L2 fallback for unsupported cameras (OBSBOT Tiny 3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ add_executable(obsbot-gui
     src/gui/VirtualCameraStreamer.h
     src/gui/PreviewWindow.cpp
     src/gui/PreviewWindow.h
+    src/gui/V4l2Backend.cpp
+    src/gui/V4l2Backend.h
     src/gui/XYPad.cpp
     src/gui/XYPad.h
     src/common/Config.cpp

--- a/src/common/Config.cpp
+++ b/src/common/Config.cpp
@@ -44,6 +44,7 @@ void Config::setDefaults()
     m_settings.saturation = 128;
     m_settings.whiteBalance = 0;      // Auto
     m_settings.whiteBalanceKelvin = 5000;
+    m_settings.focus = -1;            // Auto focus
 
     // Audio defaults
     m_settings.audioAutoGain = true;
@@ -188,6 +189,7 @@ bool Config::load(std::vector<ValidationError> &errors)
         "virtual_camera_device",
         "virtual_camera_resolution",
         "white_balance_kelvin",
+        "focus",
         "snapshot_directory"
     };
 
@@ -351,11 +353,14 @@ bool Config::parseLine(const std::string &line, int lineNumber, std::vector<Vali
     } else if (key == "zoom") {
         try {
             double zoom = std::stod(value);
-            if (zoom < 1.0 || zoom > 2.0) {
+            if (zoom == 0.0) {
+                m_settings.zoom = 0.0;
+            } else if (zoom < 1.0 || zoom > 2.0) {
                 addError(InvalidValue, "zoom must be between 1.0 and 2.0");
                 return false;
+            } else {
+                m_settings.zoom = zoom;
             }
-            m_settings.zoom = zoom;
         } catch (...) {
             addError(InvalidValue, "zoom must be a number between 1.0 and 2.0");
             return false;
@@ -433,11 +438,14 @@ bool Config::parseLine(const std::string &line, int lineNumber, std::vector<Vali
     } else if (key == "brightness") {
         try {
             int brightness = std::stoi(value);
-            if (brightness < 0 || brightness > 255) {
+            if (brightness == -1) {
+                m_settings.brightness = -1;
+            } else if (brightness < 0 || brightness > 255) {
                 addError(InvalidValue, "brightness must be between 0 and 255");
                 return false;
+            } else {
+                m_settings.brightness = brightness;
             }
-            m_settings.brightness = brightness;
         } catch (...) {
             addError(InvalidValue, "brightness must be an integer between 0 and 255");
             return false;
@@ -450,11 +458,14 @@ bool Config::parseLine(const std::string &line, int lineNumber, std::vector<Vali
     } else if (key == "contrast") {
         try {
             int contrast = std::stoi(value);
-            if (contrast < 0 || contrast > 255) {
+            if (contrast == -1) {
+                m_settings.contrast = -1;
+            } else if (contrast < 0 || contrast > 255) {
                 addError(InvalidValue, "contrast must be between 0 and 255");
                 return false;
+            } else {
+                m_settings.contrast = contrast;
             }
-            m_settings.contrast = contrast;
         } catch (...) {
             addError(InvalidValue, "contrast must be an integer between 0 and 255");
             return false;
@@ -467,11 +478,14 @@ bool Config::parseLine(const std::string &line, int lineNumber, std::vector<Vali
     } else if (key == "saturation") {
         try {
             int saturation = std::stoi(value);
-            if (saturation < 0 || saturation > 255) {
+            if (saturation == -1) {
+                m_settings.saturation = -1;
+            } else if (saturation < 0 || saturation > 255) {
                 addError(InvalidValue, "saturation must be between 0 and 255");
                 return false;
+            } else {
+                m_settings.saturation = saturation;
             }
-            m_settings.saturation = saturation;
         } catch (...) {
             addError(InvalidValue, "saturation must be an integer between 0 and 255");
             return false;
@@ -502,13 +516,31 @@ bool Config::parseLine(const std::string &line, int lineNumber, std::vector<Vali
     } else if (key == "white_balance_kelvin") {
         try {
             int kelvin = std::stoi(value);
-            if (kelvin < 2000 || kelvin > 10000) {
+            if (kelvin == -1) {
+                m_settings.whiteBalanceKelvin = -1;
+            } else if (kelvin < 2000 || kelvin > 10000) {
                 addError(InvalidValue, "white_balance_kelvin must be between 2000 and 10000");
                 return false;
+            } else {
+                m_settings.whiteBalanceKelvin = kelvin;
             }
-            m_settings.whiteBalanceKelvin = kelvin;
         } catch (...) {
             addError(InvalidValue, "white_balance_kelvin must be an integer between 2000 and 10000");
+            return false;
+        }
+    } else if (key == "focus") {
+        try {
+            int focus = std::stoi(value);
+            if (focus == -1) {
+                m_settings.focus = -1;
+            } else if (focus < 0 || focus > 100) {
+                addError(InvalidValue, "focus must be between 0 and 100");
+                return false;
+            } else {
+                m_settings.focus = focus;
+            }
+        } catch (...) {
+            addError(InvalidValue, "focus must be an integer between 0 and 100");
             return false;
         }
     } else if (key == "audio_auto_gain") {
@@ -589,7 +621,7 @@ bool Config::validateSettings(std::vector<ValidationError> &errors)
         addError("fov out of range (must be 0-2)");
     }
 
-    if (m_settings.zoom < 1.0 || m_settings.zoom > 2.0) {
+    if (m_settings.zoom != 0.0 && (m_settings.zoom < 1.0 || m_settings.zoom > 2.0)) {
         addError("zoom out of range (must be 1.0-2.0)");
     }
 
@@ -614,7 +646,7 @@ bool Config::validateSettings(std::vector<ValidationError> &errors)
     }
 
     if (m_settings.whiteBalance == 255) {
-        if (m_settings.whiteBalanceKelvin < 2000 || m_settings.whiteBalanceKelvin > 10000) {
+        if (m_settings.whiteBalanceKelvin != -1 && (m_settings.whiteBalanceKelvin < 2000 || m_settings.whiteBalanceKelvin > 10000)) {
             addError("white_balance_kelvin out of range (must be 2000-10000)");
         }
     }
@@ -768,6 +800,9 @@ bool Config::save()
     file << "white_balance=" << wbStr << "\n";
     file << "# Manual white balance temperature (Kelvin, only used when white_balance=manual)\n";
     file << "white_balance_kelvin=" << m_settings.whiteBalanceKelvin << "\n\n";
+
+    file << "# Manual focus position (0-100, -1 = auto)\n";
+    file << "focus=" << m_settings.focus << "\n\n";
 
     for (size_t i = 0; i < m_settings.presets.size(); ++i) {
         const auto &preset = m_settings.presets[i];

--- a/src/common/Config.h
+++ b/src/common/Config.h
@@ -62,6 +62,7 @@ public:
         int saturation;       // Typically 0-255 or similar range
         int whiteBalance;     // 0=Auto, 1=Daylight, 2=Fluorescent, etc.
         int whiteBalanceKelvin; // Manual Kelvin value (when whiteBalance==255)
+        int focus;            // Manual focus position (0-100, -1 = auto)
 
         // Audio
         bool audioAutoGain;   // Enable auto gain control for microphones

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -2,6 +2,8 @@
 #include <QThread>
 #include <algorithm>
 
+static constexpr int kDefaultWhiteBalanceKelvin = 4800;
+
 CameraController::CameraController(QObject *parent)
     : QObject(parent)
     , m_connected(false)
@@ -58,9 +60,6 @@ void CameraController::connectToCamera()
     Devices::get().setDevChangedCallback(onDevChanged, nullptr);
     Devices::get().setEnableMdnsScan(false);  // USB only
 
-    // Actively check for existing devices (handles reconnection scenario)
-    // The callback only fires on connect/disconnect events, so if the device
-    // is already connected (e.g., after window restore), we need to connect directly
     auto dev_list = Devices::get().getDevList();
     if (!dev_list.empty() && !m_connected) {
         m_device = dev_list.front();
@@ -68,21 +67,132 @@ void CameraController::connectToCamera()
 
         m_cameraInfo.name = QString::fromStdString(m_device->devName());
         m_cameraInfo.serialNumber = QString::fromStdString(m_device->devSn());
-    m_cameraInfo.version = QString::fromStdString(m_device->devVersion());
-    m_cameraInfo.productType = m_device->productType();
+        m_cameraInfo.version = QString::fromStdString(m_device->devVersion());
+        m_cameraInfo.productType = m_device->productType();
+        m_cameraInfo.connected = true;
+
+        refreshControlRanges();
+        emit cameraConnected(m_cameraInfo);
+        updateState();
+    } else {
+        tryV4l2Fallback();
+    }
+}
+
+void CameraController::tryV4l2Fallback()
+{
+    auto path = V4l2Backend::findObsbotDevice();
+    if (!path.empty()) {
+        connectV4l2(path);
+        return;
+    }
+
+    if (!m_v4l2ScanTimer) {
+        m_v4l2ScanTimer = new QTimer(this);
+        m_v4l2ScanTimer->setSingleShot(false);
+        connect(m_v4l2ScanTimer, &QTimer::timeout, this, [this]() {
+            if (m_connected)
+                return;
+            auto path = V4l2Backend::findObsbotDevice();
+            if (!path.empty()) {
+                m_v4l2ScanTimer->stop();
+                connectV4l2(path);
+            }
+        });
+    }
+    m_v4l2ScanTimer->start(3000);
+}
+
+void CameraController::connectV4l2(const std::string &devicePath)
+{
+    if (!m_v4l2.open(devicePath))
+        return;
+
+    Devices::get().close();
+
+    m_connected = true;
+    m_v4l2Only = true;
+    m_v4l2DevicePath = QString::fromStdString(devicePath);
+
+    std::string card = m_v4l2.cardName();
+    auto colon = card.find(':');
+    if (colon != std::string::npos)
+        card = card.substr(0, colon);
+    if (card.empty())
+        card = "OBSBOT";
+    m_cameraInfo.name = QString::fromStdString(card) + QStringLiteral(" (V4L2)");
+    m_cameraInfo.serialNumber = QString();
+    m_cameraInfo.version = QString();
+    m_cameraInfo.productType = -1;
     m_cameraInfo.connected = true;
 
-    refreshControlRanges();
+    refreshV4l2ControlRanges();
+
+    m_v4l2.setWhiteBalanceAuto(false);
+    m_v4l2.setWhiteBalanceTemperature(kDefaultWhiteBalanceKelvin);
+
     emit cameraConnected(m_cameraInfo);
-    updateState();
-    }
+    updateV4l2State();
+}
+
+void CameraController::refreshV4l2ControlRanges()
+{
+    auto convert = [](V4l2Backend::ControlRange r) -> ParamRange {
+        return {r.min, r.max, r.step, r.defaultValue, r.valid};
+    };
+
+    m_brightnessRange = convert(m_v4l2.getBrightnessRange());
+    m_contrastRange = convert(m_v4l2.getContrastRange());
+    m_saturationRange = convert(m_v4l2.getSaturationRange());
+    m_whiteBalanceKelvinRange = convert(m_v4l2.getWhiteBalanceTemperatureRange());
+
+    m_supportedWhiteBalanceTypes.clear();
+    m_supportedWhiteBalanceTypes.push_back(static_cast<int>(Device::DevWhiteBalanceAuto));
+    m_supportedWhiteBalanceTypes.push_back(static_cast<int>(Device::DevWhiteBalanceManual));
+}
+
+void CameraController::updateV4l2State()
+{
+    if (!m_v4l2.isOpen())
+        return;
+
+    m_currentState.brightness = m_v4l2.getBrightness();
+    m_currentState.contrast = m_v4l2.getContrast();
+    m_currentState.saturation = m_v4l2.getSaturation();
+
+    bool autoWb = m_v4l2.getWhiteBalanceAuto();
+    m_currentState.whiteBalance = autoWb
+        ? static_cast<int>(Device::DevWhiteBalanceAuto)
+        : static_cast<int>(Device::DevWhiteBalanceManual);
+    m_currentState.whiteBalanceKelvin = m_v4l2.getWhiteBalanceTemperature();
+
+    auto zoomRange = m_v4l2.getZoomRange();
+    int zoomMax = zoomRange.valid ? zoomRange.max : 100;
+    int zoomRaw = m_v4l2.getZoomAbsolute();
+    m_currentState.zoom = (zoomMax > 0) ? (static_cast<double>(zoomRaw) / zoomMax + 1.0) : 1.0;
+
+    auto panRange = m_v4l2.getPanRange();
+    auto tiltRange = m_v4l2.getTiltRange();
+    if (panRange.valid && panRange.max != 0)
+        m_currentState.pan = static_cast<double>(m_v4l2.getPanAbsolute()) / panRange.max;
+    if (tiltRange.valid && tiltRange.max != 0)
+        m_currentState.tilt = static_cast<double>(m_v4l2.getTiltAbsolute()) / tiltRange.max;
+
+    m_currentState.autoFocusEnabled = m_v4l2.getAutoFocus();
+    m_currentState.manualFocusValue = m_v4l2.getFocusAbsolute();
+
+    emit stateChanged(m_currentState);
 }
 
 void CameraController::disconnectFromCamera()
 {
     if (m_connected) {
-        // Release our device handle - this allows other apps to access the camera
-        m_device.reset();
+        if (m_v4l2Only) {
+            m_v4l2.close();
+            m_v4l2Only = false;
+        } else {
+            m_device.reset();
+        }
         m_connected = false;
         m_cameraInfo.connected = false;
         resetControlRanges();
@@ -93,18 +203,21 @@ void CameraController::disconnectFromCamera()
 
 QString CameraController::getVideoDevicePath() const
 {
-    if (m_connected && m_device) {
+    if (m_v4l2Only)
+        return m_v4l2DevicePath;
+    if (m_connected && m_device)
         return QString::fromStdString(m_device->videoDevPath());
-    }
     return QString();
 }
 
 CameraController::CameraState CameraController::getCurrentState()
 {
     if (m_connected && !isSettling()) {
-        updateState();
+        if (m_v4l2Only)
+            updateV4l2State();
+        else
+            updateState();
     }
-    // Return cached state during settling, actual state otherwise
     return isSettling() ? m_cachedState : m_currentState;
 }
 
@@ -115,7 +228,7 @@ bool CameraController::hasTiny2Capabilities() const
 
 bool CameraController::enableAutoFraming(bool enabled)
 {
-    if (!m_connected) return false;
+    if (!m_connected || m_v4l2Only) return false;
 
     if (enabled) {
         // Step 1: Set MediaMode to AutoFrame
@@ -155,7 +268,7 @@ bool CameraController::enableAutoFraming(bool enabled)
 
 bool CameraController::setAiMode(int mode, int subMode)
 {
-    if (!m_connected) return false;
+    if (!m_connected || m_v4l2Only) return false;
 
     auto workMode = static_cast<Device::AiWorkModeType>(mode);
     bool success = executeCommand("Set AI Mode", [this, workMode, subMode]() {
@@ -174,7 +287,7 @@ bool CameraController::setAiMode(int mode, int subMode)
 
 bool CameraController::setAutoZoom(bool enabled)
 {
-    if (!m_connected) return false;
+    if (!m_connected || m_v4l2Only) return false;
 
     bool success = executeCommand(enabled ? "Enable Auto Zoom" : "Disable Auto Zoom", [this, enabled]() {
         return m_device->aiSetAiAutoZoomR(enabled);
@@ -190,7 +303,7 @@ bool CameraController::setAutoZoom(bool enabled)
 
 bool CameraController::setTrackSpeed(int speedMode)
 {
-    if (!m_connected) return false;
+    if (!m_connected || m_v4l2Only) return false;
 
     auto speed = static_cast<Device::AiTrackSpeedType>(speedMode);
     bool success = executeCommand("Set Tracking Speed", [this, speed]() {
@@ -207,7 +320,7 @@ bool CameraController::setTrackSpeed(int speedMode)
 
 bool CameraController::setAudioAutoGain(bool enabled)
 {
-    if (!m_connected) return false;
+    if (!m_connected || m_v4l2Only) return false;
 
     bool success = executeCommand(enabled ? "Enable Audio Auto Gain" : "Disable Audio Auto Gain", [this, enabled]() {
         return m_device->cameraSetAudioAutoGainU(enabled);
@@ -225,13 +338,21 @@ bool CameraController::setPanTilt(double pan, double tilt)
 {
     if (!m_connected) return false;
 
-    // Clamp values
     pan = qBound(-1.0, pan, 1.0);
     tilt = qBound(-1.0, tilt, 1.0);
 
-    bool success = executeCommand("Set Pan/Tilt", [this, pan, tilt]() {
-        return m_device->cameraSetPanTiltAbsolute(pan, tilt);
-    });
+    bool success;
+    if (m_v4l2Only) {
+        auto panRange = m_v4l2.getPanRange();
+        auto tiltRange = m_v4l2.getTiltRange();
+        int panVal = static_cast<int>(pan * panRange.max);
+        int tiltVal = static_cast<int>(tilt * tiltRange.max);
+        success = m_v4l2.setPanAbsolute(panVal) && m_v4l2.setTiltAbsolute(tiltVal);
+    } else {
+        success = executeCommand("Set Pan/Tilt", [this, pan, tilt]() {
+            return m_device->cameraSetPanTiltAbsolute(pan, tilt);
+        });
+    }
 
     if (success) {
         m_currentState.pan = pan;
@@ -258,12 +379,19 @@ bool CameraController::setZoom(double zoom)
 {
     if (!m_connected) return false;
 
-    // Clamp to valid range (1.0 - 2.0)
     zoom = qBound(1.0, zoom, 2.0);
 
-    bool success = executeCommand("Set Zoom", [this, zoom]() {
-        return m_device->cameraSetZoomAbsoluteR(zoom);
-    });
+    bool success;
+    if (m_v4l2Only) {
+        auto zoomRange = m_v4l2.getZoomRange();
+        int zoomMax = zoomRange.valid ? zoomRange.max : 100;
+        int v4l2Zoom = static_cast<int>((zoom - 1.0) * zoomMax);
+        success = m_v4l2.setZoomAbsolute(v4l2Zoom);
+    } else {
+        success = executeCommand("Set Zoom", [this, zoom]() {
+            return m_device->cameraSetZoomAbsoluteR(zoom);
+        });
+    }
 
     if (success) {
         m_currentState.zoom = zoom;
@@ -280,7 +408,7 @@ bool CameraController::centerView()
 
 bool CameraController::setHDR(bool enabled)
 {
-    if (!m_connected) return false;
+    if (!m_connected || m_v4l2Only) return false;
 
     return executeCommand(enabled ? "Enable HDR" : "Disable HDR", [this, enabled]() {
         return m_device->cameraSetWdrR(enabled ? Device::DevWdrModeDol2TO1 : Device::DevWdrModeNone);
@@ -289,7 +417,7 @@ bool CameraController::setHDR(bool enabled)
 
 bool CameraController::setFOV(int fovMode)
 {
-    if (!m_connected) return false;
+    if (!m_connected || m_v4l2Only) return false;
 
     Device::FovType fov;
     switch (fovMode) {
@@ -306,7 +434,7 @@ bool CameraController::setFOV(int fovMode)
 
 bool CameraController::setFaceAE(bool enabled)
 {
-    if (!m_connected) return false;
+    if (!m_connected || m_v4l2Only) return false;
 
     return executeCommand(enabled ? "Enable Face AE" : "Disable Face AE", [this, enabled]() {
         return m_device->cameraSetFaceAER(enabled);
@@ -315,7 +443,7 @@ bool CameraController::setFaceAE(bool enabled)
 
 bool CameraController::setFaceFocus(bool enabled)
 {
-    if (!m_connected) return false;
+    if (!m_connected || m_v4l2Only) return false;
 
     return executeCommand(enabled ? "Enable Face Focus" : "Disable Face Focus", [this, enabled]() {
         return m_device->cameraSetFaceFocusR(enabled);
@@ -326,9 +454,16 @@ bool CameraController::setFocusAbsolute(int position, bool autoFocus)
 {
     if (!m_connected) return false;
     position = qBound(0, position, 100);
-    bool success = executeCommand("Set Focus", [this, position, autoFocus]() {
-        return m_device->cameraSetFocusAbsolute(position, autoFocus);
-    });
+
+    bool success;
+    if (m_v4l2Only) {
+        m_v4l2.setAutoFocus(autoFocus);
+        success = autoFocus || m_v4l2.setFocusAbsolute(position);
+    } else {
+        success = executeCommand("Set Focus", [this, position, autoFocus]() {
+            return m_device->cameraSetFocusAbsolute(position, autoFocus);
+        });
+    }
     if (success) {
         m_currentState.autoFocusEnabled = autoFocus;
         m_currentState.manualFocusValue = position;
@@ -340,16 +475,17 @@ bool CameraController::setFocusAbsolute(int position, bool autoFocus)
 bool CameraController::setBrightness(int value)
 {
     if (!m_connected) return false;
-
-    // Don't send command if in auto mode
-    if (m_currentState.brightnessAuto) {
-        return true;
-    }
+    if (m_currentState.brightnessAuto) return true;
 
     int clamped = clampToRange(value, m_brightnessRange, 0, 255);
-    bool success = executeCommand("Set Brightness", [this, clamped]() {
-        return m_device->cameraSetImageBrightnessR(clamped);
-    });
+    bool success;
+    if (m_v4l2Only) {
+        success = m_v4l2.setBrightness(clamped);
+    } else {
+        success = executeCommand("Set Brightness", [this, clamped]() {
+            return m_device->cameraSetImageBrightnessR(clamped);
+        });
+    }
     if (success) {
         m_currentState.brightness = clamped;
         emit stateChanged(m_currentState);
@@ -360,16 +496,17 @@ bool CameraController::setBrightness(int value)
 bool CameraController::setContrast(int value)
 {
     if (!m_connected) return false;
-
-    // Don't send command if in auto mode
-    if (m_currentState.contrastAuto) {
-        return true;
-    }
+    if (m_currentState.contrastAuto) return true;
 
     int clamped = clampToRange(value, m_contrastRange, 0, 255);
-    bool success = executeCommand("Set Contrast", [this, clamped]() {
-        return m_device->cameraSetImageContrastR(clamped);
-    });
+    bool success;
+    if (m_v4l2Only) {
+        success = m_v4l2.setContrast(clamped);
+    } else {
+        success = executeCommand("Set Contrast", [this, clamped]() {
+            return m_device->cameraSetImageContrastR(clamped);
+        });
+    }
     if (success) {
         m_currentState.contrast = clamped;
         emit stateChanged(m_currentState);
@@ -380,16 +517,17 @@ bool CameraController::setContrast(int value)
 bool CameraController::setSaturation(int value)
 {
     if (!m_connected) return false;
-
-    // Don't send command if in auto mode
-    if (m_currentState.saturationAuto) {
-        return true;
-    }
+    if (m_currentState.saturationAuto) return true;
 
     int clamped = clampToRange(value, m_saturationRange, 0, 255);
-    bool success = executeCommand("Set Saturation", [this, clamped]() {
-        return m_device->cameraSetImageSaturationR(clamped);
-    });
+    bool success;
+    if (m_v4l2Only) {
+        success = m_v4l2.setSaturation(clamped);
+    } else {
+        success = executeCommand("Set Saturation", [this, clamped]() {
+            return m_device->cameraSetImageSaturationR(clamped);
+        });
+    }
     if (success) {
         m_currentState.saturation = clamped;
         emit stateChanged(m_currentState);
@@ -400,6 +538,32 @@ bool CameraController::setSaturation(int value)
 bool CameraController::setWhiteBalance(int mode)
 {
     if (!m_connected) return false;
+
+    if (m_v4l2Only) {
+        if (mode == static_cast<int>(Device::DevWhiteBalanceAuto)) {
+            m_v4l2.setWhiteBalanceAuto(true);
+            m_currentState.whiteBalance = mode;
+            emit stateChanged(m_currentState);
+            return true;
+        }
+        if (mode == static_cast<int>(Device::DevWhiteBalanceManual)) {
+            m_v4l2.setWhiteBalanceAuto(false);
+            m_v4l2.setWhiteBalanceTemperature(m_currentState.whiteBalanceKelvin);
+            m_currentState.whiteBalance = mode;
+            emit stateChanged(m_currentState);
+            return true;
+        }
+        int kelvin = whiteBalancePresetToKelvin(mode);
+        if (kelvin > 0) {
+            m_v4l2.setWhiteBalanceAuto(false);
+            m_v4l2.setWhiteBalanceTemperature(kelvin);
+            m_currentState.whiteBalance = mode;
+            m_currentState.whiteBalanceKelvin = kelvin;
+            emit stateChanged(m_currentState);
+            return true;
+        }
+        return false;
+    }
 
     m_lastRequestedWhiteBalance = mode;
 
@@ -463,6 +627,18 @@ bool CameraController::setWhiteBalance(int mode)
 bool CameraController::setWhiteBalanceManual(int kelvin)
 {
     if (!m_connected) return false;
+
+    if (m_v4l2Only) {
+        int clamped = clampToRange(kelvin, m_whiteBalanceKelvinRange, 2000, 10000);
+        m_v4l2.setWhiteBalanceAuto(false);
+        bool success = m_v4l2.setWhiteBalanceTemperature(clamped);
+        if (success) {
+            m_currentState.whiteBalance = static_cast<int>(Device::DevWhiteBalanceManual);
+            m_currentState.whiteBalanceKelvin = clamped;
+            emit stateChanged(m_currentState);
+        }
+        return success;
+    }
 
     m_lastRequestedWhiteBalance = static_cast<int>(Device::DevWhiteBalanceManual);
     m_whiteBalanceFallbackActive = false;
@@ -585,6 +761,11 @@ void CameraController::applyConfigToCamera()
     setFaceFocus(settings.faceFocus);
     setZoom(settings.zoom);
     setPanTilt(settings.pan, settings.tilt);
+    if (settings.focus >= 0) {
+        setFocusAbsolute(settings.focus, false);
+    } else {
+        setFocusAbsolute(0, true);
+    }
 
     if (isTiny2Family()) {
         setAiMode(settings.aiMode, settings.aiSubMode);
@@ -676,6 +857,7 @@ void CameraController::saveCurrentStateToConfig()
     settings.saturation = m_currentState.saturation;
     settings.whiteBalance = m_currentState.whiteBalance;
     settings.whiteBalanceKelvin = m_currentState.whiteBalanceKelvin;
+    settings.focus = m_currentState.autoFocusEnabled ? -1 : m_currentState.manualFocusValue;
 
     m_config.setSettings(settings);
 }

--- a/src/gui/CameraController.h
+++ b/src/gui/CameraController.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <dev/devs.hpp>
 #include "Config.h"
+#include "V4l2Backend.h"
 
 /**
  * @brief Handles all camera communication and state management
@@ -78,6 +79,7 @@ public:
 
     // Connection
     bool isConnected() const { return m_connected; }
+    bool isV4l2Only() const { return m_v4l2Only; }
     CameraInfo getCameraInfo() const { return m_cameraInfo; }
     void connectToCamera();
     void disconnectFromCamera();
@@ -146,6 +148,10 @@ signals:
 private:
     std::shared_ptr<Device> m_device;
     bool m_connected;
+    bool m_v4l2Only = false;
+    V4l2Backend m_v4l2;
+    QTimer *m_v4l2ScanTimer = nullptr;
+    QString m_v4l2DevicePath;
     CameraInfo m_cameraInfo;
     CameraState m_currentState;
     CameraState m_cachedState;  // Cache intended state during settling
@@ -160,6 +166,10 @@ private:
     bool m_whiteBalanceFallbackActive;
     int m_fallbackWhiteBalanceMode;
     bool isTiny2Family() const;
+    void tryV4l2Fallback();
+    void connectV4l2(const std::string &devicePath);
+    void refreshV4l2ControlRanges();
+    void updateV4l2State();
 
     // Helper
     bool executeCommand(const QString &description, std::function<int32_t()> command);

--- a/src/gui/CameraSettingsWidget.cpp
+++ b/src/gui/CameraSettingsWidget.cpp
@@ -16,8 +16,8 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     layout->setContentsMargins(8, 14, 8, 14);
     layout->setSpacing(14);
 
-    QGroupBox *groupBox = new QGroupBox("Advanced Camera Settings", this);
-    QVBoxLayout *groupLayout = new QVBoxLayout(groupBox);
+    m_advancedGroupBox = new QGroupBox("Advanced Camera Settings", this);
+    QVBoxLayout *groupLayout = new QVBoxLayout(m_advancedGroupBox);
     groupLayout->setContentsMargins(16, 16, 16, 16);
     groupLayout->setSpacing(10);
 
@@ -53,7 +53,7 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     connect(m_faceFocusCheckBox, &QCheckBox::toggled, this, &CameraSettingsWidget::onFaceFocusToggled);
     groupLayout->addWidget(m_faceFocusCheckBox);
 
-    layout->addWidget(groupBox);
+    layout->addWidget(m_advancedGroupBox);
 
     // Image Controls Group
     QGroupBox *imageGroupBox = new QGroupBox("Image Controls", this);
@@ -419,6 +419,11 @@ void CameraSettingsWidget::updateWhiteBalanceControls(int mode)
     const bool enableManual = manualSelected && rangeAvailable;
     m_whiteBalanceKelvinSlider->setEnabled(enableManual);
     m_whiteBalanceKelvinLabel->setEnabled(enableManual);
+}
+
+void CameraSettingsWidget::setV4l2Mode(bool v4l2Only)
+{
+    m_advancedGroupBox->setVisible(!v4l2Only);
 }
 
 void CameraSettingsWidget::updateWhiteBalanceKelvinLabel(int value)

--- a/src/gui/CameraSettingsWidget.h
+++ b/src/gui/CameraSettingsWidget.h
@@ -23,6 +23,7 @@ public:
     explicit CameraSettingsWidget(CameraController *controller, QWidget *parent = nullptr);
 
     void updateFromState(const CameraController::CameraState &state);
+    void setV4l2Mode(bool v4l2Only);
 
     // Getters for current UI state
     bool isHDREnabled() const { return m_hdrCheckBox->isChecked(); }
@@ -153,6 +154,8 @@ private:
     void applyControlRanges();
     void updateWhiteBalanceControls(int mode);
     void updateWhiteBalanceKelvinLabel(int value);
+
+    QGroupBox *m_advancedGroupBox;
 };
 
 #endif // CAMERASETTINGSWIDGET_H

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -951,9 +951,15 @@ void MainWindow::onTogglePreview(bool enabled)
             return;
         }
 
-        // Try to enable preview - will emit previewStarted() or previewFailed()
         m_previewWidget->setCameraDeviceId(devicePath);
         m_previewWidget->enablePreview(true);
+
+        if (m_controller->isV4l2Only()) {
+            QTimer::singleShot(1500, this, [this]() {
+                auto state = m_controller->getCurrentState();
+                m_controller->setWhiteBalanceManual(state.whiteBalanceKelvin);
+            });
+        }
 
         if (!m_previewDetached) {
             if (m_previewStack->indexOf(m_previewWidget) == -1) {
@@ -1010,17 +1016,24 @@ void MainWindow::onPreviewWindowClosed()
 
 void MainWindow::onCameraConnected(const CameraController::CameraInfo &info)
 {
-    QString deviceText = QString("✓ Connected:\n%1\n(v%2)")
-        .arg(info.name)
-        .arg(info.version);
+    QString deviceText;
+    if (info.version.isEmpty()) {
+        deviceText = QString("✓ Connected:\n%1").arg(info.name);
+    } else {
+        deviceText = QString("✓ Connected:\n%1\n(v%2)")
+            .arg(info.name)
+            .arg(info.version);
+    }
 
     m_deviceInfoLabel->setText(deviceText);
     updateStatusBanner(true);
     m_cameraWarningLabel->setVisible(false);
     m_cameraWarningLabel->setText("");
 
-    // Apply current UI state to camera asynchronously (respects user changes before connection)
-    // Use a short delay to let the connection stabilize
+    bool v4l2Mode = m_controller->isV4l2Only();
+    m_trackingWidget->setV4l2Mode(v4l2Mode);
+    m_settingsWidget->setV4l2Mode(v4l2Mode);
+
     QTimer::singleShot(100, this, [this]() {
         auto uiState = getUIState();
         m_controller->applyCurrentStateToCamera(uiState);

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -23,9 +23,9 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     layout->setContentsMargins(8, 14, 8, 14);
     layout->setSpacing(14);
 
-    QGroupBox *groupBox = new QGroupBox("Face Tracking", this);
-    groupBox->setFlat(true);
-    QVBoxLayout *groupLayout = new QVBoxLayout(groupBox);
+    m_trackingGroupBox = new QGroupBox("Face Tracking", this);
+    m_trackingGroupBox->setFlat(true);
+    QVBoxLayout *groupLayout = new QVBoxLayout(m_trackingGroupBox);
     groupLayout->setContentsMargins(16, 16, 16, 16);
     groupLayout->setSpacing(12);
 
@@ -103,7 +103,7 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     groupLayout->addWidget(m_advancedContainer);
     updateTiny2Visibility();
 
-    layout->addWidget(groupBox);
+    layout->addWidget(m_trackingGroupBox);
 
     // Manual PTZ Controls (disabled when auto-framing is enabled)
     m_ptzContainer = new QWidget(this);
@@ -333,6 +333,17 @@ void TrackingControlWidget::updateFromState(const CameraController::CameraState 
         }
     }
 
+    // Sync zoom slider from camera state (only when user isn't dragging)
+    if (!m_zoomSlider->isSliderDown() && !commandInFlight && !isSettling) {
+        int zoomSliderVal = static_cast<int>(state.zoom * 10.0 + 0.5);
+        if (m_zoomSlider->value() != zoomSliderVal) {
+            m_zoomSlider->blockSignals(true);
+            m_zoomSlider->setValue(zoomSliderVal);
+            m_zoomSlider->blockSignals(false);
+            m_zoomLabel->setText(QString("%1x").arg(zoomSliderVal / 10.0, 0, 'f', 1));
+        }
+    }
+
     // Sync focus slider from camera state (only when user isn't dragging)
     if (!m_focusSlider->isSliderDown() && !commandInFlight && !isSettling) {
         if (m_focusSlider->value() != state.manualFocusValue) {
@@ -503,6 +514,11 @@ void TrackingControlWidget::onFocusChanged(int value)
     m_dirtyFocus = true;
     m_focusLabel->setText(QString::number(value));
     scheduleFlush();
+}
+
+void TrackingControlWidget::setV4l2Mode(bool v4l2Only)
+{
+    m_trackingGroupBox->setVisible(!v4l2Only);
 }
 
 void TrackingControlWidget::setMirrored(bool mirrored)

--- a/src/gui/TrackingControlWidget.h
+++ b/src/gui/TrackingControlWidget.h
@@ -26,6 +26,7 @@ public:
     explicit TrackingControlWidget(CameraController *controller, QWidget *parent = nullptr);
 
     void updateFromState(const CameraController::CameraState &state);
+    void setV4l2Mode(bool v4l2Only);
     bool isTrackingEnabled() const { return m_trackingCheckBox->isChecked(); }
     void setTrackingEnabled(bool enabled) {
         m_trackingCheckBox->blockSignals(true);
@@ -99,6 +100,8 @@ private:
 
     void updateTiny2Visibility();
     void updatePTZControlsState();
+
+    QGroupBox *m_trackingGroupBox;
 };
 
 #endif // TRACKINGCONTROLWIDGET_H

--- a/src/gui/V4l2Backend.cpp
+++ b/src/gui/V4l2Backend.cpp
@@ -1,0 +1,174 @@
+#include "V4l2Backend.h"
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <dirent.h>
+#include <cstring>
+#include <linux/videodev2.h>
+
+V4l2Backend::V4l2Backend() = default;
+
+V4l2Backend::~V4l2Backend()
+{
+    close();
+}
+
+bool V4l2Backend::open(const std::string &devicePath)
+{
+    close();
+    int fd = ::open(devicePath.c_str(), O_RDWR | O_NONBLOCK);
+    if (fd < 0)
+        return false;
+    ::close(fd);
+    m_devicePath = devicePath;
+    m_configured = true;
+    return true;
+}
+
+void V4l2Backend::close()
+{
+    m_configured = false;
+    m_devicePath.clear();
+}
+
+int V4l2Backend::openDevice() const
+{
+    if (m_devicePath.empty())
+        return -1;
+    return ::open(m_devicePath.c_str(), O_RDWR | O_NONBLOCK);
+}
+
+std::string V4l2Backend::findObsbotDevice()
+{
+    DIR *dir = opendir("/dev");
+    if (!dir)
+        return {};
+
+    struct dirent *entry;
+    while ((entry = readdir(dir)) != nullptr) {
+        std::string name = entry->d_name;
+        if (name.find("video") != 0)
+            continue;
+
+        std::string path = "/dev/" + name;
+        int fd = ::open(path.c_str(), O_RDWR | O_NONBLOCK);
+        if (fd < 0)
+            continue;
+
+        struct v4l2_capability cap{};
+        if (ioctl(fd, VIDIOC_QUERYCAP, &cap) == 0) {
+            std::string card(reinterpret_cast<const char *>(cap.card));
+            bool isVideoCapture = (cap.device_caps & V4L2_CAP_VIDEO_CAPTURE) != 0;
+            if (card.find("OBSBOT") != std::string::npos && isVideoCapture) {
+                ::close(fd);
+                closedir(dir);
+                return path;
+            }
+        }
+        ::close(fd);
+    }
+    closedir(dir);
+    return {};
+}
+
+std::string V4l2Backend::cardName() const
+{
+    int fd = openDevice();
+    if (fd < 0)
+        return {};
+    struct v4l2_capability cap{};
+    std::string name;
+    if (ioctl(fd, VIDIOC_QUERYCAP, &cap) == 0)
+        name = reinterpret_cast<const char *>(cap.card);
+    ::close(fd);
+    return name;
+}
+
+int V4l2Backend::getControl(uint32_t id)
+{
+    int fd = openDevice();
+    if (fd < 0)
+        return -1;
+    struct v4l2_control ctrl{};
+    ctrl.id = id;
+    int result = -1;
+    if (ioctl(fd, VIDIOC_G_CTRL, &ctrl) == 0)
+        result = ctrl.value;
+    ::close(fd);
+    return result;
+}
+
+bool V4l2Backend::setControl(uint32_t id, int value)
+{
+    int fd = openDevice();
+    if (fd < 0)
+        return false;
+    struct v4l2_control ctrl{};
+    ctrl.id = id;
+    ctrl.value = value;
+    bool ok = ioctl(fd, VIDIOC_S_CTRL, &ctrl) == 0;
+    ::close(fd);
+    return ok;
+}
+
+V4l2Backend::ControlRange V4l2Backend::queryRange(uint32_t id)
+{
+    ControlRange range{};
+    int fd = openDevice();
+    if (fd < 0)
+        return range;
+
+    struct v4l2_queryctrl qctrl{};
+    qctrl.id = id;
+    if (ioctl(fd, VIDIOC_QUERYCTRL, &qctrl) == 0) {
+        range.min = qctrl.minimum;
+        range.max = qctrl.maximum;
+        range.step = qctrl.step == 0 ? 1 : qctrl.step;
+        range.defaultValue = qctrl.default_value;
+        range.valid = true;
+    }
+    ::close(fd);
+    return range;
+}
+
+bool V4l2Backend::setBrightness(int value) { return setControl(V4L2_CID_BRIGHTNESS, value); }
+int V4l2Backend::getBrightness() { return getControl(V4L2_CID_BRIGHTNESS); }
+V4l2Backend::ControlRange V4l2Backend::getBrightnessRange() { return queryRange(V4L2_CID_BRIGHTNESS); }
+
+bool V4l2Backend::setContrast(int value) { return setControl(V4L2_CID_CONTRAST, value); }
+int V4l2Backend::getContrast() { return getControl(V4L2_CID_CONTRAST); }
+V4l2Backend::ControlRange V4l2Backend::getContrastRange() { return queryRange(V4L2_CID_CONTRAST); }
+
+bool V4l2Backend::setSaturation(int value) { return setControl(V4L2_CID_SATURATION, value); }
+int V4l2Backend::getSaturation() { return getControl(V4L2_CID_SATURATION); }
+V4l2Backend::ControlRange V4l2Backend::getSaturationRange() { return queryRange(V4L2_CID_SATURATION); }
+
+bool V4l2Backend::setWhiteBalanceAuto(bool enabled) { return setControl(V4L2_CID_AUTO_WHITE_BALANCE, enabled ? 1 : 0); }
+bool V4l2Backend::getWhiteBalanceAuto() { return getControl(V4L2_CID_AUTO_WHITE_BALANCE) == 1; }
+bool V4l2Backend::setWhiteBalanceTemperature(int kelvin) { return setControl(V4L2_CID_WHITE_BALANCE_TEMPERATURE, kelvin); }
+int V4l2Backend::getWhiteBalanceTemperature() { return getControl(V4L2_CID_WHITE_BALANCE_TEMPERATURE); }
+V4l2Backend::ControlRange V4l2Backend::getWhiteBalanceTemperatureRange() { return queryRange(V4L2_CID_WHITE_BALANCE_TEMPERATURE); }
+
+bool V4l2Backend::setPanAbsolute(int value) { return setControl(V4L2_CID_PAN_ABSOLUTE, value); }
+int V4l2Backend::getPanAbsolute() { return getControl(V4L2_CID_PAN_ABSOLUTE); }
+V4l2Backend::ControlRange V4l2Backend::getPanRange() { return queryRange(V4L2_CID_PAN_ABSOLUTE); }
+
+bool V4l2Backend::setTiltAbsolute(int value) { return setControl(V4L2_CID_TILT_ABSOLUTE, value); }
+int V4l2Backend::getTiltAbsolute() { return getControl(V4L2_CID_TILT_ABSOLUTE); }
+V4l2Backend::ControlRange V4l2Backend::getTiltRange() { return queryRange(V4L2_CID_TILT_ABSOLUTE); }
+
+bool V4l2Backend::setZoomAbsolute(int value) { return setControl(V4L2_CID_ZOOM_ABSOLUTE, value); }
+int V4l2Backend::getZoomAbsolute() { return getControl(V4L2_CID_ZOOM_ABSOLUTE); }
+V4l2Backend::ControlRange V4l2Backend::getZoomRange() { return queryRange(V4L2_CID_ZOOM_ABSOLUTE); }
+
+bool V4l2Backend::setAutoExposure(bool automatic)
+{
+    return setControl(V4L2_CID_EXPOSURE_AUTO, automatic ? V4L2_EXPOSURE_AUTO : V4L2_EXPOSURE_MANUAL);
+}
+
+bool V4l2Backend::setExposureAbsolute(int value) { return setControl(V4L2_CID_EXPOSURE_ABSOLUTE, value); }
+
+bool V4l2Backend::setAutoFocus(bool enabled) { return setControl(V4L2_CID_FOCUS_AUTO, enabled ? 1 : 0); }
+bool V4l2Backend::getAutoFocus() { return getControl(V4L2_CID_FOCUS_AUTO) == 1; }
+bool V4l2Backend::setFocusAbsolute(int value) { return setControl(V4L2_CID_FOCUS_ABSOLUTE, value); }
+int V4l2Backend::getFocusAbsolute() { return getControl(V4L2_CID_FOCUS_ABSOLUTE); }

--- a/src/gui/V4l2Backend.h
+++ b/src/gui/V4l2Backend.h
@@ -1,0 +1,78 @@
+#ifndef V4L2BACKEND_H
+#define V4L2BACKEND_H
+
+#include <cstdint>
+#include <string>
+#include <linux/videodev2.h>
+
+class V4l2Backend
+{
+public:
+    struct ControlRange {
+        int min = 0;
+        int max = 0;
+        int step = 1;
+        int defaultValue = 0;
+        bool valid = false;
+    };
+
+    V4l2Backend();
+    ~V4l2Backend();
+
+    bool open(const std::string &devicePath);
+    void close();
+    bool isOpen() const { return m_configured; }
+    std::string devicePath() const { return m_devicePath; }
+
+    static std::string findObsbotDevice();
+    std::string cardName() const;
+
+    int getControl(uint32_t id);
+    bool setControl(uint32_t id, int value);
+    ControlRange queryRange(uint32_t id);
+
+    bool setBrightness(int value);
+    int getBrightness();
+    ControlRange getBrightnessRange();
+
+    bool setContrast(int value);
+    int getContrast();
+    ControlRange getContrastRange();
+
+    bool setSaturation(int value);
+    int getSaturation();
+    ControlRange getSaturationRange();
+
+    bool setWhiteBalanceAuto(bool enabled);
+    bool getWhiteBalanceAuto();
+    bool setWhiteBalanceTemperature(int kelvin);
+    int getWhiteBalanceTemperature();
+    ControlRange getWhiteBalanceTemperatureRange();
+
+    bool setPanAbsolute(int value);
+    int getPanAbsolute();
+    ControlRange getPanRange();
+
+    bool setTiltAbsolute(int value);
+    int getTiltAbsolute();
+    ControlRange getTiltRange();
+
+    bool setZoomAbsolute(int value);
+    int getZoomAbsolute();
+    ControlRange getZoomRange();
+
+    bool setAutoExposure(bool automatic);
+    bool setExposureAbsolute(int value);
+
+    bool setAutoFocus(bool enabled);
+    bool getAutoFocus();
+    bool setFocusAbsolute(int value);
+    int getFocusAbsolute();
+
+private:
+    bool m_configured = false;
+    std::string m_devicePath;
+    int openDevice() const;
+};
+
+#endif // V4L2BACKEND_H


### PR DESCRIPTION
## Problem

The OBSBOT Tiny 3 is not recognized by the closed-source SDK — its product type isn't in the SDK's enum, so the UUID handshake fails in an infinite retry loop (`getDevUuidR ret_val = -3`). This means the app can't control the camera at all on Linux, even though the camera works fine as a standard UVC device.

Related: #34

## Solution

When the SDK fails to detect a camera, the app now falls back to direct V4L2 control via standard `ioctl` calls. This is automatic — no user configuration needed.

### What works in V4L2 fallback mode
- Brightness, contrast, saturation, white balance
- Pan, tilt, zoom (absolute)
- Manual focus
- Live preview with format/FPS selection
- All settings persist across app restarts
- Auto white balance fix (manual 4800K) to correct the green tint the Tiny 3 produces under Linux UVC

### What doesn't work (SDK-only features, hidden in UI)
- AI face tracking / auto-framing
- HDR, FOV, Face AE, Face Focus

## Other fixes

- **`findObsbotDevice()` returned wrong V4L2 node** — The metadata capture node (`/dev/video1`) could be returned instead of the video capture node (`/dev/video0`), causing all V4L2 ioctls to fail with `ENOTTY`. Now checks `V4L2_CAP_VIDEO_CAPTURE` in device caps.
- **Config validation rejected V4L2 values** — Sentinel values like `-1` (use camera default) and `zoom=0` (unset) were rejected by the config validator. Now accepted.
- **Zoom/focus/pan/tilt state not read on startup** — Sliders showed 0 instead of actual camera values. Now reads state from V4L2 on connect.

## Proof

Camera detection and V4L2 controls working on the OBSBOT Tiny 3 (Arch Linux 6.18.9, `3564:ff02`):

```
$ v4l2-ctl -d /dev/video0 --info | head -3
Driver Info:
	Driver name      : uvcvideo
	Card type        : OBSBOT Tiny 3: OBSBOT Tiny 3 St

$ v4l2-ctl -d /dev/video0 --get-ctrl=zoom_absolute,focus_absolute,white_balance_temperature
white_balance_temperature: 4800
zoom_absolute: 0
focus_absolute: 14
```

## Files changed

| File | What |
|------|------|
| `V4l2Backend.h/cpp` | New — thin wrapper around V4L2 ioctls (open/close per operation to avoid blocking preview) |
| `CameraController.cpp/h` | V4L2 fallback path in all control methods, state readback, config save/load |
| `MainWindow.cpp` | Post-preview WB fix timer, conditional version display, V4L2 mode UI setup |
| `TrackingControlWidget.cpp/h` | Hide face tracking group in V4L2 mode, sync zoom slider from state |
| `CameraSettingsWidget.cpp/h` | Hide SDK-only settings group in V4L2 mode |
| `Config.cpp/h` | Add `focus` field, accept sentinel values, register `focus` as known key |
| `CMakeLists.txt` | Add V4l2Backend sources |