### PR TITLE
Fix: tracking/HDR controls never appear, V4L2 fallback always wins the connect race

### DIFF
--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -58,6 +58,13 @@ void CameraController::connectToCamera(const QString &devicePath)
             auto dev_list = Devices::get().getDevList();
             auto dev = pickDevice(dev_list);
             if (dev) {
+                // SDK enumeration may finish after the V4L2 fallback has
+                // already connected; drop the fallback so SDK-only controls
+                // (tracking, HDR) aren't left hidden by a stale flag.
+                if (m_v4l2Only) {
+                    m_v4l2.close();
+                    m_v4l2Only = false;
+                }
                 m_device = dev;
                 m_connected = true;
                 m_cameraInfo.name = QString::fromStdString(m_device->devName());
@@ -96,7 +103,15 @@ void CameraController::connectToCamera(const QString &devicePath)
             updateState();
         }
     } else {
-        tryV4l2Fallback();
+        // The SDK enumerates devices on a background thread and its connect
+        // handshake takes several seconds, so the list is almost always
+        // still empty here. An immediate fallback would win that race every
+        // launch and lock the UI into V4L2-only mode; give the SDK a grace
+        // period before settling for plain V4L2.
+        QTimer::singleShot(8000, this, [this]() {
+            if (!m_connected)
+                tryV4l2Fallback();
+        });
     }
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1103,6 +1103,13 @@ void MainWindow::onCameraDisconnected()
 
 void MainWindow::onStateChanged(const CameraController::CameraState &state)
 {
+    // Re-sync mode-dependent visibility: the connection can upgrade from
+    // the V4L2 fallback to a full SDK session after onCameraConnected ran,
+    // and a snapshot taken there would hide these controls forever.
+    bool v4l2Mode = m_controller->isV4l2Only();
+    m_trackingWidget->setV4l2Mode(v4l2Mode);
+    m_settingsWidget->setV4l2Mode(v4l2Mode);
+
     // Update all widgets with new state
     m_trackingWidget->updateFromState(state);
     m_settingsWidget->updateFromState(state);

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -461,6 +461,10 @@ void TrackingControlWidget::updateTiny2Visibility()
         return;
     }
 
+    // Re-read on every pass: the constructor runs before a camera is
+    // connected, so a value captured once there can never become true.
+    m_tiny2Capabilities = m_controller->hasTiny2Capabilities();
+
     m_advancedContainer->setVisible(m_tiny2Capabilities);
     m_humanSubModeCombo->setEnabled(m_tiny2Capabilities && m_modeCombo->currentData().toInt() == Device::AiWorkModeHuman);
 }


### PR DESCRIPTION
## What does this change?

Fixes three stacked bugs that hid the tracking and advanced camera controls on every launch with an already-connected camera:

1. `connectToCamera()` calls `getDevList()` right after starting the SDK, but enumeration runs on a background thread and the full handshake (uuid/version/info queries) takes several seconds. The list is always empty at that point, so `tryV4l2Fallback()` runs immediately, finds the camera on `/dev/videoN`, and wins every time. I gave the SDK an 8-second grace period before falling back.
2. Even when the SDK connection came up afterwards, `onDevChanged` upgraded `m_device` but never cleared `m_v4l2Only`, so the UI stayed in reduced mode. It now closes the fallback and clears the flag.
3. `TrackingControlWidget` reads `hasTiny2Capabilities()` once in its constructor, which always runs before a camera is connected, so it's permanently false and the Tiny2 advanced controls can never show on any machine. It now re-reads on each `updateTiny2Visibility()` pass, and `MainWindow::onStateChanged()` re-syncs the v4l2-mode visibility so the UI converges on the controller's real state.

Bugs 1 and 2 affect all camera models; bug 3 affects the Tiny 2 family (Tiny 2 / Tiny 2 Lite / Tiny SE).

## Why?

On my Tiny 2 Lite the app always connected in V4L2-only mode even though SDK detection worked fine. The device label showed "(V4L2)" and the Tracking tab and Advanced Camera Settings were empty.

**Environment:** Bazzite (Fedora 44 Atomic), with the app built and running inside a Fedora 44 distrobox, camera passed through via the shared `/dev`. This setup probably contributed to how consistently I hit the bug: the SDK's connect handshake takes about 4 seconds for me, likely slower than a bare-metal install, so the V4L2 fallback won the race 100% of the time. The race itself is in the code and exists on any setup though, since the device list is checked synchronously right after SDK init; a faster machine just has a smaller losing window.

I suspect this is also why the compatibility table has "auto-framing doesn't work" style entries: the SDK path never actually engages when the camera is plugged in before launch.

## How to test
1. Plug in the camera before launching the app.
2. Without this fix: the device label shows "(V4L2)" and the Tracking tab and Advanced Camera Settings group are empty.
3. With this fix: after a few seconds the label shows the SDK device name and both sections are populated.
4. Toggle tracking, AI modes, tracking speed, auto-zoom, HDR, FOV, and face AE/focus; all are accepted by the camera (every `cameraSet*` in the SDK log returns success).

## Checklist
- [x] Builds cleanly: `./build.sh build --confirm`
- [x] Tested with my camera (model: OBSBOT Tiny 2 Lite)

---

Side note, unrelated but noticed while debugging: the Tiny 2 Lite reports `zoom_ratio` as `5` where the code expects 100-200, so zoom readback gets discarded (the "unexpected zoom_ratio" path). Will probably need more investigation to uncover what the Lite is actually reporting there. If there is interest I could open a separate issue for it.
