### PR TITLE
first tab (Tracking) that loads after camera detection has its elemen…

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1063,6 +1063,13 @@ void MainWindow::onStateChanged(const CameraController::CameraState &state)
     // Update all widgets with new state
     m_trackingWidget->updateFromState(state);
     m_settingsWidget->updateFromState(state);
+
+    // Refit tab height — widget visibility may have changed (e.g. Tiny2 advanced controls)
+    QWidget *page = m_tabWidget->currentWidget();
+    if (page) {
+        m_tabWidget->setMaximumHeight(
+            page->sizeHint().height() + m_tabWidget->tabBar()->sizeHint().height());
+    }
 }
 
 void MainWindow::onCommandFailed(const QString &description, int errorCode)


### PR DESCRIPTION
## What does this change?
First tab (Tracking) that loads after camera gets detected and goes online has the additional settings that populate look squashed or flattened vertical.
Dunno if it's just me, but this is a simple fix for it.

## Why?
OCD

## How to test
1. open the app
2. wait for camera to be detected and be online
3. once online, the Tracking tab will populate with settings that were originally squashed or flattened vertically. should render properly now.

## Checklist
- [x] Builds cleanly: `./build.sh build --confirm`
- [x] Tested with my camera (model: Tiny 2 Lite)
Ubuntu 24.04 (x11)
