### PR TITLE
Fix Tiny 2: show AI tracking panel (clear stale V4L2 fallback) + keep zoom usable while tracking

### DIFF
--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -60,6 +60,8 @@ void CameraController::connectToCamera(const QString &devicePath)
             if (dev) {
                 m_device = dev;
                 m_connected = true;
+                m_v4l2Only = false;                       // SDK reached: clear stale V4L2 fallback
+                if (m_v4l2ScanTimer) m_v4l2ScanTimer->stop();
                 m_cameraInfo.name = QString::fromStdString(m_device->devName());
                 m_cameraInfo.serialNumber = QString::fromStdString(m_device->devSn());
                 m_cameraInfo.version = QString::fromStdString(m_device->devVersion());
@@ -86,6 +88,8 @@ void CameraController::connectToCamera(const QString &devicePath)
         if (dev) {
             m_device = dev;
             m_connected = true;
+            m_v4l2Only = false;                       // SDK reached: clear stale V4L2 fallback
+            if (m_v4l2ScanTimer) m_v4l2ScanTimer->stop();
             m_cameraInfo.name = QString::fromStdString(m_device->devName());
             m_cameraInfo.serialNumber = QString::fromStdString(m_device->devSn());
             m_cameraInfo.version = QString::fromStdString(m_device->devVersion());

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -467,9 +467,13 @@ void TrackingControlWidget::updateTiny2Visibility()
 
 void TrackingControlWidget::updatePTZControlsState()
 {
-    // Disable PTZ controls when auto-framing is enabled
-    bool enabled = !m_trackingCheckBox->isChecked();
-    m_ptzContainer->setEnabled(enabled);
+    // Manual pan/tilt fights the AI tracker, so disable only the XY pad while
+    // tracking. Zoom and focus are compatible with tracking (the gimbal keeps
+    // following), so leave them adjustable.
+    bool tracking = m_trackingCheckBox->isChecked();
+    m_ptzContainer->setEnabled(true);
+    if (m_xyPad) m_xyPad->setEnabled(!tracking);
+    if (m_positionLabel) m_positionLabel->setEnabled(!tracking);
 }
 
 void TrackingControlWidget::flushPendingCommands()


### PR DESCRIPTION
## Summary
Two Linux fixes for the OBSBOT Tiny 2. On my setup the AI tracking panel never appeared and `setAiMode()` silently did nothing despite a successful SDK connection, and the Zoom slider was greyed out whenever tracking was on.

## 1. Stale `m_v4l2Only` after the async SDK connect
At launch, `Devices::get().getDevList()` is empty for ~3s (enumeration is async), so `connectToCamera()` falls through to `tryV4l2Fallback()` → `m_v4l2Only = true`. When the SDK device subsequently arrives via the `onDevChanged` callback (and the immediate `getDevList()` path), `m_device` is set but `m_v4l2Only` is never cleared. The app then has a live SDK device while still believing it is V4L2-only:
- `MainWindow::onCameraConnected` calls `setV4l2Mode(true)`, hiding the entire Face Tracking group.
- `setAiMode()` / `enableAutoFraming()` early-return on `m_v4l2Only`.

Fix: clear `m_v4l2Only` (and stop the rescan timer) in both SDK connect paths.

## 2. Zoom/focus locked while tracking
`updatePTZControlsState()` disabled the whole manual-control container during tracking, which greys out the Zoom (and Focus) sliders. Only pan/tilt conflicts with the gimbal tracker; zoom/focus are compatible. Fix: disable only the XY pad, keep Zoom/Focus adjustable.

## Testing
Tiny 2 (USB `3564:fef8`, firmware `6.0.5.1`, `productType=2`) on Ubuntu 26.04, Qt6 build:
- Before: Tracking tab showed only "Manual Camera Control"; status bar "AI: Off"; the Enable checkbox did nothing.
- After: the AI panel (Enable Auto-Framing / Mode / Speed / Auto-Zoom) appears, `AiWorkModeHuman` drives the gimbal, and the Zoom slider works while tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)