### PR TITLE
chore(cli): simplify interactive command dispatch

### DIFF
--- a/src/cli/meet2_test.cpp
+++ b/src/cli/meet2_test.cpp
@@ -308,17 +308,8 @@ void runInteractiveMode(shared_ptr<Device> dev)
         if (cmd == "q") break;
 
         char firstChar = cmd[0];
-        int choice = atoi(cmd.c_str());
+        int choice = (firstChar >= '0' && firstChar <= '9') ? (firstChar - '0') : firstChar;
         int32_t ret;
-
-        // Handle both numeric commands (0-9) and letter commands (a,m,k,j)
-        if (firstChar >= '1' && firstChar <= '9') {
-            choice = firstChar - '0';
-        } else if (firstChar == '0') {
-            choice = 0;
-        } else {
-            choice = firstChar;
-        }
 
         switch (choice) {
             case 1:


### PR DESCRIPTION
## Summary
- Follow-up cleanup to #42
- Drop dead `atoi(cmd.c_str())` call that was immediately overwritten by the numeric/letter branch below it
- Collapse the `if/else if/else` dispatch into a single ternary — `'0'..'9'` → digit, anything else → char code

## Test plan
- [x] `cmake --build build --target obsbot-cli` succeeds clean
- [ ] Spot-check interactive mode: numeric commands (1–9, 0) and letter commands (a/m/k/j/h/H/i/I) still route correctly