### PR TITLE
feat: multi-camera selector dropdown

### DIFF
--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -29,21 +29,40 @@ CameraController::~CameraController()
 
 void CameraController::connectToCamera()
 {
-    // Setup device detection callback
-    auto onDevChanged = [this](std::string dev_sn, bool connected, void *param) {
-        if (connected) {
-            // Device connected
-            auto dev_list = Devices::get().getDevList();
-            if (!dev_list.empty()) {
-                m_device = dev_list.front();
-                m_connected = true;
+    connectToCamera(QString());
+}
 
+void CameraController::connectToCamera(const QString &devicePath)
+{
+    m_selectedDevicePath = devicePath;
+
+    auto pickDevice = [this](const std::list<std::shared_ptr<Device>> &list)
+        -> std::shared_ptr<Device>
+    {
+        if (list.empty()) return nullptr;
+        if (m_selectedDevicePath.isEmpty()) return list.front();
+
+        for (const auto &dev : list) {
+            if (QString::fromStdString(dev->videoDevPath()) == m_selectedDevicePath)
+                return dev;
+        }
+        qDebug() << "CameraController: device" << m_selectedDevicePath
+                 << "not found in SDK list, using first available";
+        return list.front();
+    };
+
+    auto onDevChanged = [this, pickDevice](std::string /*dev_sn*/, bool connected, void * /*param*/) {
+        if (connected) {
+            auto dev_list = Devices::get().getDevList();
+            auto dev = pickDevice(dev_list);
+            if (dev) {
+                m_device = dev;
+                m_connected = true;
                 m_cameraInfo.name = QString::fromStdString(m_device->devName());
                 m_cameraInfo.serialNumber = QString::fromStdString(m_device->devSn());
                 m_cameraInfo.version = QString::fromStdString(m_device->devVersion());
                 m_cameraInfo.productType = m_device->productType();
                 m_cameraInfo.connected = true;
-
                 refreshControlRanges();
                 emit cameraConnected(m_cameraInfo);
                 updateState();
@@ -57,25 +76,23 @@ void CameraController::connectToCamera()
     };
 
     Devices::get().setDevChangedCallback(onDevChanged, nullptr);
-    Devices::get().setEnableMdnsScan(false);  // USB only
+    Devices::get().setEnableMdnsScan(false);
 
-    // Actively check for existing devices (handles reconnection scenario)
-    // The callback only fires on connect/disconnect events, so if the device
-    // is already connected (e.g., after window restore), we need to connect directly
     auto dev_list = Devices::get().getDevList();
     if (!dev_list.empty() && !m_connected) {
-        m_device = dev_list.front();
-        m_connected = true;
-
-        m_cameraInfo.name = QString::fromStdString(m_device->devName());
-        m_cameraInfo.serialNumber = QString::fromStdString(m_device->devSn());
-    m_cameraInfo.version = QString::fromStdString(m_device->devVersion());
-    m_cameraInfo.productType = m_device->productType();
-    m_cameraInfo.connected = true;
-
-    refreshControlRanges();
-    emit cameraConnected(m_cameraInfo);
-    updateState();
+        auto dev = pickDevice(dev_list);
+        if (dev) {
+            m_device = dev;
+            m_connected = true;
+            m_cameraInfo.name = QString::fromStdString(m_device->devName());
+            m_cameraInfo.serialNumber = QString::fromStdString(m_device->devSn());
+            m_cameraInfo.version = QString::fromStdString(m_device->devVersion());
+            m_cameraInfo.productType = m_device->productType();
+            m_cameraInfo.connected = true;
+            refreshControlRanges();
+            emit cameraConnected(m_cameraInfo);
+            updateState();
+        }
     }
 }
 
@@ -98,6 +115,19 @@ QString CameraController::getVideoDevicePath() const
         return QString::fromStdString(m_device->videoDevPath());
     }
     return QString();
+}
+
+QMap<QString, QString> CameraController::getSerialsByDevicePath() const
+{
+    QMap<QString, QString> result;
+    const auto dev_list = Devices::get().getDevList();
+    for (const auto &dev : dev_list) {
+        const QString path = QString::fromStdString(dev->videoDevPath());
+        const QString serial = QString::fromStdString(dev->devSn());
+        if (!path.isEmpty() && !serial.isEmpty())
+            result.insert(path, serial);
+    }
+    return result;
 }
 
 CameraController::CameraState CameraController::getCurrentState()
@@ -498,6 +528,10 @@ void CameraController::updateState()
     m_currentState.aiMode = status.tiny.ai_mode;
     m_currentState.aiSubMode = status.tiny.ai_sub_mode;
     m_currentState.zoomRatio = status.tiny.zoom_ratio;
+    // Derive zoom float from zoom_ratio (100 = 1.0x, 200 = 2.0x)
+    if (status.tiny.zoom_ratio >= 100 && status.tiny.zoom_ratio <= 200) {
+        m_currentState.zoom = status.tiny.zoom_ratio / 100.0;
+    }
     m_currentState.hdrEnabled = status.tiny.hdr;
     m_currentState.faceAEEnabled = status.tiny.face_ae;
     m_currentState.faceFocusEnabled = status.tiny.face_auto_focus;
@@ -662,7 +696,7 @@ void CameraController::saveCurrentStateToConfig()
     settings.fov = m_currentState.fovMode;
     settings.faceAE = m_currentState.faceAEEnabled;
     settings.faceFocus = m_currentState.faceFocusEnabled;
-    settings.zoom = m_currentState.zoom;
+    settings.zoom = qBound(1.0, m_currentState.zoom, 2.0);
     settings.pan = m_currentState.pan;
     settings.tilt = m_currentState.tilt;
     settings.aiMode = m_currentState.aiMode;

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -1,5 +1,6 @@
 #include "CameraController.h"
 #include <QThread>
+#include <QDebug>
 #include <algorithm>
 
 CameraController::CameraController(QObject *parent)
@@ -261,9 +262,12 @@ bool CameraController::setZoom(double zoom)
     // Clamp to valid range (1.0 - 2.0)
     zoom = qBound(1.0, zoom, 2.0);
 
-    bool success = executeCommand("Set Zoom", [this, zoom]() {
-        return m_device->cameraSetZoomAbsoluteR(zoom);
+    uint32_t zoomRatio = static_cast<uint32_t>(zoom * 100);
+    bool success = executeCommand("Set Zoom", [this, zoomRatio]() {
+        return m_device->cameraSetZoomWithSpeedAbsoluteR(zoomRatio, 255);
     });
+
+    qDebug() << "setZoom:" << zoom << "ratio:" << zoomRatio;
 
     if (success) {
         m_currentState.zoom = zoom;

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -297,8 +297,6 @@ bool CameraController::setZoom(double zoom)
         return m_device->cameraSetZoomWithSpeedAbsoluteR(zoomRatio, 255);
     });
 
-    qDebug() << "setZoom:" << zoom << "ratio:" << zoomRatio;
-
     if (success) {
         m_currentState.zoom = zoom;
         emit stateChanged(m_currentState);
@@ -531,6 +529,9 @@ void CameraController::updateState()
     // Derive zoom float from zoom_ratio (100 = 1.0x, 200 = 2.0x)
     if (status.tiny.zoom_ratio >= 100 && status.tiny.zoom_ratio <= 200) {
         m_currentState.zoom = status.tiny.zoom_ratio / 100.0;
+    } else {
+        qDebug() << "CameraController: unexpected zoom_ratio" << status.tiny.zoom_ratio
+                 << "— keeping previous zoom" << m_currentState.zoom;
     }
     m_currentState.hdrEnabled = status.tiny.hdr;
     m_currentState.faceAEEnabled = status.tiny.face_ae;

--- a/src/gui/CameraController.h
+++ b/src/gui/CameraController.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 #include <QTimer>
+#include <QMap>
 #include <memory>
 #include <functional>
 #include <vector>
@@ -80,8 +81,10 @@ public:
     bool isConnected() const { return m_connected; }
     CameraInfo getCameraInfo() const { return m_cameraInfo; }
     void connectToCamera();
+    void connectToCamera(const QString &devicePath);
     void disconnectFromCamera();
     QString getVideoDevicePath() const;
+    QMap<QString, QString> getSerialsByDevicePath() const;
 
     // State
     CameraState getCurrentState();
@@ -146,6 +149,7 @@ signals:
 private:
     std::shared_ptr<Device> m_device;
     bool m_connected;
+    QString m_selectedDevicePath;
     CameraInfo m_cameraInfo;
     CameraState m_currentState;
     CameraState m_cachedState;  // Cache intended state during settling

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -352,6 +352,29 @@ void MainWindow::setupUI()
 
     scrollLayout->addWidget(m_statusBanner);
 
+    // Camera selector (hidden when only one OBSBOT is present)
+    {
+        QWidget *selectorRow = new QWidget(scrollContent);
+        QHBoxLayout *selectorLayout = new QHBoxLayout(selectorRow);
+        selectorLayout->setContentsMargins(0, 0, 0, 0);
+        selectorLayout->setSpacing(8);
+
+        m_cameraSelectorLabel = new QLabel(tr("Camera"), selectorRow);
+        selectorLayout->addWidget(m_cameraSelectorLabel);
+
+        m_cameraSelectorCombo = new QComboBox(selectorRow);
+        m_cameraSelectorCombo->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+        m_cameraSelectorCombo->setToolTip(tr("Select which OBSBOT camera to control"));
+        selectorLayout->addWidget(m_cameraSelectorCombo, 1);
+
+        connect(m_cameraSelectorCombo,
+                QOverload<int>::of(&QComboBox::currentIndexChanged),
+                this, &MainWindow::onCameraSelectorChanged);
+
+        scrollLayout->addWidget(selectorRow);
+    }
+    populateCameraSelector();
+
     QWidget *actionRow = new QWidget(scrollContent);
     actionRow->setObjectName("actionRow");
     QHBoxLayout *actionLayout = new QHBoxLayout(actionRow);
@@ -1022,8 +1045,15 @@ void MainWindow::onCameraConnected(const CameraController::CameraInfo &info)
     // Apply current UI state to camera asynchronously (respects user changes before connection)
     // Use a short delay to let the connection stabilize
     QTimer::singleShot(100, this, [this]() {
-        auto uiState = getUIState();
-        m_controller->applyCurrentStateToCamera(uiState);
+        if (m_isCameraSwitch) {
+            // Pull the new camera's actual state into the UI
+            // without pushing the old camera's state back
+            auto state = m_controller->getCurrentState();
+            onStateChanged(state);
+            m_isCameraSwitch = false;
+        } else {
+            m_controller->applyCurrentStateToCamera(getUIState());
+        }
     });
 
     updateStatus();
@@ -1431,7 +1461,12 @@ void MainWindow::onPreviewFailed(const QString &error)
     QString warningText = "⚠ Cannot open camera preview";
 
     // Try to detect which process is using the camera
-    QString process = getProcessUsingCamera("/dev/video0");
+    const QString failedDevice = m_detectedCameras.isEmpty()
+        ? QStringLiteral("/dev/video0")
+        : m_detectedCameras.value(
+              m_cameraSelectorCombo ? m_cameraSelectorCombo->currentIndex() : 0
+          ).devicePath;
+    QString process = getProcessUsingCamera(failedDevice);
     if (!process.isEmpty()) {
         warningText += "\n(In use by: " + process + ")";
     } else {
@@ -1476,6 +1511,75 @@ void MainWindow::onPresetUpdated(int index, double pan, double tilt, double zoom
 
     m_controller->getConfig().setSettings(settings);
     m_controller->saveConfig();
+}
+
+void MainWindow::populateCameraSelector()
+{
+    const QList<QCameraDevice> allCameras = QMediaDevices::videoInputs();
+
+    m_detectedCameras.clear();
+    for (const QCameraDevice &dev : allCameras) {
+        if (dev.description().contains("OBSBOT", Qt::CaseInsensitive) ||
+            dev.description().contains("Meet", Qt::CaseInsensitive)) {
+            const QString id = dev.id();
+            if (id.startsWith("/dev/video")) {
+                DetectedCamera cam;
+                cam.devicePath = id;
+                cam.label = dev.description() + "  (" + id + ")";
+                m_detectedCameras.append(cam);
+            }
+        }
+    }
+
+    // Enrich with serial numbers from the SDK device list
+    const auto sdkSerials = m_controller->getSerialsByDevicePath();
+    for (auto &cam : m_detectedCameras) {
+        const QString sn = sdkSerials.value(cam.devicePath);
+        if (!sn.isEmpty()) {
+            cam.serial = sn;
+            cam.label += "  [" + sn + "]";
+        }
+    }
+
+    if (!m_cameraSelectorCombo) return;
+
+    m_cameraSelectorCombo->blockSignals(true);
+    m_cameraSelectorCombo->clear();
+
+    if (m_detectedCameras.isEmpty()) {
+        m_cameraSelectorCombo->addItem(tr("No OBSBOT camera found"));
+        m_cameraSelectorCombo->setEnabled(false);
+    } else {
+        for (const auto &cam : std::as_const(m_detectedCameras))
+            m_cameraSelectorCombo->addItem(cam.label);
+        m_cameraSelectorCombo->setEnabled(true);
+    }
+    m_cameraSelectorCombo->blockSignals(false);
+
+    const bool multiCam = m_detectedCameras.size() > 1;
+    m_cameraSelectorCombo->setVisible(multiCam);
+    if (m_cameraSelectorLabel)
+        m_cameraSelectorLabel->setVisible(multiCam);
+}
+
+void MainWindow::onCameraSelectorChanged(int index)
+{
+    if (index < 0 || index >= m_detectedCameras.size()) return;
+
+    const DetectedCamera &cam = m_detectedCameras[index];
+
+    if (m_previewToggleButton->isChecked()) {
+        m_previewToggleButton->setChecked(false);
+    }
+
+    m_previewWidget->setCameraDeviceId(cam.devicePath);
+
+    const QString devicePath = cam.devicePath;
+    m_isCameraSwitch = true;
+    m_controller->disconnectFromCamera();
+    QTimer::singleShot(300, this, [this, devicePath]() {
+        m_controller->connectToCamera(devicePath);
+    });
 }
 
 QString MainWindow::findObsbotVideoDevice()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1071,6 +1071,7 @@ void MainWindow::onCameraConnected(const CameraController::CameraInfo &info)
 
 void MainWindow::onCameraDisconnected()
 {
+    m_isCameraSwitch = false;
     m_deviceInfoLabel->setText("❌ Camera Disconnected");
     updateStatusBanner(false);
     m_statusLabel->setText("Status: Not connected");
@@ -1103,6 +1104,9 @@ void MainWindow::onCommandFailed(const QString &description, int errorCode)
 
 void MainWindow::updateStatus()
 {
+    // Refresh camera selector in case devices were hot-plugged
+    populateCameraSelector();
+
     if (!m_controller->isConnected()) {
         return;
     }
@@ -1574,10 +1578,14 @@ void MainWindow::onCameraSelectorChanged(int index)
 
     m_previewWidget->setCameraDeviceId(cam.devicePath);
 
+    // Brief delay after disconnect so the SDK releases the previous device
+    // before we attempt to connect to the new one.
+    static constexpr int kCameraSwitchDelayMs = 300;
+
     const QString devicePath = cam.devicePath;
     m_isCameraSwitch = true;
     m_controller->disconnectFromCamera();
-    QTimer::singleShot(300, this, [this, devicePath]() {
+    QTimer::singleShot(kCameraSwitchDelayMs, this, [this, devicePath]() {
         m_controller->connectToCamera(devicePath);
     });
 }

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -40,6 +40,7 @@ public:
     ~MainWindow();
 
 private slots:
+    void onCameraSelectorChanged(int index);
     void onCameraConnected(const CameraController::CameraInfo &info);
     void onCameraDisconnected();
     void onStateChanged(const CameraController::CameraState &state);
@@ -84,6 +85,14 @@ private:
 
     // Controller
     CameraController *m_controller;
+
+    // Camera selector (shown only when >1 OBSBOT camera is detected)
+    QComboBox *m_cameraSelectorCombo {nullptr};
+    QLabel *m_cameraSelectorLabel {nullptr};
+    struct DetectedCamera { QString label; QString devicePath; QString serial; };
+    QList<DetectedCamera> m_detectedCameras;
+    void populateCameraSelector();
+    bool m_isCameraSwitch {false};
 
     // UI
     QPushButton *m_previewToggleButton;

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -131,9 +131,9 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     zoomLabel->setFixedWidth(40);
     zoomLayout->addWidget(zoomLabel);
     m_zoomSlider = new QSlider(Qt::Horizontal, this);
-    m_zoomSlider->setMinimum(10);  // 1.0x
-    m_zoomSlider->setMaximum(20);  // 2.0x
-    m_zoomSlider->setValue(10);
+    m_zoomSlider->setMinimum(100);  // 1.00x
+    m_zoomSlider->setMaximum(200);  // 2.00x
+    m_zoomSlider->setValue(100);
     connect(m_zoomSlider, &QSlider::valueChanged, this, &TrackingControlWidget::onZoomChanged);
     zoomLayout->addWidget(m_zoomSlider);
     m_zoomLabel = new QLabel("1.0x", this);
@@ -453,7 +453,7 @@ void TrackingControlWidget::flushPendingCommands()
         m_dirtyPanTilt = false;
     }
     if (m_dirtyZoom) {
-        m_controller->setZoom(m_pendingZoom / 10.0);
+        m_controller->setZoom(m_pendingZoom / 100.0);
         m_dirtyZoom = false;
     }
     if (m_dirtyFocus) {
@@ -493,7 +493,7 @@ void TrackingControlWidget::onZoomChanged(int value)
 {
     m_pendingZoom = value;
     m_dirtyZoom = true;
-    m_zoomLabel->setText(QString("%1x").arg(value / 10.0, 0, 'f', 1));
+    m_zoomLabel->setText(QString("%1x").arg(value / 100.0, 0, 'f', 2));
     scheduleFlush();
 }
 

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -288,6 +288,10 @@ void TrackingControlWidget::updateFromState(const CameraController::CameraState 
         m_trackingCheckBox->blockSignals(false);
     }
 
+    if (!m_userInitiated && !commandInFlight && !isSettling) {
+        updatePTZControlsState();
+    }
+
     bool tiny2 = m_controller->hasTiny2Capabilities();
     if (tiny2 != m_tiny2Capabilities) {
         m_tiny2Capabilities = tiny2;
@@ -340,6 +344,17 @@ void TrackingControlWidget::updateFromState(const CameraController::CameraState 
             m_focusSlider->setValue(state.manualFocusValue);
             m_focusSlider->blockSignals(false);
             m_focusLabel->setText(QString::number(state.manualFocusValue));
+        }
+    }
+
+    // Sync zoom slider from camera state (only when user isn't dragging)
+    if (!m_zoomSlider->isSliderDown() && !commandInFlight && !isSettling) {
+        int zoomSliderVal = qRound(state.zoom * 100.0);
+        if (m_zoomSlider->value() != zoomSliderVal) {
+            m_zoomSlider->blockSignals(true);
+            m_zoomSlider->setValue(zoomSliderVal);
+            m_zoomSlider->blockSignals(false);
+            m_zoomLabel->setText(QString("%1x").arg(state.zoom, 0, 'f', 2));
         }
     }
 

--- a/src/gui/TrackingControlWidget.h
+++ b/src/gui/TrackingControlWidget.h
@@ -89,7 +89,7 @@ private:
     QTimer *m_controlThrottle;
     float m_pendingPan = 0;
     float m_pendingTilt = 0;
-    int m_pendingZoom = 10;
+    int m_pendingZoom = 100;
     int m_pendingFocus = 50;
     bool m_dirtyPanTilt = false;
     bool m_dirtyZoom = false;


### PR DESCRIPTION
## Summary

- Adds a camera selector dropdown that appears when multiple OBSBOT cameras are connected
- Hidden automatically for single-camera setups — no UI change for existing users
- On camera switch, pulls the new camera's state into the UI without pushing old state back

Based on patches contributed by @Wireheadbe in #35 — reworked to integrate cleanly with the current codebase.

### Changes

- **CameraController**: new `connectToCamera(devicePath)` overload, `getSerialsByDevicePath()` helper, zoom state derivation from `zoom_ratio`, config save clamping
- **MainWindow**: camera selector UI, `populateCameraSelector()`, `onCameraSelectorChanged()` with disconnect→reconnect flow, fixed `onPreviewFailed` device path
- **TrackingControlWidget**: PTZ controls state sync and zoom slider sync from camera state on switch

Closes #35

## Test plan

- [ ] Single camera: verify selector is hidden, no behavior change
- [ ] Multiple cameras: verify selector appears with device paths and serial numbers
- [ ] Switch cameras: verify UI updates to reflect new camera's state
- [ ] Preview toggle works correctly after camera switch
- [ ] Reconnect button still works as expected