### PR TITLE
Fix Tiny SE (and slow-detecting cameras) falling back to V4L2 and hiding AI tracking

### DIFF
--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -38,66 +38,104 @@ void CameraController::connectToCamera(const QString &devicePath)
 {
     m_selectedDevicePath = devicePath;
 
-    auto pickDevice = [this](const std::list<std::shared_ptr<Device>> &list)
-        -> std::shared_ptr<Device>
-    {
-        if (list.empty()) return nullptr;
-        if (m_selectedDevicePath.isEmpty()) return list.front();
-
-        for (const auto &dev : list) {
-            if (QString::fromStdString(dev->videoDevPath()) == m_selectedDevicePath)
-                return dev;
-        }
-        qDebug() << "CameraController: device" << m_selectedDevicePath
-                 << "not found in SDK list, using first available";
-        return list.front();
-    };
-
-    auto onDevChanged = [this, pickDevice](std::string /*dev_sn*/, bool connected, void * /*param*/) {
+    auto onDevChanged = [this](std::string /*dev_sn*/, bool connected, void * /*param*/) {
         if (connected) {
-            auto dev_list = Devices::get().getDevList();
-            auto dev = pickDevice(dev_list);
-            if (dev) {
-                m_device = dev;
-                m_connected = true;
-                m_cameraInfo.name = QString::fromStdString(m_device->devName());
-                m_cameraInfo.serialNumber = QString::fromStdString(m_device->devSn());
-                m_cameraInfo.version = QString::fromStdString(m_device->devVersion());
-                m_cameraInfo.productType = m_device->productType();
-                m_cameraInfo.connected = true;
-                refreshControlRanges();
-                emit cameraConnected(m_cameraInfo);
-                updateState();
-            }
+            // SDK detection runs on its own thread. Marshal the connect onto the
+            // Qt/main thread so we never touch m_device or emit signals off-thread.
+            QMetaObject::invokeMethod(this, [this]() {
+                if (m_connected && !m_v4l2Only) return;  // already on the SDK
+                auto dev = pickSdkDevice(Devices::get().getDevList());
+                if (dev) connectSdkDevice(dev);
+            }, Qt::QueuedConnection);
         } else {
-            m_connected = false;
-            m_cameraInfo.connected = false;
-            resetControlRanges();
-            emit cameraDisconnected();
+            QMetaObject::invokeMethod(this, [this]() {
+                if (m_v4l2Only) return;  // V4L2 path manages its own lifecycle
+                m_connected = false;
+                m_cameraInfo.connected = false;
+                resetControlRanges();
+                emit cameraDisconnected();
+            }, Qt::QueuedConnection);
         }
     };
 
     Devices::get().setDevChangedCallback(onDevChanged, nullptr);
     Devices::get().setEnableMdnsScan(false);
 
-    auto dev_list = Devices::get().getDevList();
-    if (!dev_list.empty() && !m_connected) {
-        auto dev = pickDevice(dev_list);
-        if (dev) {
-            m_device = dev;
-            m_connected = true;
-            m_cameraInfo.name = QString::fromStdString(m_device->devName());
-            m_cameraInfo.serialNumber = QString::fromStdString(m_device->devSn());
-            m_cameraInfo.version = QString::fromStdString(m_device->devVersion());
-            m_cameraInfo.productType = m_device->productType();
-            m_cameraInfo.connected = true;
-            refreshControlRanges();
-            emit cameraConnected(m_cameraInfo);
-            updateState();
-        }
+    auto dev = pickSdkDevice(Devices::get().getDevList());
+    if (dev && !m_connected) {
+        connectSdkDevice(dev);
     } else {
-        tryV4l2Fallback();
+        // SDK USB detection is asynchronous and can take several seconds on some
+        // devices (Tiny SE ~3.4s). Give it a grace period to report the device
+        // before falling back to V4L2-only mode: the V4L2 fallback calls
+        // Devices::close(), which permanently stops SDK detection for the whole
+        // process and hides every SDK-only feature (AI tracking, HDR, etc.).
+        startSdkGraceThenFallback();
     }
+}
+
+std::shared_ptr<Device> CameraController::pickSdkDevice(const std::list<std::shared_ptr<Device>> &list) const
+{
+    if (list.empty()) return nullptr;
+    if (m_selectedDevicePath.isEmpty()) return list.front();
+
+    for (const auto &dev : list) {
+        if (QString::fromStdString(dev->videoDevPath()) == m_selectedDevicePath)
+            return dev;
+    }
+    qDebug() << "CameraController: device" << m_selectedDevicePath
+             << "not found in SDK list, using first available";
+    return list.front();
+}
+
+void CameraController::connectSdkDevice(const std::shared_ptr<Device> &dev)
+{
+    if (m_sdkGraceTimer) m_sdkGraceTimer->stop();
+    m_sdkGraceElapsedMs = 0;
+
+    m_device = dev;
+    m_v4l2Only = false;
+    m_connected = true;
+    m_cameraInfo.name = QString::fromStdString(m_device->devName());
+    m_cameraInfo.serialNumber = QString::fromStdString(m_device->devSn());
+    m_cameraInfo.version = QString::fromStdString(m_device->devVersion());
+    m_cameraInfo.productType = m_device->productType();
+    m_cameraInfo.connected = true;
+    refreshControlRanges();
+    emit cameraConnected(m_cameraInfo);
+    updateState();
+}
+
+void CameraController::startSdkGraceThenFallback()
+{
+    static constexpr int kGraceTotalMs = 8000;  // > observed SDK detection latency
+    static constexpr int kGraceStepMs = 250;
+
+    if (!m_sdkGraceTimer) {
+        m_sdkGraceTimer = new QTimer(this);
+        m_sdkGraceTimer->setInterval(kGraceStepMs);
+        connect(m_sdkGraceTimer, &QTimer::timeout, this, [this]() {
+            if (m_connected) {  // SDK callback already connected us
+                m_sdkGraceTimer->stop();
+                m_sdkGraceElapsedMs = 0;
+                return;
+            }
+            if (auto dev = pickSdkDevice(Devices::get().getDevList())) {
+                m_sdkGraceTimer->stop();
+                connectSdkDevice(dev);
+                return;
+            }
+            m_sdkGraceElapsedMs += kGraceStepMs;
+            if (m_sdkGraceElapsedMs >= kGraceTotalMs) {
+                m_sdkGraceTimer->stop();
+                m_sdkGraceElapsedMs = 0;
+                if (!m_connected)
+                    tryV4l2Fallback();  // no SDK device appeared; use V4L2
+            }
+        });
+    }
+    m_sdkGraceElapsedMs = 0;
+    m_sdkGraceTimer->start();
 }
 
 void CameraController::tryV4l2Fallback()
@@ -207,6 +245,9 @@ void CameraController::updateV4l2State()
 
 void CameraController::disconnectFromCamera()
 {
+    if (m_sdkGraceTimer) m_sdkGraceTimer->stop();
+    m_sdkGraceElapsedMs = 0;
+
     if (m_connected) {
         if (m_v4l2Only) {
             m_v4l2.close();

--- a/src/gui/CameraController.h
+++ b/src/gui/CameraController.h
@@ -155,6 +155,8 @@ private:
     bool m_v4l2Only = false;
     V4l2Backend m_v4l2;
     QTimer *m_v4l2ScanTimer = nullptr;
+    QTimer *m_sdkGraceTimer = nullptr;  // Waits for async SDK detection before V4L2 fallback
+    int m_sdkGraceElapsedMs = 0;
     QString m_v4l2DevicePath;
     CameraInfo m_cameraInfo;
     CameraState m_currentState;
@@ -170,6 +172,9 @@ private:
     bool m_whiteBalanceFallbackActive;
     int m_fallbackWhiteBalanceMode;
     bool isTiny2Family() const;
+    std::shared_ptr<Device> pickSdkDevice(const std::list<std::shared_ptr<Device>> &list) const;
+    void connectSdkDevice(const std::shared_ptr<Device> &dev);
+    void startSdkGraceThenFallback();
     void tryV4l2Fallback();
     void connectV4l2(const std::string &devicePath);
     void refreshV4l2ControlRanges();


### PR DESCRIPTION
## What & why

On the OBSBOT Tiny SE, the GUI showed only **Manual Camera Control** — the entire **Face Tracking** section (Enable Auto-Framing + the AI mode selector) was missing, and the app was stuck in V4L2-only mode.

Root cause is a startup race in `CameraController::connectToCamera()`:

1. The SDK's USB detection runs on a background thread and takes **several seconds** on some devices (Tiny SE measured at ~3.4s).
2. `connectToCamera()` checked `Devices::get().getDevList()` **once, synchronously**, at startup. The list was empty, so it immediately called `tryV4l2Fallback()`.
3. The V4L2 fallback calls `Devices::get().close()`, which **permanently stops SDK detection for the whole process**. So even hitting **Reconnect** never recovered — `getDevList()` stayed empty forever.
4. In V4L2-only mode `productType == -1`, which isn't in `isTiny2Family()`, so `setV4l2Mode(true)` hides the whole Face Tracking / AI section and no SDK-only features (AI tracking, HDR, etc.) are available.

Because detection latency (~3.4s) always exceeds the synchronous check at t=0, the Tiny SE fell into V4L2 mode **100% of the time**.

## The fix

Give the SDK a grace period (up to 8s, polled every 250ms) to report the device **before** falling back to V4L2:

- Connect via the SDK as soon as the device appears — from either the poll or the device-changed callback.
- The callback is now marshalled onto the Qt thread via `QMetaObject::invokeMethod(..., Qt::QueuedConnection)`, so `m_device` mutation and signal emission never happen on the SDK's detection thread.
- V4L2 remains the fallback only when no SDK device shows up within the grace window — and it no longer prematurely tears down SDK detection.

No UI or behavior change for cameras that are detected quickly; they still connect on the first synchronous check.

## Testing

- **Camera:** OBSBOT Tiny SE (firmware 6.4.4.1), Linux, SDK v1.0.2.
- Confirmed via the SDK that `getDevList()` is empty at t=0 and the device appears ~3.4s later, and that `Devices::close()` does not restart detection.
- Before: GUI connects V4L2-only, `productType = -1`, Face Tracking section hidden.
- After: GUI waits for detection, connects via the SDK (`productType = 12`, Tiny SE), and the full AI mode selector (Group/Human/Hand/Whiteboard/Desk) is shown and functional.
- Built via `./build.sh build --confirm`; both `obsbot-gui` and `obsbot-cli` build clean.

## Notes / scope

- This should also help any Tiny 2 / Tiny 2 Lite user whose SDK detection is slower than the app's startup check.
- Separately, the Tiny SE reports `zoom_ratio = 0` in its status struct (shows "Zoom: 0%" and logs an `unexpected zoom_ratio` warning). That's cosmetic and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)