### PR TITLE
fix: persist saved camera settings on connect

### DIFF
--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -3,8 +3,6 @@
 #include <QDebug>
 #include <algorithm>
 
-static constexpr int kDefaultWhiteBalanceKelvin = 4800;
-
 CameraController::CameraController(QObject *parent)
     : QObject(parent)
     , m_connected(false)
@@ -67,6 +65,7 @@ void CameraController::connectToCamera(const QString &devicePath)
                 m_cameraInfo.connected = true;
                 refreshControlRanges();
                 emit cameraConnected(m_cameraInfo);
+                applyConfigToCamera();
                 updateState();
             }
         } else {
@@ -93,6 +92,7 @@ void CameraController::connectToCamera(const QString &devicePath)
             m_cameraInfo.connected = true;
             refreshControlRanges();
             emit cameraConnected(m_cameraInfo);
+            applyConfigToCamera();
             updateState();
         }
     } else {
@@ -149,10 +149,8 @@ void CameraController::connectV4l2(const std::string &devicePath)
 
     refreshV4l2ControlRanges();
 
-    m_v4l2.setWhiteBalanceAuto(false);
-    m_v4l2.setWhiteBalanceTemperature(kDefaultWhiteBalanceKelvin);
-
     emit cameraConnected(m_cameraInfo);
+    applyConfigToCamera();
     updateV4l2State();
 }
 


### PR DESCRIPTION
## Summary

- `applyConfigToCamera()` was defined but never called — saved settings reached the UI but never the device
- On connect, `updateState` then read device defaults and emitted them back to the UI, and the next `saveConfig` overwrote disk with those defaults, silently destroying the user's saved white balance / brightness / FOV / HDR / etc.
- Wire `applyConfigToCamera()` into both SDK paths and the V4L2 fallback, between `cameraConnected` emit and the initial state read-back
- Drop hardcoded V4L2 WB reset in `connectV4l2` (`setWhiteBalanceAuto(false)` + `setWhiteBalanceTemperature(4800)`) — was wiping the user's saved Kelvin on every V4L2 reconnect
- Remove now-orphan `kDefaultWhiteBalanceKelvin` constant

## Reproduction (pre-fix)

1. Set white balance to a non-default Kelvin (e.g. 6500K)
2. Close the app — `settings.conf` correctly saves 6500
3. Reopen the app
4. Result: WB resets to device default (or 4800 on V4L2 path); next save persists the default to disk

## Test plan

- [x] Tested with OBSBOT Meet 2 (V4L2 path)
- [x] Set WB to 6500K, close + reopen, verify slider reads 6500K and camera reflects it
- [ ] Verify SDK path on Tiny 2 family if a reviewer has hardware