### PR TITLE
Refine UI / Fix Tiny 4K SDK discovery and controls

### DIFF
--- a/src/common/Config.cpp
+++ b/src/common/Config.cpp
@@ -58,6 +58,7 @@ void Config::setDefaults()
 
     for (auto &preset : m_settings.presets) {
         preset.defined = false;
+        preset.name.clear();
         preset.pan = 0.0;
         preset.tilt = 0.0;
         preset.zoom = 1.0;
@@ -218,6 +219,7 @@ bool Config::load(std::vector<ValidationError> &errors)
         const std::string suffix = key.substr(8);
         static const std::unordered_set<std::string> presetSuffixes = {
             "defined",
+            "name",
             "pan",
             "tilt",
             "zoom"
@@ -283,6 +285,9 @@ bool Config::parseLine(const std::string &line, int lineNumber, std::vector<Vali
                     addError(InvalidValue, base + "defined must be true/false or enabled/disabled");
                     return false;
                 }
+                return true;
+            } else if (suffix == "name") {
+                preset.name = value;
                 return true;
             } else if (suffix == "pan") {
                 try {
@@ -857,6 +862,7 @@ bool Config::save()
         const auto &preset = m_settings.presets[i];
         file << "# PTZ Preset " << (i + 1) << "\n";
         file << "preset" << (i + 1) << "_defined=" << (preset.defined ? "enabled" : "disabled") << "\n";
+        file << "preset" << (i + 1) << "_name=" << preset.name << "\n";
         file << "preset" << (i + 1) << "_pan=" << preset.pan << "\n";
         file << "preset" << (i + 1) << "_tilt=" << preset.tilt << "\n";
         file << "preset" << (i + 1) << "_zoom=" << preset.zoom << "\n\n";

--- a/src/common/Config.cpp
+++ b/src/common/Config.cpp
@@ -34,6 +34,7 @@ void Config::setDefaults()
     m_settings.aiSubMode = 0;         // AiSubModeNormal
     m_settings.autoZoom = false;
     m_settings.trackSpeed = 2;        // AiTrackSpeedStandard
+    m_settings.trackingStyle = 0;      // AiVTrackStandard
 
     // Image controls - use auto mode by default
     m_settings.brightnessAuto = true;
@@ -430,6 +431,18 @@ bool Config::parseLine(const std::string &line, int lineNumber, std::vector<Vali
             addError(InvalidValue, "track_speed must be an integer between 0 and 5");
             return false;
         }
+    } else if (key == "tracking_style") {
+        try {
+            int style = std::stoi(value);
+            if (style < 0 || style > 2) {
+                addError(InvalidValue, "tracking_style must be between 0 and 2");
+                return false;
+            }
+            m_settings.trackingStyle = style;
+        } catch (...) {
+            addError(InvalidValue, "tracking_style must be an integer between 0 and 2");
+            return false;
+        }
     } else if (key == "brightness_auto") {
         if (!parseBool(value, m_settings.brightnessAuto)) {
             addError(InvalidValue, "brightness_auto must be true/false or enabled/disabled");
@@ -766,6 +779,9 @@ bool Config::save()
 
     file << "# Tracking Speed (0=Lazy,1=Slow,2=Standard,3=Fast,4=Crazy,5=Auto)\n";
     file << "track_speed=" << m_settings.trackSpeed << "\n\n";
+
+    file << "# Tiny tracking style (0=Standard,1=Headroom,2=Motion)\n";
+    file << "tracking_style=" << m_settings.trackingStyle << "\n\n";
 
     // Image controls
     file << "# Brightness Auto Mode (when enabled, brightness slider is read-only)\n";

--- a/src/common/Config.cpp
+++ b/src/common/Config.cpp
@@ -66,6 +66,8 @@ void Config::setDefaults()
 
     // Application settings
     m_settings.startMinimized = false;
+    m_settings.invertGimbalX = false;
+    m_settings.invertGimbalY = false;
     m_settings.virtualCameraEnabled = false;
     m_settings.virtualCameraDevice = "/dev/video42";
     m_settings.virtualCameraResolution = "match";
@@ -199,7 +201,9 @@ bool Config::load(std::vector<ValidationError> &errors)
         "virtual_camera_resolution",
         "white_balance_kelvin",
         "focus",
-        "snapshot_directory"
+        "snapshot_directory",
+        "invert_gimbal_x",
+        "invert_gimbal_y"
     };
 
     auto isPresetKey = [](const std::string &key) -> bool {
@@ -595,6 +599,16 @@ bool Config::parseLine(const std::string &line, int lineNumber, std::vector<Vali
             addError(InvalidValue, "start_minimized must be true/false or enabled/disabled");
             return false;
         }
+    } else if (key == "invert_gimbal_x") {
+        if (!parseBool(value, m_settings.invertGimbalX)) {
+            addError(InvalidValue, "invert_gimbal_x must be true/false or enabled/disabled");
+            return false;
+        }
+    } else if (key == "invert_gimbal_y") {
+        if (!parseBool(value, m_settings.invertGimbalY)) {
+            addError(InvalidValue, "invert_gimbal_y must be true/false or enabled/disabled");
+            return false;
+        }
     } else if (key == "virtual_camera_enabled") {
         if (!parseBool(value, m_settings.virtualCameraEnabled)) {
             addError(InvalidValue, "virtual_camera_enabled must be true/false or enabled/disabled");
@@ -877,6 +891,8 @@ bool Config::save()
     file << "# Application Settings\n";
     file << "# Start application minimized to system tray\n";
     file << "start_minimized=" << (m_settings.startMinimized ? "enabled" : "disabled") << "\n";
+    file << "invert_gimbal_x=" << (m_settings.invertGimbalX ? "enabled" : "disabled") << "\n";
+    file << "invert_gimbal_y=" << (m_settings.invertGimbalY ? "enabled" : "disabled") << "\n";
 
     file << "\n# Virtual camera output\n";
     file << "virtual_camera_enabled=" << (m_settings.virtualCameraEnabled ? "enabled" : "disabled") << "\n";

--- a/src/common/Config.cpp
+++ b/src/common/Config.cpp
@@ -43,6 +43,9 @@ void Config::setDefaults()
     m_settings.contrast = 128;
     m_settings.saturationAuto = true;
     m_settings.saturation = 128;
+    m_settings.hue = 50;
+    m_settings.sharpness = 50;
+    m_settings.antiFlicker = 1;
     m_settings.whiteBalance = 0;      // Auto
     m_settings.whiteBalanceKelvin = 5000;
     m_settings.focus = -1;            // Auto focus
@@ -184,6 +187,10 @@ bool Config::load(std::vector<ValidationError> &errors)
         "ai_sub_mode",
         "auto_zoom",
         "track_speed",
+        "tracking_style",
+        "hue",
+        "sharpness",
+        "anti_flicker",
         "audio_auto_gain",
         "preview_format",
         "virtual_camera_enabled",
@@ -503,6 +510,21 @@ bool Config::parseLine(const std::string &line, int lineNumber, std::vector<Vali
             addError(InvalidValue, "saturation must be an integer between 0 and 255");
             return false;
         }
+    } else if (key == "hue" || key == "sharpness" || key == "anti_flicker") {
+        try {
+            int parsed = std::stoi(value);
+            const int maximum = key == "anti_flicker" ? 3 : 100;
+            if (parsed < 0 || parsed > maximum) {
+                addError(InvalidValue, key + " is out of range");
+                return false;
+            }
+            if (key == "hue") m_settings.hue = parsed;
+            else if (key == "sharpness") m_settings.sharpness = parsed;
+            else m_settings.antiFlicker = parsed;
+        } catch (...) {
+            addError(InvalidValue, key + " must be an integer");
+            return false;
+        }
     } else if (key == "white_balance") {
         if (value == "auto" || value == "0") {
             m_settings.whiteBalance = 0;
@@ -658,6 +680,10 @@ bool Config::validateSettings(std::vector<ValidationError> &errors)
         addError("track_speed out of range (must be 0-5)");
     }
 
+    if (m_settings.trackingStyle < 0 || m_settings.trackingStyle > 2) {
+        addError("tracking_style out of range (must be 0-2)");
+    }
+
     if (m_settings.whiteBalance == 255) {
         if (m_settings.whiteBalanceKelvin != -1 && (m_settings.whiteBalanceKelvin < 2000 || m_settings.whiteBalanceKelvin > 10000)) {
             addError("white_balance_kelvin out of range (must be 2000-10000)");
@@ -798,6 +824,13 @@ bool Config::save()
     file << "saturation_auto=" << (m_settings.saturationAuto ? "enabled" : "disabled") << "\n";
     file << "# Saturation (0-255, default 128)\n";
     file << "saturation=" << m_settings.saturation << "\n\n";
+
+    file << "# Hue and sharpness (camera range is applied at runtime)\n";
+    file << "hue=" << m_settings.hue << "\n";
+    file << "sharpness=" << m_settings.sharpness << "\n\n";
+
+    file << "# Anti-flicker (0=Off,1=50Hz,2=60Hz,3=Auto when supported)\n";
+    file << "anti_flicker=" << m_settings.antiFlicker << "\n\n";
 
     file << "# White Balance (auto/daylight/fluorescent/tungsten/flash/fine/cloudy/shade)\n";
     std::string wbStr;

--- a/src/common/Config.h
+++ b/src/common/Config.h
@@ -33,6 +33,7 @@ public:
     struct CameraSettings {
         struct PresetSlot {
             bool defined;
+            std::string name;
             double pan;
             double tilt;
             double zoom;

--- a/src/common/Config.h
+++ b/src/common/Config.h
@@ -61,6 +61,9 @@ public:
         int contrast;         // Typically 0-255 or similar range
         bool saturationAuto;  // Auto mode for saturation
         int saturation;       // Typically 0-255 or similar range
+        int hue;
+        int sharpness;
+        int antiFlicker;
         int whiteBalance;     // 0=Auto, 1=Daylight, 2=Fluorescent, etc.
         int whiteBalanceKelvin; // Manual Kelvin value (when whiteBalance==255)
         int focus;            // Manual focus position (0-100, -1 = auto)

--- a/src/common/Config.h
+++ b/src/common/Config.h
@@ -79,6 +79,8 @@ public:
 
         // Application settings
         bool startMinimized;  // Start application minimized to tray
+        bool invertGimbalX;
+        bool invertGimbalY;
         bool virtualCameraEnabled;
         std::string virtualCameraDevice;
         std::string virtualCameraResolution;

--- a/src/common/Config.h
+++ b/src/common/Config.h
@@ -52,6 +52,7 @@ public:
         int aiSubMode;        // Device::AiSubModeType
         bool autoZoom;        // Enable adaptive auto zoom
         int trackSpeed;       // Device::AiTrackSpeedType
+        int trackingStyle;    // Device::AiVerticalTrackType (Tiny/Tiny 4K)
 
         // Image controls
         bool brightnessAuto;  // Auto mode for brightness

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -1233,6 +1233,7 @@ void CameraController::applyCurrentStateToCamera(const CameraState &uiState)
     setFOV(uiState.fovMode);
     setFaceAE(uiState.faceAEEnabled);
     setFaceFocus(uiState.faceFocusEnabled);
+    setFocusAbsolute(uiState.manualFocusValue, uiState.autoFocusEnabled);
     setZoom(uiState.zoom);
     setPanTilt(uiState.pan, uiState.tilt);
 

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -537,9 +537,14 @@ bool CameraController::setHDR(bool enabled)
 {
     if (!m_connected || m_v4l2Only) return false;
 
-    return executeCommand(enabled ? "Enable HDR" : "Disable HDR", [this, enabled]() {
+    bool success = executeCommand(enabled ? "Enable HDR" : "Disable HDR", [this, enabled]() {
         return m_device->cameraSetWdrR(enabled ? Device::DevWdrModeDol2TO1 : Device::DevWdrModeNone);
     });
+    if (success) {
+        m_currentState.hdrEnabled = enabled;
+        emit stateChanged(m_currentState);
+    }
+    return success;
 }
 
 bool CameraController::setFOV(int fovMode)
@@ -554,27 +559,42 @@ bool CameraController::setFOV(int fovMode)
         default: return false;
     }
 
-    return executeCommand("Set FOV", [this, fov]() {
+    bool success = executeCommand("Set FOV", [this, fov]() {
         return m_device->cameraSetFovU(fov);
     });
+    if (success) {
+        m_currentState.fovMode = fovMode;
+        emit stateChanged(m_currentState);
+    }
+    return success;
 }
 
 bool CameraController::setFaceAE(bool enabled)
 {
     if (!m_connected || m_v4l2Only) return false;
 
-    return executeCommand(enabled ? "Enable Face AE" : "Disable Face AE", [this, enabled]() {
+    bool success = executeCommand(enabled ? "Enable Face AE" : "Disable Face AE", [this, enabled]() {
         return m_device->cameraSetFaceAER(enabled);
     });
+    if (success) {
+        m_currentState.faceAEEnabled = enabled;
+        emit stateChanged(m_currentState);
+    }
+    return success;
 }
 
 bool CameraController::setFaceFocus(bool enabled)
 {
     if (!m_connected || m_v4l2Only) return false;
 
-    return executeCommand(enabled ? "Enable Face Focus" : "Disable Face Focus", [this, enabled]() {
+    bool success = executeCommand(enabled ? "Enable Face Focus" : "Disable Face Focus", [this, enabled]() {
         return m_device->cameraSetFaceFocusR(enabled);
     });
+    if (success) {
+        m_currentState.faceFocusEnabled = enabled;
+        emit stateChanged(m_currentState);
+    }
+    return success;
 }
 
 bool CameraController::setFocusAbsolute(int position, bool autoFocus)
@@ -639,8 +659,10 @@ bool CameraController::setAntiFlicker(int frequency)
     bool success = executeCommand("Set anti-flicker", [this, clamped]() {
         return m_device->cameraSetAntiFlickR(clamped);
     });
-    if (success)
+    if (success) {
         m_currentState.antiFlicker = clamped;
+        emit stateChanged(m_currentState);
+    }
     return success;
 }
 
@@ -714,8 +736,10 @@ bool CameraController::setHue(int value)
     bool success = executeCommand("Set Hue", [this, clamped]() {
         return m_device->cameraSetImageHueR(clamped);
     });
-    if (success)
+    if (success) {
         m_currentState.hue = clamped;
+        emit stateChanged(m_currentState);
+    }
     return success;
 }
 
@@ -726,8 +750,10 @@ bool CameraController::setSharpness(int value)
     bool success = executeCommand("Set Sharpness", [this, clamped]() {
         return m_device->cameraSetImageSharpR(clamped);
     });
-    if (success)
+    if (success) {
         m_currentState.sharpness = clamped;
+        emit stateChanged(m_currentState);
+    }
     return success;
 }
 
@@ -1002,6 +1028,9 @@ void CameraController::applyConfigToCamera()
     setBrightness(settings.brightness);
     setContrast(settings.contrast);
     setSaturation(settings.saturation);
+    setHue(settings.hue);
+    setSharpness(settings.sharpness);
+    setAntiFlicker(settings.antiFlicker);
     if (settings.whiteBalance == static_cast<int>(Device::DevWhiteBalanceManual)) {
         setWhiteBalanceManual(settings.whiteBalanceKelvin);
     } else {
@@ -1047,6 +1076,9 @@ void CameraController::applyCurrentStateToCamera(const CameraState &uiState)
     setBrightness(uiState.brightness);
     setContrast(uiState.contrast);
     setSaturation(uiState.saturation);
+    setHue(uiState.hue);
+    setSharpness(uiState.sharpness);
+    setAntiFlicker(uiState.antiFlicker);
     if (uiState.whiteBalance == static_cast<int>(Device::DevWhiteBalanceManual)) {
         setWhiteBalanceManual(uiState.whiteBalanceKelvin);
     } else {
@@ -1082,6 +1114,9 @@ void CameraController::saveCurrentStateToConfig()
     settings.contrast = m_currentState.contrast;
     settings.saturationAuto = m_currentState.saturationAuto;
     settings.saturation = m_currentState.saturation;
+    settings.hue = m_currentState.hue;
+    settings.sharpness = m_currentState.sharpness;
+    settings.antiFlicker = m_currentState.antiFlicker;
     settings.whiteBalance = m_currentState.whiteBalance;
     settings.whiteBalanceKelvin = m_currentState.whiteBalanceKelvin;
     settings.focus = m_currentState.autoFocusEnabled ? -1 : m_currentState.manualFocusValue;

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -607,8 +607,10 @@ bool CameraController::setTrackingStyle(int style)
     bool success = executeCommand("Set tracking style", [this, style]() {
         return m_device->aiSetTrackingModeR(static_cast<Device::AiVerticalTrackType>(style));
     });
-    if (success)
+    if (success) {
         m_currentState.trackingStyle = style;
+        emit stateChanged(m_currentState);
+    }
     return success;
 }
 
@@ -993,6 +995,8 @@ void CameraController::applyConfigToCamera()
         setTrackSpeed(settings.trackSpeed);
         setAudioAutoGain(settings.audioAutoGain);
     }
+    if (isOriginalTinyFamily())
+        setTrackingStyle(settings.trackingStyle);
 
     // Image controls
     setBrightness(settings.brightness);
@@ -1030,6 +1034,8 @@ void CameraController::applyCurrentStateToCamera(const CameraState &uiState)
         setTrackSpeed(uiState.trackSpeedMode);
         setAudioAutoGain(uiState.audioAutoGainEnabled);
     }
+    if (isOriginalTinyFamily())
+        setTrackingStyle(uiState.trackingStyle);
     setHDR(uiState.hdrEnabled);
     setFOV(uiState.fovMode);
     setFaceAE(uiState.faceAEEnabled);
@@ -1066,6 +1072,7 @@ void CameraController::saveCurrentStateToConfig()
     settings.aiSubMode = m_currentState.aiSubMode;
     settings.autoZoom = m_currentState.autoZoomEnabled;
     settings.trackSpeed = m_currentState.trackSpeedMode;
+    settings.trackingStyle = m_currentState.trackingStyle;
     settings.audioAutoGain = m_currentState.audioAutoGainEnabled;
 
     // Image controls

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -5,6 +5,28 @@
 
 static constexpr int kDefaultWhiteBalanceKelvin = 4800;
 
+static QString productDisplayName(int productType, const QString &fallback)
+{
+    switch (productType) {
+    case ObsbotProdTiny:      return QStringLiteral("OBSBOT Tiny");
+    case ObsbotProdTiny4k:    return QStringLiteral("OBSBOT Tiny 4K");
+    case ObsbotProdTiny2:     return QStringLiteral("OBSBOT Tiny 2");
+    case ObsbotProdTiny2Lite: return QStringLiteral("OBSBOT Tiny 2 Lite");
+    case ObsbotProdTinySE:    return QStringLiteral("OBSBOT Tiny SE");
+    case ObsbotProdTailAir:   return QStringLiteral("OBSBOT Tail Air");
+    case ObsbotProdTail2:     return QStringLiteral("OBSBOT Tail 2");
+    case ObsbotProdTail2S:    return QStringLiteral("OBSBOT Tail 2S");
+    case ObsbotProdMeet:      return QStringLiteral("OBSBOT Meet");
+    case ObsbotProdMeet4k:    return QStringLiteral("OBSBOT Meet 4K");
+    case ObsbotProdMeet2:     return QStringLiteral("OBSBOT Meet 2");
+    case ObsbotProdMeetSE:    return QStringLiteral("OBSBOT Meet SE");
+    case ObsbotProdMe:        return QStringLiteral("OBSBOT Me");
+    case ObsbotProdHDMIBox:   return QStringLiteral("OBSBOT HDMI Box");
+    case ObsbotProdNDIBox:    return QStringLiteral("OBSBOT NDI Box");
+    default:                  return fallback;
+    }
+}
+
 static int shutterTypeToV4l2(int shutterType)
 {
     static constexpr double denominators[] = {
@@ -85,7 +107,8 @@ void CameraController::connectToCamera(const QString &devicePath)
                 }
                 m_device = dev;
                 m_connected = true;
-                m_cameraInfo.name = QString::fromStdString(m_device->devName());
+                m_cameraInfo.name = productDisplayName(
+                    m_device->productType(), QString::fromStdString(m_device->devName()));
                 m_cameraInfo.serialNumber = QString::fromStdString(m_device->devSn());
                 m_cameraInfo.version = QString::fromStdString(m_device->devVersion());
                 m_cameraInfo.productType = m_device->productType();
@@ -111,7 +134,8 @@ void CameraController::connectToCamera(const QString &devicePath)
         if (dev) {
             m_device = dev;
             m_connected = true;
-            m_cameraInfo.name = QString::fromStdString(m_device->devName());
+            m_cameraInfo.name = productDisplayName(
+                m_device->productType(), QString::fromStdString(m_device->devName()));
             m_cameraInfo.serialNumber = QString::fromStdString(m_device->devSn());
             m_cameraInfo.version = QString::fromStdString(m_device->devVersion());
             m_cameraInfo.productType = m_device->productType();

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -567,28 +567,10 @@ bool CameraController::setFOV(int fovMode)
     });
     if (success) {
         m_currentState.fovMode = fovMode;
-        float zoom = m_currentState.zoom;
-        if (m_device->cameraGetZoomAbsoluteR(zoom) == 0
-                && zoom >= 1.0f && zoom <= 2.0f) {
-            m_currentState.zoom = zoom;
-            m_currentState.zoomRatio = qRound(zoom * 100.0f);
-        }
+        static constexpr double presetZoom[] = {1.00, 1.05, 1.15};
+        m_currentState.zoom = presetZoom[fovMode];
+        m_currentState.zoomRatio = qRound(m_currentState.zoom * 100.0);
         emit stateChanged(m_currentState);
-
-        // Tiny/Tiny 4K apply named FOV presets asynchronously. The immediate
-        // getter above can still return the previous zoom, so read it again
-        // after both the camera movement and UI command debounce have settled.
-        QTimer::singleShot(1100, this, [this, fovMode]() {
-            if (!m_connected || m_v4l2Only || m_currentState.fovMode != fovMode)
-                return;
-            float settledZoom = m_currentState.zoom;
-            if (m_device->cameraGetZoomAbsoluteR(settledZoom) == 0
-                    && settledZoom >= 1.0f && settledZoom <= 2.0f) {
-                m_currentState.zoom = settledZoom;
-                m_currentState.zoomRatio = qRound(settledZoom * 100.0f);
-                emit stateChanged(m_currentState);
-            }
-        });
     }
     return success;
 }
@@ -1083,14 +1065,20 @@ void CameraController::updateState()
 
     m_currentState.aiMode = status.tiny.ai_mode;
     m_currentState.aiSubMode = status.tiny.ai_sub_mode;
-    // Tiny/Tiny 4K report zoom_ratio as 0..100, not 100..200. The normalized
-    // getter is supported across the OBSBOT product families and avoids
-    // interpreting product-specific status layouts.
-    float zoom = 1.0f;
-    if (m_device->cameraGetZoomAbsoluteR(zoom) == 0 &&
-        zoom >= 1.0f && zoom <= 2.0f) {
-        m_currentState.zoom = zoom;
-        m_currentState.zoomRatio = qRound(zoom * 100.0f);
+    // Tiny/Tiny 4K firmware 1.2.6.2 returns 2.0 from the normalized getter
+    // regardless of the actual zoom. Its status field reliably reports a
+    // 0..100 offset from 1.0x instead.
+    if (isOriginalTinyFamily() && status.tiny.zoom_ratio <= 100) {
+        m_currentState.zoom = 1.0
+            + static_cast<double>(status.tiny.zoom_ratio) / 100.0;
+        m_currentState.zoomRatio = qRound(m_currentState.zoom * 100.0);
+    } else {
+        float zoom = 1.0f;
+        if (m_device->cameraGetZoomAbsoluteR(zoom) == 0
+                && zoom >= 1.0f && zoom <= 2.0f) {
+            m_currentState.zoom = zoom;
+            m_currentState.zoomRatio = qRound(zoom * 100.0f);
+        }
     }
     m_currentState.hdrEnabled = status.tiny.hdr;
     m_currentState.faceAEEnabled = status.tiny.face_ae;

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -583,6 +583,9 @@ bool CameraController::setFOV(int fovMode)
         static constexpr double presetZoom[] = {1.00, 1.05, 1.15};
         m_currentState.zoom = presetZoom[fovMode];
         m_currentState.zoomRatio = qRound(m_currentState.zoom * 100.0);
+        // Tiny/Tiny 4K can briefly report the previous zoom after changing
+        // FOV. Preserve the intended preset until the camera has caught up.
+        m_zoomPollingPause.start();
         emit stateChanged(m_currentState);
     }
     return success;
@@ -1081,16 +1084,20 @@ void CameraController::updateState(bool includeImageControls)
     // Tiny/Tiny 4K firmware 1.2.6.2 returns 2.0 from the normalized getter
     // regardless of the actual zoom. Its status field reliably reports a
     // 0..100 offset from 1.0x instead.
-    if (isOriginalTinyFamily() && status.tiny.zoom_ratio <= 100) {
-        m_currentState.zoom = 1.0
-            + static_cast<double>(status.tiny.zoom_ratio) / 100.0;
-        m_currentState.zoomRatio = qRound(m_currentState.zoom * 100.0);
-    } else {
-        float zoom = 1.0f;
-        if (m_device->cameraGetZoomAbsoluteR(zoom) == 0
-                && zoom >= 1.0f && zoom <= 2.0f) {
-            m_currentState.zoom = zoom;
-            m_currentState.zoomRatio = qRound(zoom * 100.0f);
+    const bool zoomPollingPaused =
+        m_zoomPollingPause.isValid() && m_zoomPollingPause.elapsed() < 1000;
+    if (!zoomPollingPaused) {
+        if (isOriginalTinyFamily() && status.tiny.zoom_ratio <= 100) {
+            m_currentState.zoom = 1.0
+                + static_cast<double>(status.tiny.zoom_ratio) / 100.0;
+            m_currentState.zoomRatio = qRound(m_currentState.zoom * 100.0);
+        } else {
+            float zoom = 1.0f;
+            if (m_device->cameraGetZoomAbsoluteR(zoom) == 0
+                    && zoom >= 1.0f && zoom <= 2.0f) {
+                m_currentState.zoom = zoom;
+                m_currentState.zoomRatio = qRound(zoom * 100.0f);
+            }
         }
     }
     m_currentState.hdrEnabled = status.tiny.hdr;

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -512,6 +512,8 @@ bool CameraController::setZoom(double zoom)
 
     if (success) {
         m_currentState.zoom = zoom;
+        if (!m_v4l2Only && isOriginalTinyFamily())
+            m_currentState.fovMode = Device::FovTypeNull;
         emit stateChanged(m_currentState);
     }
 
@@ -565,6 +567,12 @@ bool CameraController::setFOV(int fovMode)
     });
     if (success) {
         m_currentState.fovMode = fovMode;
+        float zoom = m_currentState.zoom;
+        if (m_device->cameraGetZoomAbsoluteR(zoom) == 0
+                && zoom >= 1.0f && zoom <= 2.0f) {
+            m_currentState.zoom = zoom;
+            m_currentState.zoomRatio = qRound(zoom * 100.0f);
+        }
         emit stateChanged(m_currentState);
     }
     return success;
@@ -1075,7 +1083,7 @@ void CameraController::updateState()
     m_currentState.autoFocusEnabled = status.tiny.auto_focus;
     m_currentState.manualFocusValue = status.tiny.manual_focus_value;
     if (status.tiny.fov >= Device::FovType86
-            && status.tiny.fov <= Device::FovType65) {
+            && status.tiny.fov <= Device::FovTypeNull) {
         m_currentState.fovMode = status.tiny.fov;
     }
     m_currentState.devStatus = status.tiny.dev_status;
@@ -1279,7 +1287,10 @@ void CameraController::saveCurrentStateToConfig()
     // Update only camera-related settings from current state
     settings.faceTracking = m_currentState.autoFramingEnabled;
     settings.hdr = m_currentState.hdrEnabled;
-    settings.fov = m_currentState.fovMode;
+    if (m_currentState.fovMode >= Device::FovType86
+            && m_currentState.fovMode <= Device::FovType65) {
+        settings.fov = m_currentState.fovMode;
+    }
     settings.faceAE = m_currentState.faceAEEnabled;
     settings.faceFocus = m_currentState.faceFocusEnabled;
     settings.zoom = qBound(1.0, m_currentState.zoom, 2.0);

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -1085,7 +1085,7 @@ void CameraController::updateState(bool includeImageControls)
     // regardless of the actual zoom. Its status field reliably reports a
     // 0..100 offset from 1.0x instead.
     const bool zoomPollingPaused =
-        m_zoomPollingPause.isValid() && m_zoomPollingPause.elapsed() < 1000;
+        m_zoomPollingPause.isValid() && m_zoomPollingPause.elapsed() < 2000;
     if (!zoomPollingPaused) {
         if (isOriginalTinyFamily() && status.tiny.zoom_ratio <= 100) {
             m_currentState.zoom = 1.0

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -588,6 +588,13 @@ bool CameraController::setFaceFocus(bool enabled)
 {
     if (!m_connected || m_v4l2Only) return false;
 
+    // Face focus selects the subject to prioritize; it does not itself leave
+    // manual lens mode. Ensure the lens can actually follow that subject.
+    if (enabled && !m_currentState.autoFocusEnabled
+            && !setFocusAbsolute(m_currentState.manualFocusValue, true)) {
+        return false;
+    }
+
     bool success = executeCommand(enabled ? "Enable Face Focus" : "Disable Face Focus", [this, enabled]() {
         return m_device->cameraSetFaceFocusR(enabled);
     });
@@ -1173,7 +1180,7 @@ void CameraController::applyConfigToCamera()
     setFaceFocus(settings.faceFocus);
     setZoom(settings.zoom);
     setPanTilt(settings.pan, settings.tilt);
-    if (settings.focus >= 0) {
+    if (settings.focus >= 0 && !settings.faceFocus) {
         setFocusAbsolute(settings.focus, false);
     } else {
         setFocusAbsolute(0, true);
@@ -1233,7 +1240,8 @@ void CameraController::applyCurrentStateToCamera(const CameraState &uiState)
     setFOV(uiState.fovMode);
     setFaceAE(uiState.faceAEEnabled);
     setFaceFocus(uiState.faceFocusEnabled);
-    setFocusAbsolute(uiState.manualFocusValue, uiState.autoFocusEnabled);
+    setFocusAbsolute(uiState.manualFocusValue,
+                     uiState.autoFocusEnabled || uiState.faceFocusEnabled);
     setZoom(uiState.zoom);
     setPanTilt(uiState.pan, uiState.tilt);
 

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -36,6 +36,7 @@ void CameraController::connectToCamera()
 
 void CameraController::connectToCamera(const QString &devicePath)
 {
+    const quint64 connectionAttempt = ++m_connectionAttempt;
     m_selectedDevicePath = devicePath;
 
     auto pickDevice = [this](const std::list<std::shared_ptr<Device>> &list)
@@ -108,8 +109,8 @@ void CameraController::connectToCamera(const QString &devicePath)
         // still empty here. An immediate fallback would win that race every
         // launch and lock the UI into V4L2-only mode; give the SDK a grace
         // period before settling for plain V4L2.
-        QTimer::singleShot(8000, this, [this]() {
-            if (!m_connected)
+        QTimer::singleShot(8000, this, [this, connectionAttempt]() {
+            if (connectionAttempt == m_connectionAttempt && !m_connected)
                 tryV4l2Fallback();
         });
     }
@@ -222,6 +223,12 @@ void CameraController::updateV4l2State()
 
 void CameraController::disconnectFromCamera()
 {
+    // Invalidate any delayed fallback belonging to the connection being
+    // closed, even when SDK discovery has not completed yet.
+    ++m_connectionAttempt;
+    if (m_v4l2ScanTimer)
+        m_v4l2ScanTimer->stop();
+
     if (m_connected) {
         if (m_v4l2Only) {
             m_v4l2.close();

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -27,18 +27,6 @@ static QString productDisplayName(int productType, const QString &fallback)
     }
 }
 
-static int shutterTypeToV4l2(int shutterType)
-{
-    static constexpr double denominators[] = {
-        8000, 6400, 5000, 4000, 3200, 2500, 2000, 1600, 1250, 1000,
-        800, 640, 500, 400, 320, 240, 200, 160, 120, 100, 80, 60, 50,
-        40, 30, 25, 20, 15, 12.5, 10, 8, 6.25, 5, 4
-    };
-    int index = qBound(0, shutterType - 9, 33);
-    // V4L2_CID_EXPOSURE_ABSOLUTE is measured in 100 microsecond units.
-    return qMax(1, qRound(10000.0 / denominators[index]));
-}
-
 CameraController::CameraController(QObject *parent)
     : QObject(parent)
     , m_connected(false)
@@ -627,22 +615,8 @@ bool CameraController::setTrackingStyle(int style)
 bool CameraController::setExposure(int shutterTime, bool automatic)
 {
     if (!m_connected || m_v4l2Only) return false;
+    if (isTiny4k()) return false;
     int clamped = clampToRange(shutterTime, m_exposureRange, 9, 42);
-
-    if (isTiny4k()) {
-        V4l2Backend exposureBackend;
-        if (!exposureBackend.open(m_device->videoDevPath()))
-            return false;
-        bool success = exposureBackend.setAutoExposure(automatic);
-        if (success && !automatic)
-            success = exposureBackend.setExposureAbsolute(shutterTypeToV4l2(clamped));
-        if (success) {
-            m_currentState.exposureAuto = automatic;
-            m_currentState.exposure = clamped;
-            emit stateChanged(m_currentState);
-        }
-        return success;
-    }
 
     bool success = executeCommand(automatic ? "Enable auto exposure" : "Set exposure",
                                   [this, clamped, automatic]() {
@@ -935,16 +909,7 @@ void CameraController::updateState()
     if (m_device->cameraGetImageSharpR(sharpness) == 0)
         m_currentState.sharpness = clampToRange(sharpness, m_sharpnessRange, 0, 100);
 
-    if (isTiny4k()) {
-        V4l2Backend exposureBackend;
-        if (exposureBackend.open(m_device->videoDevPath())) {
-            int mode = exposureBackend.getControl(V4L2_CID_EXPOSURE_AUTO);
-            if (mode >= 0)
-                m_currentState.exposureAuto =
-                    mode == V4L2_EXPOSURE_AUTO ||
-                    mode == V4L2_EXPOSURE_SHUTTER_PRIORITY;
-        }
-    } else {
+    if (!isTiny4k()) {
         int32_t exposure = m_currentState.exposure;
         bool exposureAuto = m_currentState.exposureAuto;
         if (m_device->cameraGetExposureAbsolute(exposure, exposureAuto) == 0) {

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -605,7 +605,7 @@ bool CameraController::setExposure(int shutterTime, bool automatic)
     if (!m_connected || m_v4l2Only) return false;
     int clamped = clampToRange(shutterTime, m_exposureRange, 9, 42);
 
-    if (isOriginalTinyFamily()) {
+    if (isTiny4k()) {
         V4l2Backend exposureBackend;
         if (!exposureBackend.open(m_device->videoDevPath()))
             return false;
@@ -911,7 +911,7 @@ void CameraController::updateState()
     if (m_device->cameraGetImageSharpR(sharpness) == 0)
         m_currentState.sharpness = clampToRange(sharpness, m_sharpnessRange, 0, 100);
 
-    if (isOriginalTinyFamily()) {
+    if (isTiny4k()) {
         V4l2Backend exposureBackend;
         if (exposureBackend.open(m_device->videoDevPath())) {
             int mode = exposureBackend.getControl(V4L2_CID_EXPOSURE_AUTO);
@@ -1104,6 +1104,11 @@ bool CameraController::isOriginalTinyFamily() const
 {
     return m_cameraInfo.productType == ObsbotProdTiny ||
            m_cameraInfo.productType == ObsbotProdTiny4k;
+}
+
+bool CameraController::isTiny4k() const
+{
+    return m_cameraInfo.productType == ObsbotProdTiny4k;
 }
 
 void CameraController::refreshControlRanges()

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -5,6 +5,18 @@
 
 static constexpr int kDefaultWhiteBalanceKelvin = 4800;
 
+static int shutterTypeToV4l2(int shutterType)
+{
+    static constexpr double denominators[] = {
+        8000, 6400, 5000, 4000, 3200, 2500, 2000, 1600, 1250, 1000,
+        800, 640, 500, 400, 320, 240, 200, 160, 120, 100, 80, 60, 50,
+        40, 30, 25, 20, 15, 12.5, 10, 8, 6.25, 5, 4
+    };
+    int index = qBound(0, shutterType - 9, 33);
+    // V4L2_CID_EXPOSURE_ABSOLUTE is measured in 100 microsecond units.
+    return qMax(1, qRound(10000.0 / denominators[index]));
+}
+
 CameraController::CameraController(QObject *parent)
     : QObject(parent)
     , m_connected(false)
@@ -592,6 +604,22 @@ bool CameraController::setExposure(int shutterTime, bool automatic)
 {
     if (!m_connected || m_v4l2Only) return false;
     int clamped = clampToRange(shutterTime, m_exposureRange, 9, 42);
+
+    if (isOriginalTinyFamily()) {
+        V4l2Backend exposureBackend;
+        if (!exposureBackend.open(m_device->videoDevPath()))
+            return false;
+        bool success = exposureBackend.setAutoExposure(automatic);
+        if (success && !automatic)
+            success = exposureBackend.setExposureAbsolute(shutterTypeToV4l2(clamped));
+        if (success) {
+            m_currentState.exposureAuto = automatic;
+            m_currentState.exposure = clamped;
+            emit stateChanged(m_currentState);
+        }
+        return success;
+    }
+
     bool success = executeCommand(automatic ? "Enable auto exposure" : "Set exposure",
                                   [this, clamped, automatic]() {
         return m_device->cameraSetExposureAbsolute(clamped, automatic);
@@ -883,11 +911,22 @@ void CameraController::updateState()
     if (m_device->cameraGetImageSharpR(sharpness) == 0)
         m_currentState.sharpness = clampToRange(sharpness, m_sharpnessRange, 0, 100);
 
-    int32_t exposure = m_currentState.exposure;
-    bool exposureAuto = m_currentState.exposureAuto;
-    if (m_device->cameraGetExposureAbsolute(exposure, exposureAuto) == 0) {
-        m_currentState.exposure = clampToRange(exposure, m_exposureRange, 9, 42);
-        m_currentState.exposureAuto = exposureAuto;
+    if (isOriginalTinyFamily()) {
+        V4l2Backend exposureBackend;
+        if (exposureBackend.open(m_device->videoDevPath())) {
+            int mode = exposureBackend.getControl(V4L2_CID_EXPOSURE_AUTO);
+            if (mode >= 0)
+                m_currentState.exposureAuto =
+                    mode == V4L2_EXPOSURE_AUTO ||
+                    mode == V4L2_EXPOSURE_SHUTTER_PRIORITY;
+        }
+    } else {
+        int32_t exposure = m_currentState.exposure;
+        bool exposureAuto = m_currentState.exposureAuto;
+        if (m_device->cameraGetExposureAbsolute(exposure, exposureAuto) == 0) {
+            m_currentState.exposure = clampToRange(exposure, m_exposureRange, 9, 42);
+            m_currentState.exposureAuto = exposureAuto;
+        }
     }
     int32_t antiFlicker = m_currentState.antiFlicker;
     if (m_device->cameraGetAntiFlickR(antiFlicker) == 0)

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -840,6 +840,19 @@ bool CameraController::setTiny4kExposure(int value)
     return success;
 }
 
+bool CameraController::setTiny4kAutoExposure(bool automatic)
+{
+    if (!m_connected || !isTiny4k()) return false;
+    V4l2Backend backend;
+    if (!backend.open(m_device->videoDevPath())) return false;
+    bool success = backend.setAutoExposure(automatic);
+    if (success) {
+        m_currentState.exposureAuto = automatic;
+        emit stateChanged(m_currentState);
+    }
+    return success;
+}
+
 bool CameraController::setTiny4kGain(int value)
 {
     if (!m_connected || !isTiny4k()) return false;
@@ -1158,6 +1171,7 @@ void CameraController::updateState(bool includeImageControls)
     if (isTiny4k()) {
         V4l2Backend backend;
         if (backend.open(m_device->videoDevPath())) {
+            m_currentState.exposureAuto = backend.getAutoExposure();
             int value = backend.getExposureAbsolute();
             if (value >= 0) m_currentState.uvcExposure = value;
             value = backend.getGain();

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -279,6 +279,20 @@ bool CameraController::enableAutoFraming(bool enabled)
 {
     if (!m_connected || m_v4l2Only) return false;
 
+    // Tiny and Tiny 4K predate the AiWorkMode/MediaMode APIs.  The SDK sample
+    // and API documentation require target selection for these two cameras.
+    if (isOriginalTinyFamily()) {
+        bool success = executeCommand(enabled ? "Enable AI tracking" : "Disable AI tracking",
+                                      [this, enabled]() {
+            return m_device->aiSetTargetSelectR(enabled);
+        });
+        if (success) {
+            m_currentState.autoFramingEnabled = enabled;
+            emit stateChanged(m_currentState);
+        }
+        return success;
+    }
+
     if (enabled) {
         // Step 1: Set MediaMode to AutoFrame
         if (!executeCommand("Set MediaMode to AutoFrame", [this]() {
@@ -398,9 +412,19 @@ bool CameraController::setPanTilt(double pan, double tilt)
         int tiltVal = static_cast<int>(tilt * tiltRange.max);
         success = m_v4l2.setPanAbsolute(panVal) && m_v4l2.setTiltAbsolute(tiltVal);
     } else {
-        success = executeCommand("Set Pan/Tilt", [this, pan, tilt]() {
-            return m_device->cameraSetPanTiltAbsolute(pan, tilt);
-        });
+        if (isOriginalTinyFamily()) {
+            // The original Tiny SDK uses gimbal angles in degrees. The
+            // cameraSetPanTiltAbsolute API is documented for Meet cameras.
+            success = executeCommand("Set Pan/Tilt", [this, pan, tilt]() {
+                return m_device->gimbalSetSpeedPositionR(
+                    0.0f, static_cast<float>(tilt * 90.0),
+                    static_cast<float>(pan * 120.0), 0.0f, 90.0f, 90.0f);
+            });
+        } else {
+            success = executeCommand("Set Pan/Tilt", [this, pan, tilt]() {
+                return m_device->cameraSetPanTiltAbsolute(pan, tilt);
+            });
+        }
     }
 
     if (success) {
@@ -437,10 +461,16 @@ bool CameraController::setZoom(double zoom)
         int v4l2Zoom = static_cast<int>((zoom - 1.0) * zoomMax);
         success = m_v4l2.setZoomAbsolute(v4l2Zoom);
     } else {
-        uint32_t zoomRatio = static_cast<uint32_t>(zoom * 100);
-        success = executeCommand("Set Zoom", [this, zoomRatio]() {
-            return m_device->cameraSetZoomWithSpeedAbsoluteR(zoomRatio, 255);
-        });
+        if (isOriginalTinyFamily()) {
+            success = executeCommand("Set Zoom", [this, zoom]() {
+                return m_device->cameraSetZoomAbsoluteR(static_cast<float>(zoom));
+            });
+        } else {
+            uint32_t zoomRatio = static_cast<uint32_t>(zoom * 100);
+            success = executeCommand("Set Zoom", [this, zoomRatio]() {
+                return m_device->cameraSetZoomWithSpeedAbsoluteR(zoomRatio, 255);
+            });
+        }
     }
 
     if (success) {
@@ -453,6 +483,17 @@ bool CameraController::setZoom(double zoom)
 
 bool CameraController::centerView()
 {
+    if (m_connected && !m_v4l2Only && isOriginalTinyFamily()) {
+        bool success = executeCommand("Center gimbal", [this]() {
+            return m_device->gimbalRstPosR();
+        });
+        if (success) {
+            m_currentState.pan = 0.0;
+            m_currentState.tilt = 0.0;
+            emit stateChanged(m_currentState);
+        }
+        return success;
+    }
     return setPanTilt(0.0, 0.0);
 }
 
@@ -719,13 +760,14 @@ void CameraController::updateState()
 
     m_currentState.aiMode = status.tiny.ai_mode;
     m_currentState.aiSubMode = status.tiny.ai_sub_mode;
-    m_currentState.zoomRatio = status.tiny.zoom_ratio;
-    // Derive zoom float from zoom_ratio (100 = 1.0x, 200 = 2.0x)
-    if (status.tiny.zoom_ratio >= 100 && status.tiny.zoom_ratio <= 200) {
-        m_currentState.zoom = status.tiny.zoom_ratio / 100.0;
-    } else {
-        qDebug() << "CameraController: unexpected zoom_ratio" << status.tiny.zoom_ratio
-                 << "— keeping previous zoom" << m_currentState.zoom;
+    // Tiny/Tiny 4K report zoom_ratio as 0..100, not 100..200. The normalized
+    // getter is supported across the OBSBOT product families and avoids
+    // interpreting product-specific status layouts.
+    float zoom = 1.0f;
+    if (m_device->cameraGetZoomAbsoluteR(zoom) == 0 &&
+        zoom >= 1.0f && zoom <= 2.0f) {
+        m_currentState.zoom = zoom;
+        m_currentState.zoomRatio = qRound(zoom * 100.0f);
     }
     m_currentState.hdrEnabled = status.tiny.hdr;
     m_currentState.faceAEEnabled = status.tiny.face_ae;
@@ -734,7 +776,9 @@ void CameraController::updateState()
     m_currentState.manualFocusValue = status.tiny.manual_focus_value;
     m_currentState.fovMode = status.tiny.fov;
     m_currentState.devStatus = status.tiny.dev_status;
-    m_currentState.autoFramingEnabled = (m_currentState.aiMode != Device::AiWorkModeNone);
+    m_currentState.autoFramingEnabled = isOriginalTinyFamily()
+        ? status.tiny.ai_target != 0
+        : m_currentState.aiMode != Device::AiWorkModeNone;
     m_currentState.trackSpeedMode = status.tiny.ai_tracker_speed;
     m_currentState.audioAutoGainEnabled = status.tiny.audio_auto_gain;
 
@@ -924,6 +968,12 @@ bool CameraController::isTiny2Family() const
     return m_cameraInfo.productType == ObsbotProdTiny2 ||
            m_cameraInfo.productType == ObsbotProdTiny2Lite ||
            m_cameraInfo.productType == ObsbotProdTinySE;
+}
+
+bool CameraController::isOriginalTinyFamily() const
+{
+    return m_cameraInfo.productType == ObsbotProdTiny ||
+           m_cameraInfo.productType == ObsbotProdTiny4k;
 }
 
 void CameraController::refreshControlRanges()

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -610,6 +610,15 @@ bool CameraController::setFocusAbsolute(int position, bool autoFocus)
     if (!m_connected) return false;
     position = qBound(0, position, 100);
 
+    if (!autoFocus && m_currentState.faceFocusEnabled && !m_v4l2Only) {
+        if (!executeCommand("Disable Face Focus", [this]() {
+                return m_device->cameraSetFaceFocusR(false);
+            })) {
+            return false;
+        }
+        m_currentState.faceFocusEnabled = false;
+    }
+
     bool success;
     if (m_v4l2Only) {
         m_v4l2.setAutoFocus(autoFocus);
@@ -1065,7 +1074,10 @@ void CameraController::updateState()
     m_currentState.faceFocusEnabled = status.tiny.face_auto_focus;
     m_currentState.autoFocusEnabled = status.tiny.auto_focus;
     m_currentState.manualFocusValue = status.tiny.manual_focus_value;
-    m_currentState.fovMode = status.tiny.fov;
+    if (status.tiny.fov >= Device::FovType86
+            && status.tiny.fov <= Device::FovType65) {
+        m_currentState.fovMode = status.tiny.fov;
+    }
     m_currentState.devStatus = status.tiny.dev_status;
     m_currentState.autoFramingEnabled = isOriginalTinyFamily()
         ? status.tiny.ai_target != 0

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -218,20 +218,22 @@ void CameraController::refreshV4l2ControlRanges()
     m_supportedWhiteBalanceTypes.push_back(static_cast<int>(Device::DevWhiteBalanceManual));
 }
 
-void CameraController::updateV4l2State()
+void CameraController::updateV4l2State(bool includeImageControls)
 {
     if (!m_v4l2.isOpen())
         return;
 
-    m_currentState.brightness = m_v4l2.getBrightness();
-    m_currentState.contrast = m_v4l2.getContrast();
-    m_currentState.saturation = m_v4l2.getSaturation();
+    if (includeImageControls) {
+        m_currentState.brightness = m_v4l2.getBrightness();
+        m_currentState.contrast = m_v4l2.getContrast();
+        m_currentState.saturation = m_v4l2.getSaturation();
 
-    bool autoWb = m_v4l2.getWhiteBalanceAuto();
-    m_currentState.whiteBalance = autoWb
-        ? static_cast<int>(Device::DevWhiteBalanceAuto)
-        : static_cast<int>(Device::DevWhiteBalanceManual);
-    m_currentState.whiteBalanceKelvin = m_v4l2.getWhiteBalanceTemperature();
+        bool autoWb = m_v4l2.getWhiteBalanceAuto();
+        m_currentState.whiteBalance = autoWb
+            ? static_cast<int>(Device::DevWhiteBalanceAuto)
+            : static_cast<int>(Device::DevWhiteBalanceManual);
+        m_currentState.whiteBalanceKelvin = m_v4l2.getWhiteBalanceTemperature();
+    }
 
     auto zoomRange = m_v4l2.getZoomRange();
     int zoomMax = zoomRange.valid ? zoomRange.max : 100;
@@ -534,6 +536,17 @@ bool CameraController::centerView()
         return success;
     }
     return setPanTilt(0.0, 0.0);
+}
+
+CameraController::CameraState CameraController::pollCurrentState(bool includeImageControls)
+{
+    if (m_connected && !isSettling()) {
+        if (m_v4l2Only)
+            updateV4l2State(includeImageControls);
+        else
+            updateState(includeImageControls);
+    }
+    return isSettling() ? m_cachedState : m_currentState;
 }
 
 bool CameraController::setHDR(bool enabled)
@@ -1052,7 +1065,7 @@ bool CameraController::executeCommand(const QString &description, std::function<
     return true;
 }
 
-void CameraController::updateState()
+void CameraController::updateState(bool includeImageControls)
 {
     if (!m_connected) return;
 
@@ -1096,6 +1109,7 @@ void CameraController::updateState()
     m_currentState.trackSpeedMode = status.tiny.ai_tracker_speed;
     m_currentState.audioAutoGainEnabled = status.tiny.audio_auto_gain;
 
+    if (includeImageControls) {
     // Image controls - read current values from camera
     // Note: Preserve auto mode flags - camera doesn't have concept of "auto" for these
     bool preservedBrightnessAuto = m_currentState.brightnessAuto;
@@ -1160,6 +1174,7 @@ void CameraController::updateState()
         m_currentState.whiteBalance = m_fallbackWhiteBalanceMode;
     } else {
         m_lastRequestedWhiteBalance = m_currentState.whiteBalance;
+    }
     }
 
     emit stateChanged(m_currentState);

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -2,6 +2,7 @@
 #include <QThread>
 #include <QDebug>
 #include <algorithm>
+#include <cstring>
 
 static constexpr int kDefaultWhiteBalanceKelvin = 4800;
 
@@ -666,6 +667,158 @@ bool CameraController::setAntiFlicker(int frequency)
     return success;
 }
 
+bool CameraController::setGestureControl(int gesture, bool enabled)
+{
+    if (!m_connected || m_v4l2Only || !isOriginalTinyFamily()) return false;
+    return executeCommand("Set gesture control", [this, gesture, enabled]() {
+        return m_device->aiSetGestureCtrlIndividualR(gesture, enabled);
+    });
+}
+
+bool CameraController::setHardwareMirror(bool enabled)
+{
+    if (!m_connected || m_v4l2Only || !isTiny4k()) return false;
+    return executeCommand("Set hardware mirror", [this, enabled]() {
+        return m_device->cameraSetImageFlipHorizonU(enabled ? 1 : 0);
+    });
+}
+
+bool CameraController::setMicrophoneDuringSleep(bool enabled)
+{
+    if (!m_connected || m_v4l2Only || !isTiny4k()) return false;
+    return executeCommand("Set sleep microphone", [this, enabled]() {
+        return m_device->cameraSetMicrophoneDuringSleepU(enabled ? 1 : 0);
+    });
+}
+
+bool CameraController::setSleepTimeout(int seconds)
+{
+    if (!m_connected || m_v4l2Only || !isOriginalTinyFamily()) return false;
+    return executeCommand("Set sleep timeout", [this, seconds]() {
+        return m_device->cameraSetSuspendTimeU(seconds);
+    });
+}
+
+bool CameraController::setDeviceAwake(bool awake)
+{
+    if (!m_connected || m_v4l2Only) return false;
+    return executeCommand(awake ? "Wake camera" : "Sleep camera", [this, awake]() {
+        return m_device->cameraSetDevRunStatusR(
+            awake ? Device::DevStatusRun : Device::DevStatusSleep);
+    });
+}
+
+bool CameraController::setAiEnabled(bool enabled)
+{
+    if (!m_connected || m_v4l2Only || !isOriginalTinyFamily()) return false;
+    return executeCommand("Set AI enabled", [this, enabled]() {
+        return m_device->aiSetEnabledR(enabled);
+    });
+}
+
+bool CameraController::setVerticalMode(bool enabled)
+{
+    if (!m_connected || m_v4l2Only || !isTiny4k()) return false;
+    return executeCommand("Set vertical mode", [this, enabled]() {
+        return m_device->cameraSetVerticalModeU(enabled ? 1 : 0);
+    });
+}
+
+bool CameraController::restoreFactorySettings()
+{
+    if (!m_connected || m_v4l2Only) return false;
+    return executeCommand("Restore factory settings", [this]() {
+        return m_device->cameraSetRestoreFactorySettingsR();
+    });
+}
+
+bool CameraController::setCurrentViewAsBootPosition()
+{
+    if (!m_connected || m_v4l2Only || !isOriginalTinyFamily()) return false;
+    float attitude[3] = {};
+    if (m_device->gimbalGetAttitudeInfoR(attitude) != 0) return false;
+    float zoom = 1.0f;
+    if (m_device->cameraGetZoomAbsoluteR(zoom) != 0) return false;
+    Device::PresetPosInfo preset{};
+    preset.roll = attitude[0];
+    preset.pitch = attitude[1];
+    preset.yaw = attitude[2];
+    preset.zoom = zoom;
+    return executeCommand("Set boot position", [this, preset]() {
+        return m_device->aiSetGimbalBootPosR(preset);
+    });
+}
+
+bool CameraController::saveHardwarePreset(int id)
+{
+    if (!m_connected || m_v4l2Only || !isOriginalTinyFamily()) return false;
+    float attitude[3] = {};
+    if (m_device->gimbalGetAttitudeInfoR(attitude) != 0) return false;
+    float zoom = 1.0f;
+    if (m_device->cameraGetZoomAbsoluteR(zoom) != 0) return false;
+    Device::PresetPosInfo preset{};
+    preset.id = id;
+    preset.roll = attitude[0];
+    preset.pitch = attitude[1];
+    preset.yaw = attitude[2];
+    preset.zoom = zoom;
+    QByteArray name = QString("Preset %1").arg(id + 1).toUtf8();
+    preset.name_len = qMin(name.size(), 63);
+    std::memcpy(preset.name, name.constData(), preset.name_len);
+    return executeCommand("Save hardware preset", [this, preset]() mutable {
+        return m_device->aiAddGimbalPresetR(&preset);
+    });
+}
+
+bool CameraController::recallHardwarePreset(int id)
+{
+    if (!m_connected || m_v4l2Only || !isOriginalTinyFamily()) return false;
+    return executeCommand("Recall hardware preset", [this, id]() {
+        return m_device->aiTrgGimbalPresetR(id);
+    });
+}
+
+bool CameraController::setGimbalSpeed(double pitch, double pan)
+{
+    if (!m_connected || m_v4l2Only || !isOriginalTinyFamily()) return false;
+    return executeCommand("Set gimbal speed", [this, pitch, pan]() {
+        return m_device->aiSetGimbalSpeedCtrlR(pitch, pan, 0.0);
+    });
+}
+
+bool CameraController::setTiny4kExposure(int value)
+{
+    if (!m_connected || !isTiny4k()) return false;
+    V4l2Backend backend;
+    if (!backend.open(m_device->videoDevPath())) return false;
+    int clamped = clampToRange(value, m_uvcExposureRange, 1, 2500);
+    bool success = backend.setAutoExposure(false) && backend.setExposureAbsolute(clamped);
+    if (success) m_currentState.uvcExposure = clamped;
+    return success;
+}
+
+bool CameraController::setTiny4kGain(int value)
+{
+    if (!m_connected || !isTiny4k()) return false;
+    V4l2Backend backend;
+    if (!backend.open(m_device->videoDevPath())) return false;
+    int clamped = clampToRange(value, m_gainRange, 1, 48);
+    bool success = backend.setGain(clamped);
+    if (success) m_currentState.gain = clamped;
+    return success;
+}
+
+bool CameraController::setTiny4kBacklightCompensation(int value)
+{
+    if (!m_connected || !isTiny4k()) return false;
+    V4l2Backend backend;
+    if (!backend.open(m_device->videoDevPath())) return false;
+    int clamped = clampToRange(value, m_backlightRange, 0, 18);
+    bool success = backend.setBacklightCompensation(clamped);
+    if (success) m_currentState.backlightCompensation = clamped;
+    return success;
+}
+
 bool CameraController::setBrightness(int value)
 {
     if (!m_connected) return false;
@@ -945,6 +1098,17 @@ void CameraController::updateState()
             m_currentState.exposureAuto = exposureAuto;
         }
     }
+    if (isTiny4k()) {
+        V4l2Backend backend;
+        if (backend.open(m_device->videoDevPath())) {
+            int value = backend.getExposureAbsolute();
+            if (value >= 0) m_currentState.uvcExposure = value;
+            value = backend.getGain();
+            if (value >= 0) m_currentState.gain = value;
+            value = backend.getBacklightCompensation();
+            if (value >= 0) m_currentState.backlightCompensation = value;
+        }
+    }
     int32_t antiFlicker = m_currentState.antiFlicker;
     if (m_device->cameraGetAntiFlickR(antiFlicker) == 0)
         m_currentState.antiFlicker = antiFlicker;
@@ -1171,6 +1335,19 @@ void CameraController::refreshControlRanges()
     fetchRange(&Device::cameraGetRangeAntiFlickR, m_antiFlickerRange);
     fetchRange(&Device::cameraGetRangeWhiteBalanceR, m_whiteBalanceKelvinRange);
 
+    if (isTiny4k()) {
+        V4l2Backend backend;
+        if (backend.open(m_device->videoDevPath())) {
+            auto convert = [](V4l2Backend::ControlRange range) {
+                return ParamRange{range.min, range.max, range.step,
+                                  range.defaultValue, range.valid};
+            };
+            m_uvcExposureRange = convert(backend.getExposureRange());
+            m_gainRange = convert(backend.getGainRange());
+            m_backlightRange = convert(backend.getBacklightCompensationRange());
+        }
+    }
+
     m_supportedWhiteBalanceTypes.clear();
     std::vector<int32_t> wbList;
     int32_t wbMin = 0;
@@ -1199,6 +1376,9 @@ void CameraController::resetControlRanges()
     m_sharpnessRange = {};
     m_exposureRange = {};
     m_antiFlickerRange = {};
+    m_uvcExposureRange = {};
+    m_gainRange = {};
+    m_backlightRange = {};
     m_whiteBalanceKelvinRange = {};
     m_supportedWhiteBalanceTypes.clear();
     m_whiteBalanceFallbackActive = false;

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -14,6 +14,11 @@ CameraController::CameraController(QObject *parent)
     m_cachedState = {};
     m_currentState.whiteBalanceKelvin = 5000;
     m_cachedState.whiteBalanceKelvin = 5000;
+    m_currentState.exposureAuto = m_cachedState.exposureAuto = true;
+    m_currentState.exposure = m_cachedState.exposure = 33;
+    m_currentState.antiFlicker = m_cachedState.antiFlicker = Device::PowerLineFreq50;
+    m_currentState.hue = m_cachedState.hue = 50;
+    m_currentState.sharpness = m_cachedState.sharpness = 50;
     m_lastRequestedWhiteBalance = static_cast<int>(Device::DevWhiteBalanceAuto);
     m_whiteBalanceFallbackActive = false;
     m_fallbackWhiteBalanceMode = static_cast<int>(Device::DevWhiteBalanceAuto);
@@ -570,6 +575,47 @@ bool CameraController::setFocusAbsolute(int position, bool autoFocus)
     return success;
 }
 
+bool CameraController::setTrackingStyle(int style)
+{
+    if (!m_connected || m_v4l2Only || !isOriginalTinyFamily()) return false;
+    style = qBound(static_cast<int>(Device::AiVTrackStandard), style,
+                   static_cast<int>(Device::AiVTrackMotion));
+    bool success = executeCommand("Set tracking style", [this, style]() {
+        return m_device->aiSetTrackingModeR(static_cast<Device::AiVerticalTrackType>(style));
+    });
+    if (success)
+        m_currentState.trackingStyle = style;
+    return success;
+}
+
+bool CameraController::setExposure(int shutterTime, bool automatic)
+{
+    if (!m_connected || m_v4l2Only) return false;
+    int clamped = clampToRange(shutterTime, m_exposureRange, 9, 42);
+    bool success = executeCommand(automatic ? "Enable auto exposure" : "Set exposure",
+                                  [this, clamped, automatic]() {
+        return m_device->cameraSetExposureAbsolute(clamped, automatic);
+    });
+    if (success) {
+        m_currentState.exposureAuto = automatic;
+        m_currentState.exposure = clamped;
+        emit stateChanged(m_currentState);
+    }
+    return success;
+}
+
+bool CameraController::setAntiFlicker(int frequency)
+{
+    if (!m_connected || m_v4l2Only) return false;
+    int clamped = clampToRange(frequency, m_antiFlickerRange, 0, 3);
+    bool success = executeCommand("Set anti-flicker", [this, clamped]() {
+        return m_device->cameraSetAntiFlickR(clamped);
+    });
+    if (success)
+        m_currentState.antiFlicker = clamped;
+    return success;
+}
+
 bool CameraController::setBrightness(int value)
 {
     if (!m_connected) return false;
@@ -630,6 +676,30 @@ bool CameraController::setSaturation(int value)
         m_currentState.saturation = clamped;
         emit stateChanged(m_currentState);
     }
+    return success;
+}
+
+bool CameraController::setHue(int value)
+{
+    if (!m_connected || m_v4l2Only) return false;
+    int clamped = clampToRange(value, m_hueRange, 0, 100);
+    bool success = executeCommand("Set Hue", [this, clamped]() {
+        return m_device->cameraSetImageHueR(clamped);
+    });
+    if (success)
+        m_currentState.hue = clamped;
+    return success;
+}
+
+bool CameraController::setSharpness(int value)
+{
+    if (!m_connected || m_v4l2Only) return false;
+    int clamped = clampToRange(value, m_sharpnessRange, 0, 100);
+    bool success = executeCommand("Set Sharpness", [this, clamped]() {
+        return m_device->cameraSetImageSharpR(clamped);
+    });
+    if (success)
+        m_currentState.sharpness = clamped;
     return success;
 }
 
@@ -795,7 +865,7 @@ void CameraController::updateState()
     bool preservedContrastAuto = m_currentState.contrastAuto;
     bool preservedSaturationAuto = m_currentState.saturationAuto;
 
-    int32_t brightness, contrast, saturation;
+    int32_t brightness, contrast, saturation, hue, sharpness;
     Device::DevWhiteBalanceType wbType;
     int32_t wbParam;
 
@@ -808,6 +878,20 @@ void CameraController::updateState()
     if (m_device->cameraGetImageSaturationR(saturation) == 0) {
         m_currentState.saturation = clampToRange(saturation, m_saturationRange, 0, 255);
     }
+    if (m_device->cameraGetImageHueR(hue) == 0)
+        m_currentState.hue = clampToRange(hue, m_hueRange, 0, 100);
+    if (m_device->cameraGetImageSharpR(sharpness) == 0)
+        m_currentState.sharpness = clampToRange(sharpness, m_sharpnessRange, 0, 100);
+
+    int32_t exposure = m_currentState.exposure;
+    bool exposureAuto = m_currentState.exposureAuto;
+    if (m_device->cameraGetExposureAbsolute(exposure, exposureAuto) == 0) {
+        m_currentState.exposure = clampToRange(exposure, m_exposureRange, 9, 42);
+        m_currentState.exposureAuto = exposureAuto;
+    }
+    int32_t antiFlicker = m_currentState.antiFlicker;
+    if (m_device->cameraGetAntiFlickR(antiFlicker) == 0)
+        m_currentState.antiFlicker = antiFlicker;
     if (m_device->cameraGetWhiteBalanceR(wbType, wbParam) == 0) {
         m_currentState.whiteBalance = static_cast<int>(wbType);
         if (wbType == Device::DevWhiteBalanceManual) {
@@ -1006,6 +1090,10 @@ void CameraController::refreshControlRanges()
     fetchRange(&Device::cameraGetRangeImageBrightnessR, m_brightnessRange);
     fetchRange(&Device::cameraGetRangeImageContrastR, m_contrastRange);
     fetchRange(&Device::cameraGetRangeImageSaturationR, m_saturationRange);
+    fetchRange(&Device::cameraGetRangeImageHueR, m_hueRange);
+    fetchRange(&Device::cameraGetRangeImageSharpR, m_sharpnessRange);
+    fetchRange(&Device::cameraGetRangeExposureAbsolute, m_exposureRange);
+    fetchRange(&Device::cameraGetRangeAntiFlickR, m_antiFlickerRange);
     fetchRange(&Device::cameraGetRangeWhiteBalanceR, m_whiteBalanceKelvinRange);
 
     m_supportedWhiteBalanceTypes.clear();
@@ -1032,6 +1120,10 @@ void CameraController::resetControlRanges()
     m_brightnessRange = {};
     m_contrastRange = {};
     m_saturationRange = {};
+    m_hueRange = {};
+    m_sharpnessRange = {};
+    m_exposureRange = {};
+    m_antiFlickerRange = {};
     m_whiteBalanceKelvinRange = {};
     m_supportedWhiteBalanceTypes.clear();
     m_whiteBalanceFallbackActive = false;

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -58,6 +58,13 @@ void CameraController::connectToCamera(const QString &devicePath)
             auto dev_list = Devices::get().getDevList();
             auto dev = pickDevice(dev_list);
             if (dev) {
+                // SDK enumeration may finish after the V4L2 fallback has
+                // already connected; drop the fallback so SDK-only controls
+                // (tracking, HDR) aren't left hidden by a stale flag.
+                if (m_v4l2Only) {
+                    m_v4l2.close();
+                    m_v4l2Only = false;
+                }
                 m_device = dev;
                 m_connected = true;
                 m_cameraInfo.name = QString::fromStdString(m_device->devName());
@@ -96,7 +103,15 @@ void CameraController::connectToCamera(const QString &devicePath)
             updateState();
         }
     } else {
-        tryV4l2Fallback();
+        // The SDK enumerates devices on a background thread and its connect
+        // handshake takes several seconds, so the list is almost always
+        // still empty here. An immediate fallback would win that race every
+        // launch and lock the UI into V4L2-only mode; give the SDK a grace
+        // period before settling for plain V4L2.
+        QTimer::singleShot(8000, this, [this]() {
+            if (!m_connected)
+                tryV4l2Fallback();
+        });
     }
 }
 

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -318,6 +318,13 @@ bool CameraController::enableAutoFraming(bool enabled)
 {
     if (!m_connected || m_v4l2Only) return false;
 
+    const bool preservedFaceAE = m_currentState.faceAEEnabled;
+    const bool preservedFaceFocus = m_currentState.faceFocusEnabled;
+    auto restoreFaceControls = [this, preservedFaceAE, preservedFaceFocus]() {
+        setFaceAE(preservedFaceAE);
+        setFaceFocus(preservedFaceFocus);
+    };
+
     // Tiny and Tiny 4K predate the AiWorkMode/MediaMode APIs.  The SDK sample
     // and API documentation require target selection for these two cameras.
     if (isOriginalTinyFamily()) {
@@ -326,6 +333,7 @@ bool CameraController::enableAutoFraming(bool enabled)
             return m_device->aiSetTargetSelectR(enabled);
         });
         if (success) {
+            restoreFaceControls();
             m_currentState.autoFramingEnabled = enabled;
             emit stateChanged(m_currentState);
         }
@@ -341,14 +349,14 @@ bool CameraController::enableAutoFraming(bool enabled)
         }
 
         // Step 2: Set auto-framing mode after a brief delay (non-blocking)
-        QTimer::singleShot(500, [this]() {
+        QTimer::singleShot(500, this,
+                [this, preservedFaceAE, preservedFaceFocus]() {
             executeCommand("Set AutoFraming mode", [this]() {
                 return m_device->cameraSetAutoFramingModeU(Device::AutoFrmSingle, Device::AutoFrmUpperBody);
             });
+            setFaceAE(preservedFaceAE);
+            setFaceFocus(preservedFaceFocus);
         });
-
-        // Restore auto focus when auto-framing is enabled
-        setFocusAbsolute(0, true);
 
         m_currentState.autoFramingEnabled = true;
         emit stateChanged(m_currentState);
@@ -358,9 +366,7 @@ bool CameraController::enableAutoFraming(bool enabled)
             return m_device->cameraSetMediaModeU(Device::MediaModeNormal);
         });
         if (success) {
-            // Switch to manual focus when auto-framing is disabled
-            setFocusAbsolute(m_currentState.manualFocusValue, false);
-
+            restoreFaceControls();
             m_currentState.autoFramingEnabled = false;
             emit stateChanged(m_currentState);
         }

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -574,6 +574,21 @@ bool CameraController::setFOV(int fovMode)
             m_currentState.zoomRatio = qRound(zoom * 100.0f);
         }
         emit stateChanged(m_currentState);
+
+        // Tiny/Tiny 4K apply named FOV presets asynchronously. The immediate
+        // getter above can still return the previous zoom, so read it again
+        // after both the camera movement and UI command debounce have settled.
+        QTimer::singleShot(1100, this, [this, fovMode]() {
+            if (!m_connected || m_v4l2Only || m_currentState.fovMode != fovMode)
+                return;
+            float settledZoom = m_currentState.zoom;
+            if (m_device->cameraGetZoomAbsoluteR(settledZoom) == 0
+                    && settledZoom >= 1.0f && settledZoom <= 2.0f) {
+                m_currentState.zoom = settledZoom;
+                m_currentState.zoomRatio = qRound(settledZoom * 100.0f);
+                emit stateChanged(m_currentState);
+            }
+        });
     }
     return success;
 }

--- a/src/gui/CameraController.h
+++ b/src/gui/CameraController.h
@@ -2,6 +2,7 @@
 #define CAMERACONTROLLER_H
 
 #include <QObject>
+#include <QElapsedTimer>
 #include <QTimer>
 #include <QMap>
 #include <memory>
@@ -201,6 +202,7 @@ private:
     CameraState m_cachedState;  // Cache intended state during settling
     Config m_config;
     QTimer *m_settlingTimer;  // Timer for settling period after config apply
+    QElapsedTimer m_zoomPollingPause;
     ParamRange m_brightnessRange;
     ParamRange m_contrastRange;
     ParamRange m_saturationRange;

--- a/src/gui/CameraController.h
+++ b/src/gui/CameraController.h
@@ -141,6 +141,7 @@ public:
     bool recallHardwarePreset(int id);
     bool setGimbalSpeed(double pitch, double pan);
     bool setTiny4kExposure(int value);
+    bool setTiny4kAutoExposure(bool automatic);
     bool setTiny4kGain(int value);
     bool setTiny4kBacklightCompensation(int value);
 

--- a/src/gui/CameraController.h
+++ b/src/gui/CameraController.h
@@ -51,6 +51,10 @@ public:
         bool faceFocusEnabled;
         bool autoFocusEnabled;
         int manualFocusValue;  // 0-100, motor position when in manual focus
+        int trackingStyle;
+        bool exposureAuto;
+        int exposure;
+        int antiFlicker;
 
         // Image controls
         bool brightnessAuto; // Auto mode for brightness
@@ -59,6 +63,8 @@ public:
         int contrast;        // 0-255
         bool saturationAuto; // Auto mode for saturation
         int saturation;      // 0-255
+        int hue;
+        int sharpness;
         int whiteBalance;    // 0=Auto, 1=Daylight, etc.
         int whiteBalanceKelvin; // Manual Kelvin value when white balance is manual
 
@@ -91,6 +97,7 @@ public:
     // State
     CameraState getCurrentState();
     bool hasTiny2Capabilities() const;
+    bool hasOriginalTinyCapabilities() const { return isOriginalTinyFamily(); }
 
     // Tracking controls
     bool enableAutoFraming(bool enabled);
@@ -112,6 +119,9 @@ public:
     bool setFaceAE(bool enabled);
     bool setFaceFocus(bool enabled);
     bool setFocusAbsolute(int position, bool autoFocus);
+    bool setTrackingStyle(int style);
+    bool setExposure(int shutterTime, bool automatic);
+    bool setAntiFlicker(int frequency);
 
     // Image controls
     void setBrightnessAuto(bool enabled) { m_currentState.brightnessAuto = enabled; }
@@ -120,6 +130,8 @@ public:
     bool setContrast(int value);    // 0-255
     void setSaturationAuto(bool enabled) { m_currentState.saturationAuto = enabled; }
     bool setSaturation(int value);  // 0-255
+    bool setHue(int value);
+    bool setSharpness(int value);
     bool setWhiteBalance(int mode); // 0=Auto, 1=Daylight, etc.
     bool setWhiteBalanceManual(int kelvin);
 
@@ -138,6 +150,10 @@ public:
     ParamRange getBrightnessRange() const { return m_brightnessRange; }
     ParamRange getContrastRange() const { return m_contrastRange; }
     ParamRange getSaturationRange() const { return m_saturationRange; }
+    ParamRange getHueRange() const { return m_hueRange; }
+    ParamRange getSharpnessRange() const { return m_sharpnessRange; }
+    ParamRange getExposureRange() const { return m_exposureRange; }
+    ParamRange getAntiFlickerRange() const { return m_antiFlickerRange; }
     ParamRange getWhiteBalanceKelvinRange() const { return m_whiteBalanceKelvinRange; }
     const std::vector<int>& getSupportedWhiteBalanceTypes() const { return m_supportedWhiteBalanceTypes; }
 
@@ -165,6 +181,10 @@ private:
     ParamRange m_brightnessRange;
     ParamRange m_contrastRange;
     ParamRange m_saturationRange;
+    ParamRange m_hueRange;
+    ParamRange m_sharpnessRange;
+    ParamRange m_exposureRange;
+    ParamRange m_antiFlickerRange;
     ParamRange m_whiteBalanceKelvinRange;
     std::vector<int> m_supportedWhiteBalanceTypes;
     int m_lastRequestedWhiteBalance;

--- a/src/gui/CameraController.h
+++ b/src/gui/CameraController.h
@@ -98,6 +98,7 @@ public:
     CameraState getCurrentState();
     bool hasTiny2Capabilities() const;
     bool hasOriginalTinyCapabilities() const { return isOriginalTinyFamily(); }
+    bool hasTiny4kCapabilities() const { return isTiny4k(); }
 
     // Tracking controls
     bool enableAutoFraming(bool enabled);
@@ -192,6 +193,7 @@ private:
     int m_fallbackWhiteBalanceMode;
     bool isTiny2Family() const;
     bool isOriginalTinyFamily() const;
+    bool isTiny4k() const;
     void tryV4l2Fallback();
     void connectV4l2(const std::string &devicePath);
     void refreshV4l2ControlRanges();

--- a/src/gui/CameraController.h
+++ b/src/gui/CameraController.h
@@ -55,6 +55,9 @@ public:
         bool exposureAuto;
         int exposure;
         int antiFlicker;
+        int uvcExposure;
+        int gain;
+        int backlightCompensation;
 
         // Image controls
         bool brightnessAuto; // Auto mode for brightness
@@ -123,6 +126,21 @@ public:
     bool setTrackingStyle(int style);
     bool setExposure(int shutterTime, bool automatic);
     bool setAntiFlicker(int frequency);
+    bool setGestureControl(int gesture, bool enabled);
+    bool setHardwareMirror(bool enabled);
+    bool setMicrophoneDuringSleep(bool enabled);
+    bool setSleepTimeout(int seconds);
+    bool setDeviceAwake(bool awake);
+    bool setAiEnabled(bool enabled);
+    bool setVerticalMode(bool enabled);
+    bool restoreFactorySettings();
+    bool setCurrentViewAsBootPosition();
+    bool saveHardwarePreset(int id);
+    bool recallHardwarePreset(int id);
+    bool setGimbalSpeed(double pitch, double pan);
+    bool setTiny4kExposure(int value);
+    bool setTiny4kGain(int value);
+    bool setTiny4kBacklightCompensation(int value);
 
     // Image controls
     void setBrightnessAuto(bool enabled) { m_currentState.brightnessAuto = enabled; }
@@ -155,6 +173,9 @@ public:
     ParamRange getSharpnessRange() const { return m_sharpnessRange; }
     ParamRange getExposureRange() const { return m_exposureRange; }
     ParamRange getAntiFlickerRange() const { return m_antiFlickerRange; }
+    ParamRange getTiny4kExposureRange() const { return m_uvcExposureRange; }
+    ParamRange getGainRange() const { return m_gainRange; }
+    ParamRange getBacklightCompensationRange() const { return m_backlightRange; }
     ParamRange getWhiteBalanceKelvinRange() const { return m_whiteBalanceKelvinRange; }
     const std::vector<int>& getSupportedWhiteBalanceTypes() const { return m_supportedWhiteBalanceTypes; }
 
@@ -186,6 +207,9 @@ private:
     ParamRange m_sharpnessRange;
     ParamRange m_exposureRange;
     ParamRange m_antiFlickerRange;
+    ParamRange m_uvcExposureRange;
+    ParamRange m_gainRange;
+    ParamRange m_backlightRange;
     ParamRange m_whiteBalanceKelvinRange;
     std::vector<int> m_supportedWhiteBalanceTypes;
     int m_lastRequestedWhiteBalance;

--- a/src/gui/CameraController.h
+++ b/src/gui/CameraController.h
@@ -99,6 +99,7 @@ public:
 
     // State
     CameraState getCurrentState();
+    CameraState pollCurrentState(bool includeImageControls);
     bool hasTiny2Capabilities() const;
     bool hasOriginalTinyCapabilities() const { return isOriginalTinyFamily(); }
     bool hasTiny4kCapabilities() const { return isTiny4k(); }
@@ -221,11 +222,11 @@ private:
     void tryV4l2Fallback();
     void connectV4l2(const std::string &devicePath);
     void refreshV4l2ControlRanges();
-    void updateV4l2State();
+    void updateV4l2State(bool includeImageControls = true);
 
     // Helper
     bool executeCommand(const QString &description, std::function<int32_t()> command);
-    void updateState();
+    void updateState(bool includeImageControls = true);
     void saveCurrentStateToConfig();  // Update config with current camera state
     void refreshControlRanges();
     void resetControlRanges();

--- a/src/gui/CameraController.h
+++ b/src/gui/CameraController.h
@@ -152,6 +152,7 @@ private:
     std::shared_ptr<Device> m_device;
     bool m_connected;
     QString m_selectedDevicePath;
+    quint64 m_connectionAttempt = 0;
     bool m_v4l2Only = false;
     V4l2Backend m_v4l2;
     QTimer *m_v4l2ScanTimer = nullptr;

--- a/src/gui/CameraController.h
+++ b/src/gui/CameraController.h
@@ -170,6 +170,7 @@ private:
     bool m_whiteBalanceFallbackActive;
     int m_fallbackWhiteBalanceMode;
     bool isTiny2Family() const;
+    bool isOriginalTinyFamily() const;
     void tryV4l2Fallback();
     void connectV4l2(const std::string &devicePath);
     void refreshV4l2ControlRanges();

--- a/src/gui/CameraSettingsWidget.cpp
+++ b/src/gui/CameraSettingsWidget.cpp
@@ -13,6 +13,10 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     // Create debounce timer for command completion
     m_commandTimer = new QTimer(this);
     m_commandTimer->setSingleShot(true);
+    connect(m_commandTimer, &QTimer::timeout, this, [this]() {
+        if (m_controller->isConnected())
+            m_controller->saveConfig();
+    });
     QVBoxLayout *layout = new QVBoxLayout(this);
     layout->setContentsMargins(8, 14, 8, 14);
     layout->setSpacing(14);

--- a/src/gui/CameraSettingsWidget.cpp
+++ b/src/gui/CameraSettingsWidget.cpp
@@ -97,8 +97,10 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     antiFlickerLayout->addStretch();
     layout->addWidget(m_exposureGroupBox);
 
-    m_tiny4kDeviceGroup = new QGroupBox("Tiny 4K Device Controls", this);
+    m_tiny4kDeviceGroup = new QWidget(this);
     QVBoxLayout *deviceLayout = new QVBoxLayout(m_tiny4kDeviceGroup);
+    deviceLayout->setContentsMargins(0, 0, 0, 0);
+    deviceLayout->setSpacing(14);
 
     auto addUvcSlider = [this, groupLayout](const QString &label,
                                              QWidget *&rowWidget,
@@ -141,103 +143,84 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     });
     groupLayout->addLayout(antiFlickerLayout);
 
-    QCheckBox *gestureTracking = new QCheckBox("Tracking Gesture", this);
+    QGroupBox *sleepGroup = new QGroupBox("Sleep", m_tiny4kDeviceGroup);
+    QVBoxLayout *sleepLayout = new QVBoxLayout(sleepGroup);
+    sleepLayout->setContentsMargins(16, 16, 16, 16);
+    sleepLayout->setSpacing(10);
+    QHBoxLayout *sleepTimeLayout = new QHBoxLayout();
+    sleepTimeLayout->addWidget(new QLabel("Sleep time:", sleepGroup));
+    QSpinBox *sleepTimeout = new QSpinBox(sleepGroup);
+    sleepTimeout->setRange(0, 65535);
+    sleepTimeout->setSuffix(" s");
+    sleepTimeout->setSpecialValueText("Disabled");
+    sleepTimeLayout->addWidget(sleepTimeout, 1);
+    sleepLayout->addLayout(sleepTimeLayout);
+
+    QTimer *sleepApplyTimer = new QTimer(this);
+    sleepApplyTimer->setSingleShot(true);
+    sleepApplyTimer->setInterval(400);
+    connect(sleepTimeout, QOverload<int>::of(&QSpinBox::valueChanged),
+            sleepApplyTimer, QOverload<>::of(&QTimer::start));
+    connect(sleepApplyTimer, &QTimer::timeout, this, [this, sleepTimeout]() {
+        m_controller->setSleepTimeout(sleepTimeout->value());
+    });
+
+    QHBoxLayout *powerLayout = new QHBoxLayout();
+    QPushButton *wakeButton = new QPushButton("Wake", sleepGroup);
+    connect(wakeButton, &QPushButton::clicked, this, [this]() {
+        m_controller->setDeviceAwake(true);
+    });
+    powerLayout->addWidget(wakeButton);
+    QPushButton *sleepButton = new QPushButton("Sleep", sleepGroup);
+    connect(sleepButton, &QPushButton::clicked, this, [this]() {
+        m_controller->setDeviceAwake(false);
+    });
+    powerLayout->addWidget(sleepButton);
+    sleepLayout->addLayout(powerLayout);
+    deviceLayout->addWidget(sleepGroup);
+
+    QGroupBox *gesturesGroup =
+        new QGroupBox("Gestures", m_tiny4kDeviceGroup);
+    QVBoxLayout *gesturesLayout = new QVBoxLayout(gesturesGroup);
+    gesturesLayout->setContentsMargins(16, 16, 16, 16);
+    QCheckBox *gestureTracking = new QCheckBox("Tracking", gesturesGroup);
     connect(gestureTracking, &QCheckBox::toggled, this, [this](bool enabled) {
         m_controller->setGestureControl(0, enabled);
     });
-    deviceLayout->addWidget(gestureTracking);
-    QCheckBox *gestureZoom = new QCheckBox("Zoom Gesture", this);
+    gesturesLayout->addWidget(gestureTracking);
+    QCheckBox *gestureZoom = new QCheckBox("Zoom", gesturesGroup);
     connect(gestureZoom, &QCheckBox::toggled, this, [this](bool enabled) {
         m_controller->setGestureControl(1, enabled);
     });
-    deviceLayout->addWidget(gestureZoom);
-    QCheckBox *hardwareMirror = new QCheckBox("Flip camera output (hardware)", this);
-    connect(hardwareMirror, &QCheckBox::toggled, this, [this](bool enabled) {
-        m_controller->setHardwareMirror(enabled);
+    gesturesLayout->addWidget(gestureZoom);
+    deviceLayout->addWidget(gesturesGroup);
+
+    QHBoxLayout *screenModeLayout = new QHBoxLayout();
+    screenModeLayout->addWidget(new QLabel("Screen mode:", m_tiny4kDeviceGroup));
+    QComboBox *screenMode = new QComboBox(m_tiny4kDeviceGroup);
+    screenMode->addItem("Landscape", false);
+    screenMode->addItem("Portrait", true);
+    connect(screenMode, QOverload<int>::of(&QComboBox::activated),
+            this, [this, screenMode](int index) {
+        const bool portrait = screenMode->itemData(index).toBool();
+        if (QMessageBox::warning(this, "Restart Camera",
+                "Changing screen mode restarts the camera. Continue?",
+                QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes) {
+            m_controller->setVerticalMode(portrait);
+        }
     });
-    deviceLayout->addWidget(hardwareMirror);
-    QCheckBox *aiEnabled = new QCheckBox("Global AI Enabled", this);
-    aiEnabled->setChecked(true);
-    connect(aiEnabled, &QCheckBox::toggled, this, [this](bool enabled) {
-        m_controller->setAiEnabled(enabled);
-    });
-    deviceLayout->addWidget(aiEnabled);
-    QCheckBox *sleepMicrophone = new QCheckBox("Microphone Available During Sleep", this);
+    screenModeLayout->addWidget(screenMode, 1);
+    deviceLayout->addLayout(screenModeLayout);
+
+    QCheckBox *sleepMicrophone =
+        new QCheckBox("Microphone available during sleep", m_tiny4kDeviceGroup);
     connect(sleepMicrophone, &QCheckBox::toggled, this, [this](bool enabled) {
         m_controller->setMicrophoneDuringSleep(enabled);
     });
     deviceLayout->addWidget(sleepMicrophone);
 
-    QHBoxLayout *sleepTimeoutLayout = new QHBoxLayout();
-    sleepTimeoutLayout->addWidget(new QLabel("Automatic sleep:", this));
-    QSpinBox *sleepTimeout = new QSpinBox(this);
-    sleepTimeout->setRange(0, 65535);
-    sleepTimeout->setSuffix(" s");
-    sleepTimeout->setSpecialValueText("Disabled");
-    sleepTimeoutLayout->addWidget(sleepTimeout);
-    QPushButton *applySleepTimeout = new QPushButton("Apply", this);
-    connect(applySleepTimeout, &QPushButton::clicked, this, [this, sleepTimeout]() {
-        m_controller->setSleepTimeout(sleepTimeout->value());
-    });
-    sleepTimeoutLayout->addWidget(applySleepTimeout);
-    deviceLayout->addLayout(sleepTimeoutLayout);
-
-    QHBoxLayout *powerLayout = new QHBoxLayout();
-    QPushButton *wakeButton = new QPushButton("Wake", this);
-    connect(wakeButton, &QPushButton::clicked, this, [this]() {
-        m_controller->setDeviceAwake(true);
-    });
-    powerLayout->addWidget(wakeButton);
-    QPushButton *sleepButton = new QPushButton("Sleep", this);
-    connect(sleepButton, &QPushButton::clicked, this, [this]() {
-        m_controller->setDeviceAwake(false);
-    });
-    powerLayout->addWidget(sleepButton);
-    QPushButton *bootPositionButton = new QPushButton("Use Current View at Boot", this);
-    connect(bootPositionButton, &QPushButton::clicked, this, [this]() {
-        m_controller->setCurrentViewAsBootPosition();
-    });
-    powerLayout->addWidget(bootPositionButton);
-    deviceLayout->addLayout(powerLayout);
-
-    QLabel *speedLabel = new QLabel("Continuous Gimbal Movement", this);
-    deviceLayout->addWidget(speedLabel);
-    QGridLayout *speedLayout = new QGridLayout();
-    auto addSpeedButton = [this, speedLayout](const QString &text, int row, int column,
-                                              double pitch, double pan) {
-        QPushButton *button = new QPushButton(text, this);
-        connect(button, &QPushButton::pressed, this, [this, pitch, pan]() {
-            m_controller->setGimbalSpeed(pitch, pan);
-        });
-        connect(button, &QPushButton::released, this, [this]() {
-            m_controller->setGimbalSpeed(0.0, 0.0);
-        });
-        speedLayout->addWidget(button, row, column);
-    };
-    addSpeedButton("↑", 0, 1, -30.0, 0.0);
-    addSpeedButton("←", 1, 0, 0.0, -45.0);
-    addSpeedButton("↓", 1, 1, 30.0, 0.0);
-    addSpeedButton("→", 1, 2, 0.0, 45.0);
-    deviceLayout->addLayout(speedLayout);
-
-    QHBoxLayout *dangerLayout = new QHBoxLayout();
-    QPushButton *verticalMode = new QPushButton("Enable Portrait Mode…", this);
-    connect(verticalMode, &QPushButton::clicked, this, [this]() {
-        if (QMessageBox::warning(this, "Restart Camera",
-                "Changing portrait mode restarts the camera. Enable portrait mode?",
-                QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes)
-            m_controller->setVerticalMode(true);
-    });
-    dangerLayout->addWidget(verticalMode);
-    QPushButton *landscapeMode = new QPushButton("Landscape Mode…", this);
-    connect(landscapeMode, &QPushButton::clicked, this, [this]() {
-        if (QMessageBox::warning(this, "Restart Camera",
-                "Changing landscape mode restarts the camera. Continue?",
-                QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes)
-            m_controller->setVerticalMode(false);
-    });
-    dangerLayout->addWidget(landscapeMode);
-    QPushButton *factoryReset = new QPushButton("Factory Reset…", this);
+    QPushButton *factoryReset =
+        new QPushButton("Factory Reset…", m_tiny4kDeviceGroup);
     connect(factoryReset, &QPushButton::clicked, this, [this]() {
         if (QMessageBox::critical(this, "Factory Reset",
                 "Reset every camera setting to its factory default? This cannot be undone.",
@@ -245,8 +228,7 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
                 QMessageBox::Cancel) == QMessageBox::Reset)
             m_controller->restoreFactorySettings();
     });
-    dangerLayout->addWidget(factoryReset);
-    deviceLayout->addLayout(dangerLayout);
+    deviceLayout->addWidget(factoryReset);
     // Remaining device-specific actions are exposed on the More tab.
 
     // Image Controls Group

--- a/src/gui/CameraSettingsWidget.cpp
+++ b/src/gui/CameraSettingsWidget.cpp
@@ -54,9 +54,8 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     groupLayout->addWidget(m_faceFocusCheckBox);
 
     QHBoxLayout *exposureLayout = new QHBoxLayout();
-    m_exposureAutoCheckBox = new QCheckBox("Adaptive Exposure", this);
-    m_exposureAutoCheckBox->setToolTip(
-        "Use the Tiny 4K's supported shutter-priority mode to adapt gain to changing light");
+    m_exposureAutoCheckBox = new QCheckBox("Auto Exposure", this);
+    m_exposureAutoCheckBox->setToolTip("Continuously adapt exposure to changing light");
     connect(m_exposureAutoCheckBox, &QCheckBox::toggled,
             this, &CameraSettingsWidget::onExposureAutoToggled);
     exposureLayout->addWidget(m_exposureAutoCheckBox);
@@ -381,6 +380,12 @@ void CameraSettingsWidget::onWhiteBalanceKelvinChanged(int value)
 void CameraSettingsWidget::updateFromState(const CameraController::CameraState &state)
 {
     applyControlRanges();
+
+    const bool tiny4k = m_controller->hasTiny4kCapabilities();
+    m_exposureAutoCheckBox->setText(tiny4k ? "Adaptive Exposure" : "Auto Exposure");
+    m_exposureAutoCheckBox->setToolTip(tiny4k
+        ? "Use the Tiny 4K's supported shutter-priority mode to adapt gain to changing light"
+        : "Continuously adapt exposure to changing light");
 
     // Only update if state differs, not user-initiated, command timer expired, and not settling
     bool commandInFlight = m_commandTimer->isActive();

--- a/src/gui/CameraSettingsWidget.cpp
+++ b/src/gui/CameraSettingsWidget.cpp
@@ -54,12 +54,6 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     connect(m_faceAECheckBox, &QCheckBox::toggled, this, &CameraSettingsWidget::onFaceAEToggled);
     groupLayout->addWidget(m_faceAECheckBox);
 
-    // Face Focus
-    m_faceFocusCheckBox = new QCheckBox("Face-based Auto Focus", this);
-    m_faceFocusCheckBox->setToolTip("Optimize focus for faces");
-    connect(m_faceFocusCheckBox, &QCheckBox::toggled, this, &CameraSettingsWidget::onFaceFocusToggled);
-    groupLayout->addWidget(m_faceFocusCheckBox);
-
     QHBoxLayout *exposureLayout = new QHBoxLayout();
     m_exposureAutoCheckBox = new QCheckBox("Auto Exposure", this);
     m_exposureAutoCheckBox->setToolTip("Continuously adapt exposure to changing light");
@@ -433,13 +427,6 @@ void CameraSettingsWidget::onFaceAEToggled(bool checked)
     m_commandTimer->start(1000);
 }
 
-void CameraSettingsWidget::onFaceFocusToggled(bool checked)
-{
-    m_userInitiated = true;
-    m_controller->setFaceFocus(checked);
-    m_commandTimer->start(1000);
-}
-
 void CameraSettingsWidget::onExposureAutoToggled(bool checked)
 {
     m_userInitiated = true;
@@ -625,11 +612,6 @@ void CameraSettingsWidget::updateFromState(const CameraController::CameraState &
             m_faceAECheckBox->blockSignals(false);
         }
 
-        if (m_faceFocusCheckBox->isChecked() != state.faceFocusEnabled) {
-            m_faceFocusCheckBox->blockSignals(true);
-            m_faceFocusCheckBox->setChecked(state.faceFocusEnabled);
-            m_faceFocusCheckBox->blockSignals(false);
-        }
         auto syncSlider = [](QSlider *slider, int value) {
             if (slider->value() == value) return;
             slider->blockSignals(true);

--- a/src/gui/CameraSettingsWidget.cpp
+++ b/src/gui/CameraSettingsWidget.cpp
@@ -1,7 +1,9 @@
 #include "CameraSettingsWidget.h"
 #include <QStandardItemModel>
+#include <QMessageBox>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
+#include <QGridLayout>
 #include <QLabel>
 #include <algorithm>
 
@@ -97,6 +99,169 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     groupLayout->addLayout(antiFlickerLayout);
 
     layout->addWidget(m_advancedGroupBox);
+
+    m_tiny4kDeviceGroup = new QGroupBox("Tiny 4K Device Controls", this);
+    QVBoxLayout *deviceLayout = new QVBoxLayout(m_tiny4kDeviceGroup);
+
+    auto addUvcSlider = [this, deviceLayout](const QString &label,
+                                             QSlider *&slider,
+                                             auto setter) {
+        QHBoxLayout *row = new QHBoxLayout();
+        row->addWidget(new QLabel(label, this));
+        slider = new QSlider(Qt::Horizontal, this);
+        row->addWidget(slider);
+        QPushButton *reset = new QPushButton("Reset", this);
+        row->addWidget(reset);
+        connect(slider, &QSlider::valueChanged, this, [this, setter](int value) {
+            (m_controller->*setter)(value);
+            m_commandTimer->start(1000);
+        });
+        deviceLayout->addLayout(row);
+        return reset;
+    };
+    QPushButton *exposureReset = addUvcSlider(
+        "Exposure:", m_uvcExposureSlider, &CameraController::setTiny4kExposure);
+    connect(exposureReset, &QPushButton::clicked, this, [this]() {
+        auto range = m_controller->getTiny4kExposureRange();
+        if (range.valid) m_uvcExposureSlider->setValue(range.defaultValue);
+    });
+    QPushButton *gainReset = addUvcSlider(
+        "Gain:", m_gainSlider, &CameraController::setTiny4kGain);
+    connect(gainReset, &QPushButton::clicked, this, [this]() {
+        auto range = m_controller->getGainRange();
+        if (range.valid) m_gainSlider->setValue(range.defaultValue);
+    });
+    QPushButton *backlightReset = addUvcSlider(
+        "Backlight:", m_backlightSlider,
+        &CameraController::setTiny4kBacklightCompensation);
+    connect(backlightReset, &QPushButton::clicked, this, [this]() {
+        auto range = m_controller->getBacklightCompensationRange();
+        if (range.valid) m_backlightSlider->setValue(range.defaultValue);
+    });
+
+    QCheckBox *gestureTracking = new QCheckBox("Tracking Gesture", this);
+    connect(gestureTracking, &QCheckBox::toggled, this, [this](bool enabled) {
+        m_controller->setGestureControl(0, enabled);
+    });
+    deviceLayout->addWidget(gestureTracking);
+    QCheckBox *gestureZoom = new QCheckBox("Zoom Gesture", this);
+    connect(gestureZoom, &QCheckBox::toggled, this, [this](bool enabled) {
+        m_controller->setGestureControl(1, enabled);
+    });
+    deviceLayout->addWidget(gestureZoom);
+    QCheckBox *hardwareMirror = new QCheckBox("Hardware Horizontal Flip", this);
+    connect(hardwareMirror, &QCheckBox::toggled, this, [this](bool enabled) {
+        m_controller->setHardwareMirror(enabled);
+    });
+    deviceLayout->addWidget(hardwareMirror);
+    QCheckBox *aiEnabled = new QCheckBox("Global AI Enabled", this);
+    aiEnabled->setChecked(true);
+    connect(aiEnabled, &QCheckBox::toggled, this, [this](bool enabled) {
+        m_controller->setAiEnabled(enabled);
+    });
+    deviceLayout->addWidget(aiEnabled);
+    QCheckBox *sleepMicrophone = new QCheckBox("Microphone Available During Sleep", this);
+    connect(sleepMicrophone, &QCheckBox::toggled, this, [this](bool enabled) {
+        m_controller->setMicrophoneDuringSleep(enabled);
+    });
+    deviceLayout->addWidget(sleepMicrophone);
+
+    QHBoxLayout *sleepTimeoutLayout = new QHBoxLayout();
+    sleepTimeoutLayout->addWidget(new QLabel("Automatic sleep:", this));
+    QSpinBox *sleepTimeout = new QSpinBox(this);
+    sleepTimeout->setRange(0, 65535);
+    sleepTimeout->setSuffix(" s");
+    sleepTimeout->setSpecialValueText("Disabled");
+    sleepTimeoutLayout->addWidget(sleepTimeout);
+    QPushButton *applySleepTimeout = new QPushButton("Apply", this);
+    connect(applySleepTimeout, &QPushButton::clicked, this, [this, sleepTimeout]() {
+        m_controller->setSleepTimeout(sleepTimeout->value());
+    });
+    sleepTimeoutLayout->addWidget(applySleepTimeout);
+    deviceLayout->addLayout(sleepTimeoutLayout);
+
+    QHBoxLayout *powerLayout = new QHBoxLayout();
+    QPushButton *wakeButton = new QPushButton("Wake", this);
+    connect(wakeButton, &QPushButton::clicked, this, [this]() {
+        m_controller->setDeviceAwake(true);
+    });
+    powerLayout->addWidget(wakeButton);
+    QPushButton *sleepButton = new QPushButton("Sleep", this);
+    connect(sleepButton, &QPushButton::clicked, this, [this]() {
+        m_controller->setDeviceAwake(false);
+    });
+    powerLayout->addWidget(sleepButton);
+    QPushButton *bootPositionButton = new QPushButton("Use Current View at Boot", this);
+    connect(bootPositionButton, &QPushButton::clicked, this, [this]() {
+        m_controller->setCurrentViewAsBootPosition();
+    });
+    powerLayout->addWidget(bootPositionButton);
+    deviceLayout->addLayout(powerLayout);
+
+    QLabel *speedLabel = new QLabel("Continuous Gimbal Movement", this);
+    deviceLayout->addWidget(speedLabel);
+    QGridLayout *speedLayout = new QGridLayout();
+    auto addSpeedButton = [this, speedLayout](const QString &text, int row, int column,
+                                              double pitch, double pan) {
+        QPushButton *button = new QPushButton(text, this);
+        connect(button, &QPushButton::pressed, this, [this, pitch, pan]() {
+            m_controller->setGimbalSpeed(pitch, pan);
+        });
+        connect(button, &QPushButton::released, this, [this]() {
+            m_controller->setGimbalSpeed(0.0, 0.0);
+        });
+        speedLayout->addWidget(button, row, column);
+    };
+    addSpeedButton("↑", 0, 1, 30.0, 0.0);
+    addSpeedButton("←", 1, 0, 0.0, -45.0);
+    addSpeedButton("↓", 1, 1, -30.0, 0.0);
+    addSpeedButton("→", 1, 2, 0.0, 45.0);
+    deviceLayout->addLayout(speedLayout);
+
+    for (int id = 0; id < 3; ++id) {
+        QHBoxLayout *presetLayout = new QHBoxLayout();
+        presetLayout->addWidget(new QLabel(QString("Camera Preset %1").arg(id + 1), this));
+        QPushButton *savePreset = new QPushButton("Save", this);
+        connect(savePreset, &QPushButton::clicked, this, [this, id]() {
+            m_controller->saveHardwarePreset(id);
+        });
+        presetLayout->addWidget(savePreset);
+        QPushButton *recallPreset = new QPushButton("Recall", this);
+        connect(recallPreset, &QPushButton::clicked, this, [this, id]() {
+            m_controller->recallHardwarePreset(id);
+        });
+        presetLayout->addWidget(recallPreset);
+        deviceLayout->addLayout(presetLayout);
+    }
+
+    QHBoxLayout *dangerLayout = new QHBoxLayout();
+    QPushButton *verticalMode = new QPushButton("Enable Portrait Mode…", this);
+    connect(verticalMode, &QPushButton::clicked, this, [this]() {
+        if (QMessageBox::warning(this, "Restart Camera",
+                "Changing portrait mode restarts the camera. Enable portrait mode?",
+                QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes)
+            m_controller->setVerticalMode(true);
+    });
+    dangerLayout->addWidget(verticalMode);
+    QPushButton *landscapeMode = new QPushButton("Landscape Mode…", this);
+    connect(landscapeMode, &QPushButton::clicked, this, [this]() {
+        if (QMessageBox::warning(this, "Restart Camera",
+                "Changing landscape mode restarts the camera. Continue?",
+                QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes)
+            m_controller->setVerticalMode(false);
+    });
+    dangerLayout->addWidget(landscapeMode);
+    QPushButton *factoryReset = new QPushButton("Factory Reset…", this);
+    connect(factoryReset, &QPushButton::clicked, this, [this]() {
+        if (QMessageBox::critical(this, "Factory Reset",
+                "Reset every camera setting to its factory default? This cannot be undone.",
+                QMessageBox::Reset | QMessageBox::Cancel,
+                QMessageBox::Cancel) == QMessageBox::Reset)
+            m_controller->restoreFactorySettings();
+    });
+    dangerLayout->addWidget(factoryReset);
+    deviceLayout->addLayout(dangerLayout);
+    layout->addWidget(m_tiny4kDeviceGroup);
 
     // Image Controls Group
     QGroupBox *imageGroupBox = new QGroupBox("Image Controls", this);
@@ -445,6 +610,7 @@ void CameraSettingsWidget::updateFromState(const CameraController::CameraState &
     applyControlRanges();
 
     const bool tiny4k = m_controller->hasTiny4kCapabilities();
+    m_tiny4kDeviceGroup->setVisible(tiny4k);
     // Tiny 4K firmware 1.2.6.2 boots in a camera-managed exposure mode that
     // neither its SDK nor UVC menu can restore after switching to manual.
     // Do not expose a one-way control that can leave the image overexposed.
@@ -480,6 +646,15 @@ void CameraSettingsWidget::updateFromState(const CameraController::CameraState &
             m_faceFocusCheckBox->setChecked(state.faceFocusEnabled);
             m_faceFocusCheckBox->blockSignals(false);
         }
+        auto syncSlider = [](QSlider *slider, int value) {
+            if (slider->value() == value) return;
+            slider->blockSignals(true);
+            slider->setValue(value);
+            slider->blockSignals(false);
+        };
+        syncSlider(m_uvcExposureSlider, state.uvcExposure);
+        syncSlider(m_gainSlider, state.gain);
+        syncSlider(m_backlightSlider, state.backlightCompensation);
 
         m_exposureAutoCheckBox->blockSignals(true);
         m_exposureAutoCheckBox->setChecked(state.exposureAuto);
@@ -600,6 +775,12 @@ void CameraSettingsWidget::applyControlRanges()
                QStringLiteral("Adjust image hue (%1-%2)"));
     applyRange(m_controller->getSharpnessRange(), m_sharpnessSlider, m_sharpnessRangeApplied,
                QStringLiteral("Adjust image sharpness (%1-%2)"));
+    applyRange(m_controller->getTiny4kExposureRange(), m_uvcExposureSlider,
+               m_uvcExposureRangeApplied, QStringLiteral("UVC exposure (%1-%2)"));
+    applyRange(m_controller->getGainRange(), m_gainSlider,
+               m_gainRangeApplied, QStringLiteral("UVC gain (%1-%2)"));
+    applyRange(m_controller->getBacklightCompensationRange(), m_backlightSlider,
+               m_backlightRangeApplied, QStringLiteral("Backlight compensation (%1-%2)"));
 
     const auto antiFlickerRange = m_controller->getAntiFlickerRange();
     if (antiFlickerRange.valid) {
@@ -637,6 +818,7 @@ void CameraSettingsWidget::updateWhiteBalanceControls(int mode)
 void CameraSettingsWidget::setV4l2Mode(bool v4l2Only)
 {
     m_advancedGroupBox->setVisible(!v4l2Only);
+    m_tiny4kDeviceGroup->setVisible(!v4l2Only && m_controller->hasTiny4kCapabilities());
 }
 
 void CameraSettingsWidget::updateWhiteBalanceKelvinLabel(int value)

--- a/src/gui/CameraSettingsWidget.cpp
+++ b/src/gui/CameraSettingsWidget.cpp
@@ -212,9 +212,9 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
         });
         speedLayout->addWidget(button, row, column);
     };
-    addSpeedButton("↑", 0, 1, 30.0, 0.0);
+    addSpeedButton("↑", 0, 1, -30.0, 0.0);
     addSpeedButton("←", 1, 0, 0.0, -45.0);
-    addSpeedButton("↓", 1, 1, -30.0, 0.0);
+    addSpeedButton("↓", 1, 1, 30.0, 0.0);
     addSpeedButton("→", 1, 2, 0.0, 45.0);
     deviceLayout->addLayout(speedLayout);
 

--- a/src/gui/CameraSettingsWidget.cpp
+++ b/src/gui/CameraSettingsWidget.cpp
@@ -54,8 +54,9 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     groupLayout->addWidget(m_faceFocusCheckBox);
 
     QHBoxLayout *exposureLayout = new QHBoxLayout();
-    m_exposureAutoCheckBox = new QCheckBox("Auto Exposure", this);
-    m_exposureAutoCheckBox->setToolTip("Continuously adapt exposure to changing light");
+    m_exposureAutoCheckBox = new QCheckBox("Adaptive Exposure", this);
+    m_exposureAutoCheckBox->setToolTip(
+        "Use the Tiny 4K's supported shutter-priority mode to adapt gain to changing light");
     connect(m_exposureAutoCheckBox, &QCheckBox::toggled,
             this, &CameraSettingsWidget::onExposureAutoToggled);
     exposureLayout->addWidget(m_exposureAutoCheckBox);

--- a/src/gui/CameraSettingsWidget.cpp
+++ b/src/gui/CameraSettingsWidget.cpp
@@ -53,6 +53,43 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     connect(m_faceFocusCheckBox, &QCheckBox::toggled, this, &CameraSettingsWidget::onFaceFocusToggled);
     groupLayout->addWidget(m_faceFocusCheckBox);
 
+    QHBoxLayout *exposureLayout = new QHBoxLayout();
+    m_exposureAutoCheckBox = new QCheckBox("Auto Exposure", this);
+    m_exposureAutoCheckBox->setToolTip("Continuously adapt exposure to changing light");
+    connect(m_exposureAutoCheckBox, &QCheckBox::toggled,
+            this, &CameraSettingsWidget::onExposureAutoToggled);
+    exposureLayout->addWidget(m_exposureAutoCheckBox);
+    m_exposureComboBox = new QComboBox(this);
+    static const char *shutterNames[] = {
+        "1/8000", "1/6400", "1/5000", "1/4000", "1/3200", "1/2500",
+        "1/2000", "1/1600", "1/1250", "1/1000", "1/800", "1/640",
+        "1/500", "1/400", "1/320", "1/240", "1/200", "1/160",
+        "1/120", "1/100", "1/80", "1/60", "1/50", "1/40", "1/30",
+        "1/25", "1/20", "1/15", "1/12.5", "1/10", "1/8", "1/6.25",
+        "1/5", "1/4"
+    };
+    for (int i = 0; i < 34; ++i)
+        m_exposureComboBox->addItem(shutterNames[i], 9 + i);
+    connect(m_exposureComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, &CameraSettingsWidget::onExposureChanged);
+    exposureLayout->addWidget(new QLabel("Shutter:", this));
+    exposureLayout->addWidget(m_exposureComboBox);
+    exposureLayout->addStretch();
+    groupLayout->addLayout(exposureLayout);
+
+    QHBoxLayout *antiFlickerLayout = new QHBoxLayout();
+    antiFlickerLayout->addWidget(new QLabel("Anti-flicker:", this));
+    m_antiFlickerComboBox = new QComboBox(this);
+    m_antiFlickerComboBox->addItem("Off", Device::PowerLineFreqOff);
+    m_antiFlickerComboBox->addItem("50 Hz", Device::PowerLineFreq50);
+    m_antiFlickerComboBox->addItem("60 Hz", Device::PowerLineFreq60);
+    m_antiFlickerComboBox->addItem("Auto", Device::PowerLineFreqAuto);
+    connect(m_antiFlickerComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, &CameraSettingsWidget::onAntiFlickerChanged);
+    antiFlickerLayout->addWidget(m_antiFlickerComboBox);
+    antiFlickerLayout->addStretch();
+    groupLayout->addLayout(antiFlickerLayout);
+
     layout->addWidget(m_advancedGroupBox);
 
     // Image Controls Group
@@ -64,6 +101,7 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     // Brightness
     QHBoxLayout *brightnessLayout = new QHBoxLayout();
     m_brightnessAutoCheckBox = new QCheckBox("Auto", this);
+    m_brightnessAutoCheckBox->setVisible(false);
     m_brightnessAutoCheckBox->setToolTip("Enable automatic brightness (disables manual control)");
     connect(m_brightnessAutoCheckBox, &QCheckBox::toggled, this, &CameraSettingsWidget::onBrightnessAutoToggled);
     brightnessLayout->addWidget(m_brightnessAutoCheckBox);
@@ -78,6 +116,7 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     // Contrast
     QHBoxLayout *contrastLayout = new QHBoxLayout();
     m_contrastAutoCheckBox = new QCheckBox("Auto", this);
+    m_contrastAutoCheckBox->setVisible(false);
     m_contrastAutoCheckBox->setToolTip("Enable automatic contrast (disables manual control)");
     connect(m_contrastAutoCheckBox, &QCheckBox::toggled, this, &CameraSettingsWidget::onContrastAutoToggled);
     contrastLayout->addWidget(m_contrastAutoCheckBox);
@@ -92,6 +131,7 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     // Saturation
     QHBoxLayout *saturationLayout = new QHBoxLayout();
     m_saturationAutoCheckBox = new QCheckBox("Auto", this);
+    m_saturationAutoCheckBox->setVisible(false);
     m_saturationAutoCheckBox->setToolTip("Enable automatic saturation (disables manual control)");
     connect(m_saturationAutoCheckBox, &QCheckBox::toggled, this, &CameraSettingsWidget::onSaturationAutoToggled);
     saturationLayout->addWidget(m_saturationAutoCheckBox);
@@ -102,6 +142,23 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     connect(m_saturationSlider, &QSlider::valueChanged, this, &CameraSettingsWidget::onSaturationChanged);
     saturationLayout->addWidget(m_saturationSlider);
     imageLayout->addLayout(saturationLayout);
+
+    QHBoxLayout *hueLayout = new QHBoxLayout();
+    hueLayout->addWidget(new QLabel("Hue:", this));
+    m_hueSlider = new QSlider(Qt::Horizontal, this);
+    m_hueSlider->setRange(0, 100);
+    connect(m_hueSlider, &QSlider::valueChanged, this, &CameraSettingsWidget::onHueChanged);
+    hueLayout->addWidget(m_hueSlider);
+    imageLayout->addLayout(hueLayout);
+
+    QHBoxLayout *sharpnessLayout = new QHBoxLayout();
+    sharpnessLayout->addWidget(new QLabel("Sharpness:", this));
+    m_sharpnessSlider = new QSlider(Qt::Horizontal, this);
+    m_sharpnessSlider->setRange(0, 100);
+    connect(m_sharpnessSlider, &QSlider::valueChanged,
+            this, &CameraSettingsWidget::onSharpnessChanged);
+    sharpnessLayout->addWidget(m_sharpnessSlider);
+    imageLayout->addLayout(sharpnessLayout);
 
     // White Balance
     QHBoxLayout *wbLayout = new QHBoxLayout();
@@ -168,6 +225,30 @@ void CameraSettingsWidget::onFaceFocusToggled(bool checked)
 {
     m_userInitiated = true;
     m_controller->setFaceFocus(checked);
+    m_commandTimer->start(1000);
+}
+
+void CameraSettingsWidget::onExposureAutoToggled(bool checked)
+{
+    m_userInitiated = true;
+    m_exposureComboBox->setEnabled(!checked);
+    m_controller->setExposure(m_exposureComboBox->currentData().toInt(), checked);
+    m_commandTimer->start(1000);
+}
+
+void CameraSettingsWidget::onExposureChanged(int index)
+{
+    if (index < 0 || m_exposureAutoCheckBox->isChecked()) return;
+    m_userInitiated = true;
+    m_controller->setExposure(m_exposureComboBox->itemData(index).toInt(), false);
+    m_commandTimer->start(1000);
+}
+
+void CameraSettingsWidget::onAntiFlickerChanged(int index)
+{
+    if (index < 0) return;
+    m_userInitiated = true;
+    m_controller->setAntiFlicker(m_antiFlickerComboBox->itemData(index).toInt());
     m_commandTimer->start(1000);
 }
 
@@ -255,6 +336,20 @@ void CameraSettingsWidget::onSaturationChanged(int value)
     m_commandTimer->start(1000);
 }
 
+void CameraSettingsWidget::onHueChanged(int value)
+{
+    m_userInitiated = true;
+    m_controller->setHue(value);
+    m_commandTimer->start(1000);
+}
+
+void CameraSettingsWidget::onSharpnessChanged(int value)
+{
+    m_userInitiated = true;
+    m_controller->setSharpness(value);
+    m_commandTimer->start(1000);
+}
+
 void CameraSettingsWidget::onWhiteBalanceChanged(int index)
 {
     Q_UNUSED(index);
@@ -315,6 +410,23 @@ void CameraSettingsWidget::updateFromState(const CameraController::CameraState &
             m_faceFocusCheckBox->blockSignals(false);
         }
 
+        m_exposureAutoCheckBox->blockSignals(true);
+        m_exposureAutoCheckBox->setChecked(state.exposureAuto);
+        m_exposureAutoCheckBox->blockSignals(false);
+        m_exposureComboBox->setEnabled(!state.exposureAuto);
+        int exposureIndex = m_exposureComboBox->findData(state.exposure);
+        if (exposureIndex >= 0) {
+            m_exposureComboBox->blockSignals(true);
+            m_exposureComboBox->setCurrentIndex(exposureIndex);
+            m_exposureComboBox->blockSignals(false);
+        }
+        int flickerIndex = m_antiFlickerComboBox->findData(state.antiFlicker);
+        if (flickerIndex >= 0) {
+            m_antiFlickerComboBox->blockSignals(true);
+            m_antiFlickerComboBox->setCurrentIndex(flickerIndex);
+            m_antiFlickerComboBox->blockSignals(false);
+        }
+
         // Image controls - DON'T update auto checkboxes from camera state
         // These are UI-only flags (camera doesn't have auto brightness/contrast/saturation)
         // The checkboxes are only updated via user interaction or config load
@@ -339,6 +451,16 @@ void CameraSettingsWidget::updateFromState(const CameraController::CameraState &
             m_saturationSlider->blockSignals(true);
             m_saturationSlider->setValue(state.saturation);
             m_saturationSlider->blockSignals(false);
+        }
+        if (m_hueSlider->value() != state.hue) {
+            m_hueSlider->blockSignals(true);
+            m_hueSlider->setValue(state.hue);
+            m_hueSlider->blockSignals(false);
+        }
+        if (m_sharpnessSlider->value() != state.sharpness) {
+            m_sharpnessSlider->blockSignals(true);
+            m_sharpnessSlider->setValue(state.sharpness);
+            m_sharpnessSlider->blockSignals(false);
         }
     }
 
@@ -403,6 +525,10 @@ void CameraSettingsWidget::applyControlRanges()
                QStringLiteral("Adjust image contrast (%1-%2)"));
     applyRange(m_controller->getSaturationRange(), m_saturationSlider, m_saturationRangeApplied,
                QStringLiteral("Adjust color saturation (%1-%2)"));
+    applyRange(m_controller->getHueRange(), m_hueSlider, m_hueRangeApplied,
+               QStringLiteral("Adjust image hue (%1-%2)"));
+    applyRange(m_controller->getSharpnessRange(), m_sharpnessSlider, m_sharpnessRangeApplied,
+               QStringLiteral("Adjust image sharpness (%1-%2)"));
 
     const auto wbRange = m_controller->getWhiteBalanceKelvinRange();
     if (wbRange.valid) {

--- a/src/gui/CameraSettingsWidget.cpp
+++ b/src/gui/CameraSettingsWidget.cpp
@@ -112,6 +112,15 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     m_brightnessSlider->setToolTip("Adjust image brightness (0-255)");
     connect(m_brightnessSlider, &QSlider::valueChanged, this, &CameraSettingsWidget::onBrightnessChanged);
     brightnessLayout->addWidget(m_brightnessSlider);
+    QPushButton *brightnessReset = new QPushButton("Reset", this);
+    connect(brightnessReset, &QPushButton::clicked, this, [this]() {
+        const auto range = m_controller->getBrightnessRange();
+        const int value = range.valid ? range.defaultValue : 50;
+        m_controller->setBrightnessAuto(false);
+        setBrightness(value);
+        m_controller->setBrightness(value);
+    });
+    brightnessLayout->addWidget(brightnessReset);
     imageLayout->addLayout(brightnessLayout);
 
     // Contrast
@@ -127,6 +136,15 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     m_contrastSlider->setToolTip("Adjust image contrast (0-255)");
     connect(m_contrastSlider, &QSlider::valueChanged, this, &CameraSettingsWidget::onContrastChanged);
     contrastLayout->addWidget(m_contrastSlider);
+    QPushButton *contrastReset = new QPushButton("Reset", this);
+    connect(contrastReset, &QPushButton::clicked, this, [this]() {
+        const auto range = m_controller->getContrastRange();
+        const int value = range.valid ? range.defaultValue : 50;
+        m_controller->setContrastAuto(false);
+        setContrast(value);
+        m_controller->setContrast(value);
+    });
+    contrastLayout->addWidget(contrastReset);
     imageLayout->addLayout(contrastLayout);
 
     // Saturation
@@ -142,6 +160,15 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     m_saturationSlider->setToolTip("Adjust color saturation (0-255)");
     connect(m_saturationSlider, &QSlider::valueChanged, this, &CameraSettingsWidget::onSaturationChanged);
     saturationLayout->addWidget(m_saturationSlider);
+    QPushButton *saturationReset = new QPushButton("Reset", this);
+    connect(saturationReset, &QPushButton::clicked, this, [this]() {
+        const auto range = m_controller->getSaturationRange();
+        const int value = range.valid ? range.defaultValue : 50;
+        m_controller->setSaturationAuto(false);
+        setSaturation(value);
+        m_controller->setSaturation(value);
+    });
+    saturationLayout->addWidget(saturationReset);
     imageLayout->addLayout(saturationLayout);
 
     QHBoxLayout *hueLayout = new QHBoxLayout();
@@ -150,6 +177,16 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     m_hueSlider->setRange(0, 100);
     connect(m_hueSlider, &QSlider::valueChanged, this, &CameraSettingsWidget::onHueChanged);
     hueLayout->addWidget(m_hueSlider);
+    QPushButton *hueReset = new QPushButton("Reset", this);
+    connect(hueReset, &QPushButton::clicked, this, [this]() {
+        const auto range = m_controller->getHueRange();
+        const int value = range.valid ? range.defaultValue : 50;
+        m_hueSlider->blockSignals(true);
+        m_hueSlider->setValue(value);
+        m_hueSlider->blockSignals(false);
+        m_controller->setHue(value);
+    });
+    hueLayout->addWidget(hueReset);
     imageLayout->addLayout(hueLayout);
 
     QHBoxLayout *sharpnessLayout = new QHBoxLayout();
@@ -159,6 +196,16 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     connect(m_sharpnessSlider, &QSlider::valueChanged,
             this, &CameraSettingsWidget::onSharpnessChanged);
     sharpnessLayout->addWidget(m_sharpnessSlider);
+    QPushButton *sharpnessReset = new QPushButton("Reset", this);
+    connect(sharpnessReset, &QPushButton::clicked, this, [this]() {
+        const auto range = m_controller->getSharpnessRange();
+        const int value = range.valid ? range.defaultValue : 50;
+        m_sharpnessSlider->blockSignals(true);
+        m_sharpnessSlider->setValue(value);
+        m_sharpnessSlider->blockSignals(false);
+        m_controller->setSharpness(value);
+    });
+    sharpnessLayout->addWidget(sharpnessReset);
     imageLayout->addLayout(sharpnessLayout);
 
     // White Balance
@@ -178,6 +225,16 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     connect(m_whiteBalanceComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged),
             this, &CameraSettingsWidget::onWhiteBalanceChanged);
     wbLayout->addWidget(m_whiteBalanceComboBox);
+    QPushButton *whiteBalanceReset = new QPushButton("Reset", this);
+    connect(whiteBalanceReset, &QPushButton::clicked, this, [this]() {
+        const int mode = static_cast<int>(Device::DevWhiteBalanceAuto);
+        setWhiteBalance(mode);
+        const auto range = m_controller->getWhiteBalanceKelvinRange();
+        if (range.valid)
+            setWhiteBalanceKelvin(range.defaultValue);
+        m_controller->setWhiteBalance(mode);
+    });
+    wbLayout->addWidget(whiteBalanceReset);
     wbLayout->addStretch();
     imageLayout->addLayout(wbLayout);
 

--- a/src/gui/CameraSettingsWidget.cpp
+++ b/src/gui/CameraSettingsWidget.cpp
@@ -223,11 +223,11 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     deviceLayout->addLayout(screenModeLayout);
 
     QCheckBox *sleepMicrophone =
-        new QCheckBox("Microphone available during sleep", m_tiny4kDeviceGroup);
+        new QCheckBox("Microphone available during sleep", sleepGroup);
     connect(sleepMicrophone, &QCheckBox::toggled, this, [this](bool enabled) {
         m_controller->setMicrophoneDuringSleep(enabled);
     });
-    deviceLayout->addWidget(sleepMicrophone);
+    sleepLayout->addWidget(sleepMicrophone);
 
     QPushButton *factoryReset =
         new QPushButton("Factory Reset…", m_tiny4kDeviceGroup);

--- a/src/gui/CameraSettingsWidget.cpp
+++ b/src/gui/CameraSettingsWidget.cpp
@@ -34,9 +34,8 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     connect(m_hdrCheckBox, &QCheckBox::toggled, this, &CameraSettingsWidget::onHDRToggled);
     groupLayout->addWidget(m_hdrCheckBox);
 
-    // Named zoom/FOV presets
-    QHBoxLayout *fovLayout = new QHBoxLayout();
-    fovLayout->addWidget(new QLabel("Zoom preset:", this));
+    // Retained as an internal state holder for configuration and image
+    // presets; the visible controls live beside the Zoom slider.
     m_fovComboBox = new QComboBox(this);
     m_fovComboBox->addItem("Wide (86°)", 0);
     m_fovComboBox->addItem("Medium (78°)", 1);
@@ -45,13 +44,9 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     if (auto *model = qobject_cast<QStandardItemModel*>(m_fovComboBox->model())) {
         model->item(3)->setEnabled(false);
     }
-    m_fovComboBox->setToolTip(
-        "Select a named field-of-view preset; manual zoom is shown as Custom");
     connect(m_fovComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged),
             this, &CameraSettingsWidget::onFOVChanged);
-    fovLayout->addWidget(m_fovComboBox);
-    fovLayout->addStretch();
-    groupLayout->addLayout(fovLayout);
+    m_fovComboBox->hide();
 
     // Face AE
     m_faceAECheckBox = new QCheckBox("Face-based Auto Exposure", this);

--- a/src/gui/CameraSettingsWidget.cpp
+++ b/src/gui/CameraSettingsWidget.cpp
@@ -61,7 +61,10 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
 
     QHBoxLayout *exposureLayout = new QHBoxLayout();
     m_exposureAutoCheckBox = new QCheckBox("Auto Exposure", this);
-    m_exposureAutoCheckBox->setToolTip("Continuously adapt exposure to changing light");
+    m_exposureAutoCheckBox->setToolTip(
+        "<b>Shutter Priority</b><br>"
+        "Keeps exposure time camera-managed and relatively short. "
+        "It does not automatically increase image brightness or gain.");
     connect(m_exposureAutoCheckBox, &QCheckBox::toggled,
             this, &CameraSettingsWidget::onExposureAutoToggled);
     exposureLayout->addWidget(m_exposureAutoCheckBox);

--- a/src/gui/CameraSettingsWidget.cpp
+++ b/src/gui/CameraSettingsWidget.cpp
@@ -1,4 +1,5 @@
 #include "CameraSettingsWidget.h"
+#include <QStandardItemModel>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QLabel>
@@ -595,6 +596,22 @@ void CameraSettingsWidget::applyControlRanges()
                QStringLiteral("Adjust image hue (%1-%2)"));
     applyRange(m_controller->getSharpnessRange(), m_sharpnessSlider, m_sharpnessRangeApplied,
                QStringLiteral("Adjust image sharpness (%1-%2)"));
+
+    const auto antiFlickerRange = m_controller->getAntiFlickerRange();
+    if (antiFlickerRange.valid) {
+        auto *model = qobject_cast<QStandardItemModel *>(m_antiFlickerComboBox->model());
+        for (int i = 0; model && i < m_antiFlickerComboBox->count(); ++i) {
+            const int value = m_antiFlickerComboBox->itemData(i).toInt();
+            if (QStandardItem *item = model->item(i)) {
+                item->setEnabled(value >= antiFlickerRange.min &&
+                                 value <= antiFlickerRange.max);
+            }
+        }
+        m_antiFlickerComboBox->setToolTip(
+            QStringLiteral("Supported anti-flicker modes: %1-%2")
+                .arg(antiFlickerRange.min)
+                .arg(antiFlickerRange.max));
+    }
 
     const auto wbRange = m_controller->getWhiteBalanceKelvinRange();
     if (wbRange.valid) {

--- a/src/gui/CameraSettingsWidget.cpp
+++ b/src/gui/CameraSettingsWidget.cpp
@@ -406,6 +406,17 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     layout->addStretch();
 }
 
+void CameraSettingsWidget::insertTopWidget(QWidget *widget)
+{
+    if (!widget) return;
+    if (QWidget *oldParent = widget->parentWidget()) {
+        if (QLayout *oldLayout = oldParent->layout())
+            oldLayout->removeWidget(widget);
+    }
+    if (auto *pageLayout = qobject_cast<QVBoxLayout*>(layout()))
+        pageLayout->insertWidget(0, widget);
+}
+
 void CameraSettingsWidget::onHDRToggled(bool checked)
 {
     m_userInitiated = true;

--- a/src/gui/CameraSettingsWidget.cpp
+++ b/src/gui/CameraSettingsWidget.cpp
@@ -218,22 +218,6 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     addSpeedButton("→", 1, 2, 0.0, 45.0);
     deviceLayout->addLayout(speedLayout);
 
-    for (int id = 0; id < 3; ++id) {
-        QHBoxLayout *presetLayout = new QHBoxLayout();
-        presetLayout->addWidget(new QLabel(QString("Camera Preset %1").arg(id + 1), this));
-        QPushButton *savePreset = new QPushButton("Save", this);
-        connect(savePreset, &QPushButton::clicked, this, [this, id]() {
-            m_controller->saveHardwarePreset(id);
-        });
-        presetLayout->addWidget(savePreset);
-        QPushButton *recallPreset = new QPushButton("Recall", this);
-        connect(recallPreset, &QPushButton::clicked, this, [this, id]() {
-            m_controller->recallHardwarePreset(id);
-        });
-        presetLayout->addWidget(recallPreset);
-        deviceLayout->addLayout(presetLayout);
-    }
-
     QHBoxLayout *dangerLayout = new QHBoxLayout();
     QPushButton *verticalMode = new QPushButton("Enable Portrait Mode…", this);
     connect(verticalMode, &QPushButton::clicked, this, [this]() {

--- a/src/gui/CameraSettingsWidget.cpp
+++ b/src/gui/CameraSettingsWidget.cpp
@@ -149,7 +149,7 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
         m_controller->setGestureControl(1, enabled);
     });
     deviceLayout->addWidget(gestureZoom);
-    QCheckBox *hardwareMirror = new QCheckBox("Hardware Horizontal Flip", this);
+    QCheckBox *hardwareMirror = new QCheckBox("Flip camera output (hardware)", this);
     connect(hardwareMirror, &QCheckBox::toggled, this, [this](bool enabled) {
         m_controller->setHardwareMirror(enabled);
     });

--- a/src/gui/CameraSettingsWidget.cpp
+++ b/src/gui/CameraSettingsWidget.cpp
@@ -23,16 +23,21 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     layout->setContentsMargins(8, 8, 8, 14);
     layout->setSpacing(14);
 
-    m_advancedGroupBox = new QGroupBox("Advanced Camera Settings", this);
-    QVBoxLayout *groupLayout = new QVBoxLayout(m_advancedGroupBox);
-    groupLayout->setContentsMargins(16, 16, 16, 16);
-    groupLayout->setSpacing(10);
+    m_advancedGroupBox = new QGroupBox("HDR", this);
+    QVBoxLayout *hdrLayout = new QVBoxLayout(m_advancedGroupBox);
+    hdrLayout->setContentsMargins(16, 16, 16, 16);
 
     // HDR
     m_hdrCheckBox = new QCheckBox("HDR (High Dynamic Range)", this);
     m_hdrCheckBox->setToolTip("Enhance image quality in high-contrast scenes");
     connect(m_hdrCheckBox, &QCheckBox::toggled, this, &CameraSettingsWidget::onHDRToggled);
-    groupLayout->addWidget(m_hdrCheckBox);
+    hdrLayout->addWidget(m_hdrCheckBox);
+    layout->addWidget(m_advancedGroupBox);
+
+    m_exposureGroupBox = new QGroupBox("Exposure", this);
+    QVBoxLayout *groupLayout = new QVBoxLayout(m_exposureGroupBox);
+    groupLayout->setContentsMargins(16, 16, 16, 16);
+    groupLayout->setSpacing(10);
 
     // Retained as an internal state holder for configuration and image
     // presets; the visible controls live beside the Zoom slider.
@@ -90,17 +95,18 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
             this, &CameraSettingsWidget::onAntiFlickerChanged);
     antiFlickerLayout->addWidget(m_antiFlickerComboBox);
     antiFlickerLayout->addStretch();
-    groupLayout->addLayout(antiFlickerLayout);
-
-    layout->addWidget(m_advancedGroupBox);
+    layout->addWidget(m_exposureGroupBox);
 
     m_tiny4kDeviceGroup = new QGroupBox("Tiny 4K Device Controls", this);
     QVBoxLayout *deviceLayout = new QVBoxLayout(m_tiny4kDeviceGroup);
 
-    auto addUvcSlider = [this, deviceLayout](const QString &label,
+    auto addUvcSlider = [this, groupLayout](const QString &label,
+                                             QWidget *&rowWidget,
                                              QSlider *&slider,
                                              auto setter) {
-        QHBoxLayout *row = new QHBoxLayout();
+        rowWidget = new QWidget(this);
+        QHBoxLayout *row = new QHBoxLayout(rowWidget);
+        row->setContentsMargins(0, 0, 0, 0);
         row->addWidget(new QLabel(label, this));
         slider = new QSlider(Qt::Horizontal, this);
         row->addWidget(slider);
@@ -110,28 +116,30 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
             (m_controller->*setter)(value);
             m_commandTimer->start(1000);
         });
-        deviceLayout->addLayout(row);
+        groupLayout->addWidget(rowWidget);
         return reset;
     };
     QPushButton *exposureReset = addUvcSlider(
-        "Exposure:", m_uvcExposureSlider, &CameraController::setTiny4kExposure);
+        "Exposure:", m_uvcExposureRow, m_uvcExposureSlider,
+        &CameraController::setTiny4kExposure);
     connect(exposureReset, &QPushButton::clicked, this, [this]() {
         auto range = m_controller->getTiny4kExposureRange();
         if (range.valid) m_uvcExposureSlider->setValue(range.defaultValue);
     });
     QPushButton *gainReset = addUvcSlider(
-        "Gain:", m_gainSlider, &CameraController::setTiny4kGain);
+        "Gain:", m_gainRow, m_gainSlider, &CameraController::setTiny4kGain);
     connect(gainReset, &QPushButton::clicked, this, [this]() {
         auto range = m_controller->getGainRange();
         if (range.valid) m_gainSlider->setValue(range.defaultValue);
     });
     QPushButton *backlightReset = addUvcSlider(
-        "Backlight:", m_backlightSlider,
+        "Backlight:", m_backlightRow, m_backlightSlider,
         &CameraController::setTiny4kBacklightCompensation);
     connect(backlightReset, &QPushButton::clicked, this, [this]() {
         auto range = m_controller->getBacklightCompensationRange();
         if (range.valid) m_backlightSlider->setValue(range.defaultValue);
     });
+    groupLayout->addLayout(antiFlickerLayout);
 
     QCheckBox *gestureTracking = new QCheckBox("Tracking Gesture", this);
     connect(gestureTracking, &QCheckBox::toggled, this, [this](bool enabled) {
@@ -239,11 +247,11 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     });
     dangerLayout->addWidget(factoryReset);
     deviceLayout->addLayout(dangerLayout);
-    layout->addWidget(m_tiny4kDeviceGroup);
+    // Remaining device-specific actions are exposed on the More tab.
 
     // Image Controls Group
-    QGroupBox *imageGroupBox = new QGroupBox("Image Controls", this);
-    QVBoxLayout *imageLayout = new QVBoxLayout(imageGroupBox);
+    m_imageGroupBox = new QGroupBox("Image", this);
+    QVBoxLayout *imageLayout = new QVBoxLayout(m_imageGroupBox);
     imageLayout->setContentsMargins(16, 16, 16, 16);
     imageLayout->setSpacing(10);
 
@@ -335,7 +343,6 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
         m_controller->setHue(value);
     });
     hueLayout->addWidget(hueReset);
-    imageLayout->addLayout(hueLayout);
 
     QHBoxLayout *sharpnessLayout = new QHBoxLayout();
     sharpnessLayout->addWidget(new QLabel("Sharpness:", this));
@@ -355,8 +362,14 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     });
     sharpnessLayout->addWidget(sharpnessReset);
     imageLayout->addLayout(sharpnessLayout);
+    imageLayout->addLayout(hueLayout);
 
     // White Balance
+    m_whiteBalanceGroupBox = new QGroupBox("White Balance", this);
+    QVBoxLayout *whiteBalanceLayout =
+        new QVBoxLayout(m_whiteBalanceGroupBox);
+    whiteBalanceLayout->setContentsMargins(16, 16, 16, 16);
+    whiteBalanceLayout->setSpacing(10);
     QHBoxLayout *wbLayout = new QHBoxLayout();
     wbLayout->addWidget(new QLabel("White Balance:", this));
     m_whiteBalanceComboBox = new QComboBox(this);
@@ -384,7 +397,7 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     });
     wbLayout->addWidget(whiteBalanceReset);
     wbLayout->addStretch();
-    imageLayout->addLayout(wbLayout);
+    whiteBalanceLayout->addLayout(wbLayout);
 
     QHBoxLayout *wbKelvinLayout = new QHBoxLayout();
     wbKelvinLayout->setContentsMargins(20, 0, 0, 0);
@@ -400,13 +413,14 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     m_whiteBalanceKelvinLabel = new QLabel("5000 K", this);
     m_whiteBalanceKelvinLabel->setEnabled(false);
     wbKelvinLayout->addWidget(m_whiteBalanceKelvinLabel);
-    imageLayout->addLayout(wbKelvinLayout);
+    whiteBalanceLayout->addLayout(wbKelvinLayout);
 
-    layout->addWidget(imageGroupBox);
+    layout->addWidget(m_whiteBalanceGroupBox);
+    layout->addWidget(m_imageGroupBox);
     layout->addStretch();
 }
 
-void CameraSettingsWidget::insertTopWidget(QWidget *widget)
+void CameraSettingsWidget::insertWidgetAt(int index, QWidget *widget)
 {
     if (!widget) return;
     if (QWidget *oldParent = widget->parentWidget()) {
@@ -414,7 +428,7 @@ void CameraSettingsWidget::insertTopWidget(QWidget *widget)
             oldLayout->removeWidget(widget);
     }
     if (auto *pageLayout = qobject_cast<QVBoxLayout*>(layout()))
-        pageLayout->insertWidget(0, widget);
+        pageLayout->insertWidget(index, widget);
 }
 
 void CameraSettingsWidget::onHDRToggled(bool checked)
@@ -442,7 +456,12 @@ void CameraSettingsWidget::onExposureAutoToggled(bool checked)
 {
     m_userInitiated = true;
     m_exposureComboBox->setEnabled(!checked);
-    m_controller->setExposure(m_exposureComboBox->currentData().toInt(), checked);
+    m_uvcExposureSlider->setEnabled(!checked);
+    if (m_controller->hasTiny4kCapabilities())
+        m_controller->setTiny4kAutoExposure(checked);
+    else
+        m_controller->setExposure(
+            m_exposureComboBox->currentData().toInt(), checked);
     m_commandTimer->start(1000);
 }
 
@@ -593,10 +612,10 @@ void CameraSettingsWidget::updateFromState(const CameraController::CameraState &
 
     const bool tiny4k = m_controller->hasTiny4kCapabilities();
     m_tiny4kDeviceGroup->setVisible(tiny4k);
-    // Tiny 4K firmware 1.2.6.2 boots in a camera-managed exposure mode that
-    // neither its SDK nor UVC menu can restore after switching to manual.
-    // Do not expose a one-way control that can leave the image overexposed.
-    m_exposureAutoCheckBox->setVisible(!tiny4k);
+    m_uvcExposureRow->setVisible(tiny4k);
+    m_gainRow->setVisible(tiny4k);
+    m_backlightRow->setVisible(tiny4k);
+    m_exposureAutoCheckBox->setVisible(true);
     m_exposureLabel->setVisible(!tiny4k);
     m_exposureComboBox->setVisible(!tiny4k);
 
@@ -637,6 +656,7 @@ void CameraSettingsWidget::updateFromState(const CameraController::CameraState &
         m_exposureAutoCheckBox->setChecked(state.exposureAuto);
         m_exposureAutoCheckBox->blockSignals(false);
         m_exposureComboBox->setEnabled(!state.exposureAuto);
+        m_uvcExposureSlider->setEnabled(!state.exposureAuto);
         int exposureIndex = m_exposureComboBox->findData(state.exposure);
         if (exposureIndex >= 0) {
             m_exposureComboBox->blockSignals(true);
@@ -795,6 +815,7 @@ void CameraSettingsWidget::updateWhiteBalanceControls(int mode)
 void CameraSettingsWidget::setV4l2Mode(bool v4l2Only)
 {
     m_advancedGroupBox->setVisible(!v4l2Only);
+    m_exposureGroupBox->setVisible(!v4l2Only);
     m_tiny4kDeviceGroup->setVisible(!v4l2Only && m_controller->hasTiny4kCapabilities());
 }
 

--- a/src/gui/CameraSettingsWidget.cpp
+++ b/src/gui/CameraSettingsWidget.cpp
@@ -34,14 +34,19 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     connect(m_hdrCheckBox, &QCheckBox::toggled, this, &CameraSettingsWidget::onHDRToggled);
     groupLayout->addWidget(m_hdrCheckBox);
 
-    // FOV
+    // Named zoom/FOV presets
     QHBoxLayout *fovLayout = new QHBoxLayout();
-    fovLayout->addWidget(new QLabel("Field of View:", this));
+    fovLayout->addWidget(new QLabel("Zoom preset:", this));
     m_fovComboBox = new QComboBox(this);
     m_fovComboBox->addItem("Wide (86°)", 0);
     m_fovComboBox->addItem("Medium (78°)", 1);
     m_fovComboBox->addItem("Narrow (65°)", 2);
-    m_fovComboBox->setToolTip("Change the camera's field of view");
+    m_fovComboBox->addItem("Custom", Device::FovTypeNull);
+    if (auto *model = qobject_cast<QStandardItemModel*>(m_fovComboBox->model())) {
+        model->item(3)->setEnabled(false);
+    }
+    m_fovComboBox->setToolTip(
+        "Select a named field-of-view preset; manual zoom is shown as Custom");
     connect(m_fovComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged),
             this, &CameraSettingsWidget::onFOVChanged);
     fovLayout->addWidget(m_fovComboBox);

--- a/src/gui/CameraSettingsWidget.cpp
+++ b/src/gui/CameraSettingsWidget.cpp
@@ -38,6 +38,13 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     QVBoxLayout *groupLayout = new QVBoxLayout(m_exposureGroupBox);
     groupLayout->setContentsMargins(16, 16, 16, 16);
     groupLayout->setSpacing(10);
+    constexpr int controlLabelWidth = 90;
+
+    auto alignedLabel = [this](const QString &text) {
+        auto *label = new QLabel(text, this);
+        label->setMinimumWidth(controlLabelWidth);
+        return label;
+    };
 
     // Retained as an internal state holder for configuration and image
     // presets; the visible controls live beside the Zoom slider.
@@ -105,16 +112,16 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     deviceLayout->setContentsMargins(0, 0, 0, 0);
     deviceLayout->setSpacing(14);
 
-    auto addUvcSlider = [this, groupLayout](const QString &label,
+    auto addUvcSlider = [this, groupLayout, alignedLabel](const QString &label,
                                              QWidget *&rowWidget,
                                              QSlider *&slider,
                                              auto setter) {
         rowWidget = new QWidget(this);
         QHBoxLayout *row = new QHBoxLayout(rowWidget);
         row->setContentsMargins(0, 0, 0, 0);
-        row->addWidget(new QLabel(label, this));
+        row->addWidget(alignedLabel(label));
         slider = new QSlider(Qt::Horizontal, this);
-        row->addWidget(slider);
+        row->addWidget(slider, 1);
         QPushButton *reset = new QPushButton("Reset", this);
         row->addWidget(reset);
         connect(slider, &QSlider::valueChanged, this, [this, setter](int value) {
@@ -247,12 +254,12 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     m_brightnessAutoCheckBox->setToolTip("Enable automatic brightness (disables manual control)");
     connect(m_brightnessAutoCheckBox, &QCheckBox::toggled, this, &CameraSettingsWidget::onBrightnessAutoToggled);
     brightnessLayout->addWidget(m_brightnessAutoCheckBox);
-    brightnessLayout->addWidget(new QLabel("Brightness:", this));
+    brightnessLayout->addWidget(alignedLabel("Brightness:"));
     m_brightnessSlider = new QSlider(Qt::Horizontal, this);
     m_brightnessSlider->setRange(0, 255);
     m_brightnessSlider->setToolTip("Adjust image brightness (0-255)");
     connect(m_brightnessSlider, &QSlider::valueChanged, this, &CameraSettingsWidget::onBrightnessChanged);
-    brightnessLayout->addWidget(m_brightnessSlider);
+    brightnessLayout->addWidget(m_brightnessSlider, 1);
     QPushButton *brightnessReset = new QPushButton("Reset", this);
     connect(brightnessReset, &QPushButton::clicked, this, [this]() {
         const auto range = m_controller->getBrightnessRange();
@@ -271,12 +278,12 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     m_contrastAutoCheckBox->setToolTip("Enable automatic contrast (disables manual control)");
     connect(m_contrastAutoCheckBox, &QCheckBox::toggled, this, &CameraSettingsWidget::onContrastAutoToggled);
     contrastLayout->addWidget(m_contrastAutoCheckBox);
-    contrastLayout->addWidget(new QLabel("Contrast:", this));
+    contrastLayout->addWidget(alignedLabel("Contrast:"));
     m_contrastSlider = new QSlider(Qt::Horizontal, this);
     m_contrastSlider->setRange(0, 255);
     m_contrastSlider->setToolTip("Adjust image contrast (0-255)");
     connect(m_contrastSlider, &QSlider::valueChanged, this, &CameraSettingsWidget::onContrastChanged);
-    contrastLayout->addWidget(m_contrastSlider);
+    contrastLayout->addWidget(m_contrastSlider, 1);
     QPushButton *contrastReset = new QPushButton("Reset", this);
     connect(contrastReset, &QPushButton::clicked, this, [this]() {
         const auto range = m_controller->getContrastRange();
@@ -295,12 +302,12 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     m_saturationAutoCheckBox->setToolTip("Enable automatic saturation (disables manual control)");
     connect(m_saturationAutoCheckBox, &QCheckBox::toggled, this, &CameraSettingsWidget::onSaturationAutoToggled);
     saturationLayout->addWidget(m_saturationAutoCheckBox);
-    saturationLayout->addWidget(new QLabel("Saturation:", this));
+    saturationLayout->addWidget(alignedLabel("Saturation:"));
     m_saturationSlider = new QSlider(Qt::Horizontal, this);
     m_saturationSlider->setRange(0, 255);
     m_saturationSlider->setToolTip("Adjust color saturation (0-255)");
     connect(m_saturationSlider, &QSlider::valueChanged, this, &CameraSettingsWidget::onSaturationChanged);
-    saturationLayout->addWidget(m_saturationSlider);
+    saturationLayout->addWidget(m_saturationSlider, 1);
     QPushButton *saturationReset = new QPushButton("Reset", this);
     connect(saturationReset, &QPushButton::clicked, this, [this]() {
         const auto range = m_controller->getSaturationRange();
@@ -313,11 +320,11 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     imageLayout->addLayout(saturationLayout);
 
     QHBoxLayout *hueLayout = new QHBoxLayout();
-    hueLayout->addWidget(new QLabel("Hue:", this));
+    hueLayout->addWidget(alignedLabel("Hue:"));
     m_hueSlider = new QSlider(Qt::Horizontal, this);
     m_hueSlider->setRange(0, 100);
     connect(m_hueSlider, &QSlider::valueChanged, this, &CameraSettingsWidget::onHueChanged);
-    hueLayout->addWidget(m_hueSlider);
+    hueLayout->addWidget(m_hueSlider, 1);
     QPushButton *hueReset = new QPushButton("Reset", this);
     connect(hueReset, &QPushButton::clicked, this, [this]() {
         const auto range = m_controller->getHueRange();
@@ -330,12 +337,12 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
     hueLayout->addWidget(hueReset);
 
     QHBoxLayout *sharpnessLayout = new QHBoxLayout();
-    sharpnessLayout->addWidget(new QLabel("Sharpness:", this));
+    sharpnessLayout->addWidget(alignedLabel("Sharpness:"));
     m_sharpnessSlider = new QSlider(Qt::Horizontal, this);
     m_sharpnessSlider->setRange(0, 100);
     connect(m_sharpnessSlider, &QSlider::valueChanged,
             this, &CameraSettingsWidget::onSharpnessChanged);
-    sharpnessLayout->addWidget(m_sharpnessSlider);
+    sharpnessLayout->addWidget(m_sharpnessSlider, 1);
     QPushButton *sharpnessReset = new QPushButton("Reset", this);
     connect(sharpnessReset, &QPushButton::clicked, this, [this]() {
         const auto range = m_controller->getSharpnessRange();

--- a/src/gui/CameraSettingsWidget.cpp
+++ b/src/gui/CameraSettingsWidget.cpp
@@ -20,7 +20,7 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
             m_controller->saveConfig();
     });
     QVBoxLayout *layout = new QVBoxLayout(this);
-    layout->setContentsMargins(8, 14, 8, 14);
+    layout->setContentsMargins(8, 8, 8, 14);
     layout->setSpacing(14);
 
     m_advancedGroupBox = new QGroupBox("Advanced Camera Settings", this);

--- a/src/gui/CameraSettingsWidget.cpp
+++ b/src/gui/CameraSettingsWidget.cpp
@@ -72,7 +72,8 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
         m_exposureComboBox->addItem(shutterNames[i], 9 + i);
     connect(m_exposureComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged),
             this, &CameraSettingsWidget::onExposureChanged);
-    exposureLayout->addWidget(new QLabel("Shutter:", this));
+    m_exposureLabel = new QLabel("Shutter:", this);
+    exposureLayout->addWidget(m_exposureLabel);
     exposureLayout->addWidget(m_exposureComboBox);
     exposureLayout->addStretch();
     groupLayout->addLayout(exposureLayout);
@@ -382,10 +383,12 @@ void CameraSettingsWidget::updateFromState(const CameraController::CameraState &
     applyControlRanges();
 
     const bool tiny4k = m_controller->hasTiny4kCapabilities();
-    m_exposureAutoCheckBox->setText(tiny4k ? "Adaptive Exposure" : "Auto Exposure");
-    m_exposureAutoCheckBox->setToolTip(tiny4k
-        ? "Use the Tiny 4K's supported shutter-priority mode to adapt gain to changing light"
-        : "Continuously adapt exposure to changing light");
+    // Tiny 4K firmware 1.2.6.2 boots in a camera-managed exposure mode that
+    // neither its SDK nor UVC menu can restore after switching to manual.
+    // Do not expose a one-way control that can leave the image overexposed.
+    m_exposureAutoCheckBox->setVisible(!tiny4k);
+    m_exposureLabel->setVisible(!tiny4k);
+    m_exposureComboBox->setVisible(!tiny4k);
 
     // Only update if state differs, not user-initiated, command timer expired, and not settling
     bool commandInFlight = m_commandTimer->isActive();

--- a/src/gui/CameraSettingsWidget.h
+++ b/src/gui/CameraSettingsWidget.h
@@ -30,11 +30,11 @@ public:
     int getFOVMode() const { return m_fovComboBox->currentIndex(); }
     bool isFaceAEEnabled() const { return m_faceAECheckBox->isChecked(); }
     bool isFaceFocusEnabled() const { return m_faceFocusCheckBox->isChecked(); }
-    bool isBrightnessAuto() const { return m_brightnessAutoCheckBox->isChecked(); }
+    bool isBrightnessAuto() const { return false; }
     int getBrightness() const { return m_brightnessSlider->value(); }
-    bool isContrastAuto() const { return m_contrastAutoCheckBox->isChecked(); }
+    bool isContrastAuto() const { return false; }
     int getContrast() const { return m_contrastSlider->value(); }
-    bool isSaturationAuto() const { return m_saturationAutoCheckBox->isChecked(); }
+    bool isSaturationAuto() const { return false; }
     int getSaturation() const { return m_saturationSlider->value(); }
     int getWhiteBalance() const { return m_whiteBalanceComboBox->currentData().toInt(); }
     int getWhiteBalanceKelvin() const { return m_whiteBalanceKelvinSlider->value(); }
@@ -61,10 +61,11 @@ public:
         m_faceFocusCheckBox->blockSignals(false);
     }
     void setBrightnessAuto(bool enabled) {
+        Q_UNUSED(enabled);
         m_brightnessAutoCheckBox->blockSignals(true);
-        m_brightnessAutoCheckBox->setChecked(enabled);
+        m_brightnessAutoCheckBox->setChecked(false);
         m_brightnessAutoCheckBox->blockSignals(false);
-        m_brightnessSlider->setEnabled(!enabled);
+        m_brightnessSlider->setEnabled(true);
     }
     void setBrightness(int value) {
         m_brightnessSlider->blockSignals(true);
@@ -72,10 +73,11 @@ public:
         m_brightnessSlider->blockSignals(false);
     }
     void setContrastAuto(bool enabled) {
+        Q_UNUSED(enabled);
         m_contrastAutoCheckBox->blockSignals(true);
-        m_contrastAutoCheckBox->setChecked(enabled);
+        m_contrastAutoCheckBox->setChecked(false);
         m_contrastAutoCheckBox->blockSignals(false);
-        m_contrastSlider->setEnabled(!enabled);
+        m_contrastSlider->setEnabled(true);
     }
     void setContrast(int value) {
         m_contrastSlider->blockSignals(true);
@@ -83,10 +85,11 @@ public:
         m_contrastSlider->blockSignals(false);
     }
     void setSaturationAuto(bool enabled) {
+        Q_UNUSED(enabled);
         m_saturationAutoCheckBox->blockSignals(true);
-        m_saturationAutoCheckBox->setChecked(enabled);
+        m_saturationAutoCheckBox->setChecked(false);
         m_saturationAutoCheckBox->blockSignals(false);
-        m_saturationSlider->setEnabled(!enabled);
+        m_saturationSlider->setEnabled(true);
     }
     void setSaturation(int value) {
         m_saturationSlider->blockSignals(true);
@@ -116,12 +119,17 @@ private slots:
     void onFOVChanged(int index);
     void onFaceAEToggled(bool checked);
     void onFaceFocusToggled(bool checked);
+    void onExposureAutoToggled(bool checked);
+    void onExposureChanged(int index);
+    void onAntiFlickerChanged(int index);
     void onBrightnessAutoToggled(bool checked);
     void onBrightnessChanged(int value);
     void onContrastAutoToggled(bool checked);
     void onContrastChanged(int value);
     void onSaturationAutoToggled(bool checked);
     void onSaturationChanged(int value);
+    void onHueChanged(int value);
+    void onSharpnessChanged(int value);
     void onWhiteBalanceChanged(int index);
     void onWhiteBalanceKelvinChanged(int value);
 
@@ -132,6 +140,9 @@ private:
     QComboBox *m_fovComboBox;
     QCheckBox *m_faceAECheckBox;
     QCheckBox *m_faceFocusCheckBox;
+    QCheckBox *m_exposureAutoCheckBox;
+    QComboBox *m_exposureComboBox;
+    QComboBox *m_antiFlickerComboBox;
 
     // Image controls
     QCheckBox *m_brightnessAutoCheckBox;
@@ -140,6 +151,8 @@ private:
     QSlider *m_contrastSlider;
     QCheckBox *m_saturationAutoCheckBox;
     QSlider *m_saturationSlider;
+    QSlider *m_hueSlider;
+    QSlider *m_sharpnessSlider;
     QComboBox *m_whiteBalanceComboBox;
     QSlider *m_whiteBalanceKelvinSlider;
     QLabel *m_whiteBalanceKelvinLabel;
@@ -149,6 +162,8 @@ private:
     bool m_brightnessRangeApplied = false;
     bool m_contrastRangeApplied = false;
     bool m_saturationRangeApplied = false;
+    bool m_hueRangeApplied = false;
+    bool m_sharpnessRangeApplied = false;
     bool m_whiteBalanceRangeApplied = false;
 
     void applyControlRanges();

--- a/src/gui/CameraSettingsWidget.h
+++ b/src/gui/CameraSettingsWidget.h
@@ -7,6 +7,7 @@
 #include <QGroupBox>
 #include <QLabel>
 #include <QPushButton>
+#include <QSpinBox>
 #include <QSlider>
 #include <QTimer>
 #include <algorithm>
@@ -194,6 +195,13 @@ private:
     void updateWhiteBalanceKelvinLabel(int value);
 
     QGroupBox *m_advancedGroupBox;
+    QGroupBox *m_tiny4kDeviceGroup;
+    QSlider *m_uvcExposureSlider;
+    QSlider *m_gainSlider;
+    QSlider *m_backlightSlider;
+    bool m_uvcExposureRangeApplied = false;
+    bool m_gainRangeApplied = false;
+    bool m_backlightRangeApplied = false;
 };
 
 #endif // CAMERASETTINGSWIDGET_H

--- a/src/gui/CameraSettingsWidget.h
+++ b/src/gui/CameraSettingsWidget.h
@@ -6,6 +6,7 @@
 #include <QComboBox>
 #include <QGroupBox>
 #include <QLabel>
+#include <QPushButton>
 #include <QSlider>
 #include <QTimer>
 #include <algorithm>

--- a/src/gui/CameraSettingsWidget.h
+++ b/src/gui/CameraSettingsWidget.h
@@ -31,7 +31,6 @@ public:
     bool isHDREnabled() const { return m_hdrCheckBox->isChecked(); }
     int getFOVMode() const { return m_fovComboBox->currentIndex(); }
     bool isFaceAEEnabled() const { return m_faceAECheckBox->isChecked(); }
-    bool isFaceFocusEnabled() const { return m_faceFocusCheckBox->isChecked(); }
     bool isBrightnessAuto() const { return false; }
     int getBrightness() const { return m_brightnessSlider->value(); }
     bool isContrastAuto() const { return false; }
@@ -59,11 +58,6 @@ public:
         m_faceAECheckBox->blockSignals(true);
         m_faceAECheckBox->setChecked(enabled);
         m_faceAECheckBox->blockSignals(false);
-    }
-    void setFaceFocusEnabled(bool enabled) {
-        m_faceFocusCheckBox->blockSignals(true);
-        m_faceFocusCheckBox->setChecked(enabled);
-        m_faceFocusCheckBox->blockSignals(false);
     }
     void setBrightnessAuto(bool enabled) {
         Q_UNUSED(enabled);
@@ -141,7 +135,6 @@ private slots:
     void onHDRToggled(bool checked);
     void onFOVChanged(int index);
     void onFaceAEToggled(bool checked);
-    void onFaceFocusToggled(bool checked);
     void onExposureAutoToggled(bool checked);
     void onExposureChanged(int index);
     void onAntiFlickerChanged(int index);
@@ -162,7 +155,6 @@ private:
     QCheckBox *m_hdrCheckBox;
     QComboBox *m_fovComboBox;
     QCheckBox *m_faceAECheckBox;
-    QCheckBox *m_faceFocusCheckBox;
     QCheckBox *m_exposureAutoCheckBox;
     QLabel *m_exposureLabel;
     QComboBox *m_exposureComboBox;

--- a/src/gui/CameraSettingsWidget.h
+++ b/src/gui/CameraSettingsWidget.h
@@ -26,6 +26,7 @@ public:
 
     void updateFromState(const CameraController::CameraState &state);
     void setV4l2Mode(bool v4l2Only);
+    void insertTopWidget(QWidget *widget);
 
     // Getters for current UI state
     bool isHDREnabled() const { return m_hdrCheckBox->isChecked(); }

--- a/src/gui/CameraSettingsWidget.h
+++ b/src/gui/CameraSettingsWidget.h
@@ -37,6 +37,9 @@ public:
     int getContrast() const { return m_contrastSlider->value(); }
     bool isSaturationAuto() const { return false; }
     int getSaturation() const { return m_saturationSlider->value(); }
+    int getHue() const { return m_hueSlider->value(); }
+    int getSharpness() const { return m_sharpnessSlider->value(); }
+    int getAntiFlicker() const { return m_antiFlickerComboBox->currentData().toInt(); }
     int getWhiteBalance() const { return m_whiteBalanceComboBox->currentData().toInt(); }
     int getWhiteBalanceKelvin() const { return m_whiteBalanceKelvinSlider->value(); }
 
@@ -96,6 +99,24 @@ public:
         m_saturationSlider->blockSignals(true);
         m_saturationSlider->setValue(value);
         m_saturationSlider->blockSignals(false);
+    }
+    void setHue(int value) {
+        m_hueSlider->blockSignals(true);
+        m_hueSlider->setValue(value);
+        m_hueSlider->blockSignals(false);
+    }
+    void setSharpness(int value) {
+        m_sharpnessSlider->blockSignals(true);
+        m_sharpnessSlider->setValue(value);
+        m_sharpnessSlider->blockSignals(false);
+    }
+    void setAntiFlicker(int value) {
+        int index = m_antiFlickerComboBox->findData(value);
+        if (index >= 0) {
+            m_antiFlickerComboBox->blockSignals(true);
+            m_antiFlickerComboBox->setCurrentIndex(index);
+            m_antiFlickerComboBox->blockSignals(false);
+        }
     }
     void setWhiteBalance(int value) {
         m_whiteBalanceComboBox->blockSignals(true);

--- a/src/gui/CameraSettingsWidget.h
+++ b/src/gui/CameraSettingsWidget.h
@@ -26,7 +26,8 @@ public:
 
     void updateFromState(const CameraController::CameraState &state);
     void setV4l2Mode(bool v4l2Only);
-    void insertTopWidget(QWidget *widget);
+    void insertWidgetAt(int index, QWidget *widget);
+    QGroupBox *moreGroup() const { return m_tiny4kDeviceGroup; }
 
     // Getters for current UI state
     bool isHDREnabled() const { return m_hdrCheckBox->isChecked(); }
@@ -188,10 +189,16 @@ private:
     void updateWhiteBalanceKelvinLabel(int value);
 
     QGroupBox *m_advancedGroupBox;
+    QGroupBox *m_exposureGroupBox;
+    QGroupBox *m_whiteBalanceGroupBox;
+    QGroupBox *m_imageGroupBox;
     QGroupBox *m_tiny4kDeviceGroup;
     QSlider *m_uvcExposureSlider;
     QSlider *m_gainSlider;
     QSlider *m_backlightSlider;
+    QWidget *m_uvcExposureRow;
+    QWidget *m_gainRow;
+    QWidget *m_backlightRow;
     bool m_uvcExposureRangeApplied = false;
     bool m_gainRangeApplied = false;
     bool m_backlightRangeApplied = false;

--- a/src/gui/CameraSettingsWidget.h
+++ b/src/gui/CameraSettingsWidget.h
@@ -27,7 +27,7 @@ public:
     void updateFromState(const CameraController::CameraState &state);
     void setV4l2Mode(bool v4l2Only);
     void insertWidgetAt(int index, QWidget *widget);
-    QGroupBox *moreGroup() const { return m_tiny4kDeviceGroup; }
+    QWidget *moreGroup() const { return m_tiny4kDeviceGroup; }
 
     // Getters for current UI state
     bool isHDREnabled() const { return m_hdrCheckBox->isChecked(); }
@@ -192,7 +192,7 @@ private:
     QGroupBox *m_exposureGroupBox;
     QGroupBox *m_whiteBalanceGroupBox;
     QGroupBox *m_imageGroupBox;
-    QGroupBox *m_tiny4kDeviceGroup;
+    QWidget *m_tiny4kDeviceGroup;
     QSlider *m_uvcExposureSlider;
     QSlider *m_gainSlider;
     QSlider *m_backlightSlider;

--- a/src/gui/CameraSettingsWidget.h
+++ b/src/gui/CameraSettingsWidget.h
@@ -141,6 +141,7 @@ private:
     QCheckBox *m_faceAECheckBox;
     QCheckBox *m_faceFocusCheckBox;
     QCheckBox *m_exposureAutoCheckBox;
+    QLabel *m_exposureLabel;
     QComboBox *m_exposureComboBox;
     QComboBox *m_antiFlickerComboBox;
 

--- a/src/gui/FilterPreviewWidget.cpp
+++ b/src/gui/FilterPreviewWidget.cpp
@@ -238,6 +238,7 @@ void FilterPreviewWidget::initializeGL()
 
     ensureProgram();
     ensureGeometry();
+    m_glResourcesCleaned = false;
 }
 
 void FilterPreviewWidget::resizeGL(int w, int h)
@@ -450,6 +451,10 @@ QSizeF FilterPreviewWidget::frameAspectSize() const
 
 void FilterPreviewWidget::cleanupGLResources()
 {
+    if (m_glResourcesCleaned) {
+        return;
+    }
+
     if (m_texture) {
         m_texture->destroy();
         m_texture.reset();
@@ -465,17 +470,24 @@ void FilterPreviewWidget::cleanupGLResources()
     }
     m_program.reset();
     m_geometryInitialized = false;
+    m_glResourcesCleaned = true;
 }
 
 void FilterPreviewWidget::handleContextAboutToBeDestroyed()
 {
-    if (!isValid()) {
+    QOpenGLContext *glContext = context();
+    if (!glContext || m_glResourcesCleaned) {
         return;
     }
 
     makeCurrent();
+    if (QOpenGLContext::currentContext() != glContext) {
+        return;
+    }
     cleanupGLResources();
     doneCurrent();
+    disconnect(glContext, &QOpenGLContext::aboutToBeDestroyed,
+               this, &FilterPreviewWidget::handleContextAboutToBeDestroyed);
 }
 
 void FilterPreviewWidget::applyEffectsUniforms()

--- a/src/gui/FilterPreviewWidget.h
+++ b/src/gui/FilterPreviewWidget.h
@@ -110,6 +110,7 @@ private:
     QOpenGLBuffer m_vertexBuffer;
     QOpenGLVertexArrayObject m_vertexArray;
     bool m_geometryInitialized;
+    bool m_glResourcesCleaned = true;
 
 private slots:
     void handleContextAboutToBeDestroyed();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -355,6 +355,28 @@ void MainWindow::setupUI()
     m_cameraWarningLabel->setVisible(false);
     statusLayout->addWidget(m_cameraWarningLabel);
 
+    QWidget *actionRow = new QWidget(m_statusBanner);
+    actionRow->setObjectName("actionRow");
+    QHBoxLayout *actionLayout = new QHBoxLayout(actionRow);
+    actionLayout->setContentsMargins(0, 0, 0, 0);
+    actionLayout->setSpacing(14);
+
+    m_previewToggleButton = new QPushButton(tr("Start Preview"), actionRow);
+    m_previewToggleButton->setObjectName("primaryAction");
+    m_previewToggleButton->setCheckable(true);
+    connect(m_previewToggleButton, &QPushButton::toggled,
+            this, &MainWindow::onTogglePreview);
+    actionLayout->addWidget(m_previewToggleButton, 1);
+
+    m_reconnectButton = new QPushButton(tr("Reconnect"), actionRow);
+    m_reconnectButton->setObjectName("secondaryAction");
+    connect(m_reconnectButton, &QPushButton::clicked, this, [this]() {
+        m_controller->disconnectFromCamera();
+        m_controller->connectToCamera();
+    });
+    actionLayout->addWidget(m_reconnectButton);
+    statusLayout->addWidget(actionRow);
+
     scrollLayout->addWidget(m_statusBanner);
 
     // Camera selector (hidden when only one OBSBOT is present)
@@ -379,29 +401,6 @@ void MainWindow::setupUI()
         scrollLayout->addWidget(selectorRow);
     }
     populateCameraSelector();
-
-    QWidget *actionRow = new QWidget(scrollContent);
-    actionRow->setObjectName("actionRow");
-    QHBoxLayout *actionLayout = new QHBoxLayout(actionRow);
-    actionLayout->setContentsMargins(0, 0, 0, 0);
-    actionLayout->setSpacing(14);
-
-    m_previewToggleButton = new QPushButton(tr("Start Preview"), actionRow);
-    m_previewToggleButton->setObjectName("primaryAction");
-    m_previewToggleButton->setCheckable(true);
-    connect(m_previewToggleButton, &QPushButton::toggled,
-            this, &MainWindow::onTogglePreview);
-    actionLayout->addWidget(m_previewToggleButton, 1);
-
-    m_reconnectButton = new QPushButton(tr("Reconnect"), actionRow);
-    m_reconnectButton->setObjectName("secondaryAction");
-    connect(m_reconnectButton, &QPushButton::clicked, this, [this]() {
-        m_controller->disconnectFromCamera();
-        m_controller->connectToCamera();
-    });
-    actionLayout->addWidget(m_reconnectButton);
-
-    scrollLayout->addWidget(actionRow);
 
     m_trackingWidget = new TrackingControlWidget(m_controller, this);
     m_ptzWidget = new PTZControlWidget(m_controller, this);
@@ -1055,9 +1054,9 @@ void MainWindow::onCameraConnected(const CameraController::CameraInfo &info)
 {
     QString deviceText;
     if (info.version.isEmpty()) {
-        deviceText = QString("✓ Connected:\n%1").arg(info.name);
+        deviceText = info.name;
     } else {
-        deviceText = QString("✓ Connected:\n%1\n(v%2)")
+        deviceText = QString("%1\n(v%2)")
             .arg(info.name)
             .arg(info.version);
     }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1056,7 +1056,12 @@ void MainWindow::onCameraConnected(const CameraController::CameraInfo &info)
     m_trackingWidget->setV4l2Mode(v4l2Mode);
     m_settingsWidget->setV4l2Mode(v4l2Mode);
 
-    QTimer::singleShot(100, this, [this]() {
+    // cameraConnected is emitted immediately before the controller publishes
+    // the camera's initial state. Capture the configured/user-intended values
+    // now, otherwise that initial state (Tiny 4K boots with Wide FOV) replaces
+    // the UI value before the delayed reapply runs.
+    const CameraController::CameraState intendedState = getUIState();
+    QTimer::singleShot(100, this, [this, intendedState]() {
         if (m_isCameraSwitch) {
             // Pull the new camera's actual state into the UI
             // without pushing the old camera's state back
@@ -1064,7 +1069,7 @@ void MainWindow::onCameraConnected(const CameraController::CameraInfo &info)
             onStateChanged(state);
             m_isCameraSwitch = false;
         } else {
-            m_controller->applyCurrentStateToCamera(getUIState());
+            m_controller->applyCurrentStateToCamera(intendedState);
         }
     });
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -306,7 +306,7 @@ void MainWindow::setupUI()
     m_previewStack->addWidget(m_previewPlaceholder);
     m_previewStack->setCurrentWidget(m_previewPlaceholder);
 
-    // Control column (scrollable so window can be smaller)
+    // Control column: status and tab bar stay fixed; each tab scrolls itself.
     m_controlCard = new QFrame(m_splitter);
     m_controlCard->setObjectName("controlCard");
     m_controlCard->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
@@ -316,14 +316,7 @@ void MainWindow::setupUI()
     controlLayout->setContentsMargins(0, 0, 0, 0);
     controlLayout->setSpacing(0);
 
-    QScrollArea *controlScroll = new QScrollArea(m_controlCard);
-    controlScroll->setObjectName("controlScroll");
-    controlScroll->setWidgetResizable(true);
-    controlScroll->setFrameShape(QFrame::NoFrame);
-    controlScroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    controlScroll->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-
-    QWidget *scrollContent = new QWidget(controlScroll);
+    QWidget *scrollContent = new QWidget(m_controlCard);
     scrollContent->setMinimumWidth(0);  // allow shrinking to viewport so content is not clipped
     QVBoxLayout *scrollLayout = new QVBoxLayout(scrollContent);
     scrollLayout->setContentsMargins(18, 20, 18, 20);
@@ -423,20 +416,38 @@ void MainWindow::setupUI()
     m_ptzWidget->setCameraSettingsWidget(m_settingsWidget);
     m_trackingWidget->setPositionPresetsWidget(
         m_ptzWidget->positionPresetsGroup());
+    m_settingsWidget->insertTopWidget(m_trackingWidget->focusGroup());
+    m_settingsWidget->insertTopWidget(m_ptzWidget->imagePresetsGroup());
     connect(m_ptzWidget, &PTZControlWidget::presetUpdated,
             this, &MainWindow::onPresetUpdated);
+    connect(m_trackingWidget, &TrackingControlWidget::invertControlsChanged,
+            this, [this](bool invertX, bool invertY) {
+        auto settings = m_controller->getConfig().getSettings();
+        settings.invertGimbalX = invertX;
+        settings.invertGimbalY = invertY;
+        m_controller->getConfig().setSettings(settings);
+        m_controller->saveConfig();
+    });
 
     m_tabWidget = new QTabWidget(scrollContent);
     m_tabWidget->setObjectName("controlTabs");
     m_tabWidget->setDocumentMode(true);
-    m_tabWidget->addTab(m_trackingWidget, tr("Console"));
-    m_tabWidget->addTab(m_ptzWidget, tr("Presets"));
-    m_tabWidget->addTab(m_settingsWidget, tr("Image"));
+    auto addScrollableTab = [this](QWidget *content, const QString &label) {
+        auto *area = new QScrollArea(m_tabWidget);
+        area->setWidgetResizable(true);
+        area->setFrameShape(QFrame::NoFrame);
+        area->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+        area->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+        area->setWidget(content);
+        return m_tabWidget->addTab(area, label);
+    };
+    addScrollableTab(m_trackingWidget, tr("Console"));
+    addScrollableTab(m_settingsWidget, tr("Image"));
     m_effectsWidget = new VideoEffectsWidget(this);
     connect(m_effectsWidget, &VideoEffectsWidget::effectsChanged,
             this, &MainWindow::onVideoEffectsChanged);
-    m_tabWidget->addTab(m_effectsWidget, tr("FX"));
-    scrollLayout->addWidget(m_tabWidget);
+    addScrollableTab(m_effectsWidget, tr("FX"));
+    scrollLayout->addWidget(m_tabWidget, 1);
     m_effectsWidget->reset();
 
     // Resize tab widget to fit the current tab (QTabWidget normally sizes to the tallest)
@@ -510,7 +521,7 @@ void MainWindow::setupUI()
     virtualLayout->addWidget(virtualResolutionHint);
     virtualCameraPageLayout->addWidget(virtualCameraGroup);
     virtualCameraPageLayout->addStretch();
-    m_tabWidget->addTab(virtualCameraPage, tr("Virtual Camera"));
+    addScrollableTab(virtualCameraPage, tr("Virtual Camera"));
 
     QWidget *settingsPage = new QWidget(m_tabWidget);
     QVBoxLayout *settingsPageLayout = new QVBoxLayout(settingsPage);
@@ -545,6 +556,7 @@ void MainWindow::setupUI()
     snapshotLayout->addWidget(snapshotHint);
 
     settingsPageLayout->addWidget(snapshotGroup);
+    settingsPageLayout->addWidget(m_trackingWidget->gimbalControlGroup());
 
     m_startMinimizedCheckbox = new QCheckBox(
         tr("Launch minimized / Close to tray"), settingsPage);
@@ -553,12 +565,9 @@ void MainWindow::setupUI()
             this, &MainWindow::onStartMinimizedToggled);
     settingsPageLayout->addWidget(m_startMinimizedCheckbox);
     settingsPageLayout->addStretch();
-    m_tabWidget->addTab(settingsPage, tr("Settings"));
+    addScrollableTab(settingsPage, tr("Settings"));
 
-    scrollLayout->addStretch();
-
-    controlScroll->setWidget(scrollContent);
-    controlLayout->addWidget(controlScroll);
+    controlLayout->addWidget(scrollContent);
 
     m_splitter->addWidget(m_previewCard);
     m_splitter->addWidget(m_controlCard);
@@ -1151,10 +1160,9 @@ void MainWindow::onStateChanged(const CameraController::CameraState &state)
 
 void MainWindow::fitTabToCurrentPage()
 {
-    QWidget *page = m_tabWidget->currentWidget();
-    if (!page) return;
-    m_tabWidget->setMaximumHeight(
-        page->sizeHint().height() + m_tabWidget->tabBar()->sizeHint().height());
+    m_tabWidget->setMaximumHeight(QWIDGETSIZE_MAX);
+    m_tabWidget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
+    m_tabWidget->updateGeometry();
 }
 
 void MainWindow::onCommandFailed(const QString &description, int errorCode)
@@ -1177,8 +1185,7 @@ void MainWindow::updateStatus()
     if (m_statusTimer->interval() != desiredInterval)
         m_statusTimer->setInterval(desiredInterval);
 
-    const bool imageTabVisible = !background
-        && m_tabWidget->currentWidget() == m_settingsWidget;
+    const bool imageTabVisible = !background && m_settingsWidget->isVisible();
     const bool pollImageControls = imageTabVisible && (++m_pollTick % 4 == 0);
     auto state = m_controller->pollCurrentState(pollImageControls);
 
@@ -1290,6 +1297,8 @@ void MainWindow::loadConfiguration()
     m_trackingWidget->setTrackSpeed(settings.trackSpeed);
     m_trackingWidget->setTrackingStyle(settings.trackingStyle);
     m_trackingWidget->setAudioAutoGain(settings.audioAutoGain);
+    m_trackingWidget->setInvertControls(
+        settings.invertGimbalX, settings.invertGimbalY);
     m_settingsWidget->setHDREnabled(settings.hdr);
     m_settingsWidget->setFOVMode(settings.fov);
     m_settingsWidget->setFaceAEEnabled(settings.faceAE);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -432,7 +432,7 @@ void MainWindow::setupUI()
     m_effectsWidget = new VideoEffectsWidget(this);
     connect(m_effectsWidget, &VideoEffectsWidget::effectsChanged,
             this, &MainWindow::onVideoEffectsChanged);
-    m_tabWidget->addTab(m_effectsWidget, tr("Creative FX"));
+    m_tabWidget->addTab(m_effectsWidget, tr("FX"));
     scrollLayout->addWidget(m_tabWidget);
     m_effectsWidget->reset();
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1144,7 +1144,7 @@ void MainWindow::updateStatus()
     auto state = m_controller->getCurrentState();
 
     QStringList statusParts;
-    statusParts << QString("AI: %1").arg(state.aiMode == 0 ? "Off" : "On");
+    statusParts << QString("AI: %1").arg(state.autoFramingEnabled ? "On" : "Off");
     statusParts << QString("Zoom: %1%").arg(state.zoomRatio);
     statusParts << QString("HDR: %1").arg(state.hdrEnabled ? "On" : "Off");
     statusParts << QString("Face AE: %1").arg(state.faceAEEnabled ? "On" : "Off");

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -636,8 +636,8 @@ void MainWindow::applyModernStyle()
 
     const QColor accentBackground = withAlphaF(blendColors(highlight, cardBackground, 0.25), 0.48);
     const QColor accentBorder = withAlphaF(blendColors(highlight, cardBorder, 0.25), 0.75);
-    const QColor accentChipBackground = withAlphaF(blendColors(highlight, cardBackground, 0.15), 0.7);
     const QColor accentChipText = blendColors(highlightedText.isValid() ? highlightedText : brightText, text, 0.2);
+    const QColor connectedStatusColor = QColor(QStringLiteral("#22c55e"));
 
     const QColor warningColor = blendColors(highlight.lighter(140), text, 0.4);
 
@@ -758,7 +758,7 @@ void MainWindow::applyModernStyle()
         .arg(toCssColor(accentBorder))
         .arg(toCssColor(mutedChipBackground))
         .arg(toCssColor(mutedChipText))
-        .arg(toCssColor(accentChipBackground))
+        .arg(toCssColor(connectedStatusColor))
         .arg(toCssColor(accentChipText))
         .arg(toCssColor(warningColor))
         .arg(toCssColor(previewPlaceholderText))

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -558,7 +558,11 @@ void MainWindow::setupUI()
 
     QLabel *snapshotHint = new QLabel(tr("Use Copy to also place the image on the clipboard. Leave blank for the default path shown above."), snapshotGroup);
     snapshotHint->setWordWrap(true);
-    snapshotHint->setStyleSheet("color: palette(mid); font-size: 11px;");
+    snapshotHint->setForegroundRole(QPalette::PlaceholderText);
+    QFont snapshotHintFont = snapshotHint->font();
+    snapshotHintFont.setPointSizeF(
+        std::max(1.0, snapshotHintFont.pointSizeF() - 1.0));
+    snapshotHint->setFont(snapshotHintFont);
     snapshotLayout->addWidget(snapshotHint);
 
     settingsPageLayout->addWidget(snapshotGroup);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -418,7 +418,7 @@ void MainWindow::setupUI()
     m_tabWidget->setDocumentMode(true);
     m_tabWidget->addTab(m_trackingWidget, tr("Tracking"));
     m_tabWidget->addTab(m_ptzWidget, tr("Presets"));
-    m_tabWidget->addTab(m_settingsWidget, tr("Camera Image"));
+    m_tabWidget->addTab(m_settingsWidget, tr("Image"));
     m_effectsWidget = new VideoEffectsWidget(this);
     connect(m_effectsWidget, &VideoEffectsWidget::effectsChanged,
             this, &MainWindow::onVideoEffectsChanged);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1313,6 +1313,7 @@ void MainWindow::loadConfiguration()
         const auto &preset = settings.presets[static_cast<size_t>(i)];
         presetStates[static_cast<size_t>(i)] = {
             preset.defined,
+            QString::fromStdString(preset.name),
             preset.pan,
             preset.tilt,
             preset.zoom
@@ -1577,7 +1578,8 @@ void MainWindow::onPreviewFormatChanged(const QString &formatId)
     updateVirtualCameraStreamerState();
 }
 
-void MainWindow::onPresetUpdated(int index, double pan, double tilt, double zoom, bool defined)
+void MainWindow::onPresetUpdated(int index, double pan, double tilt, double zoom,
+                                 bool defined, const QString &name)
 {
     auto settings = m_controller->getConfig().getSettings();
     if (index < 0 || index >= static_cast<int>(settings.presets.size())) {
@@ -1586,6 +1588,7 @@ void MainWindow::onPresetUpdated(int index, double pan, double tilt, double zoom
 
     auto &preset = settings.presets[static_cast<size_t>(index)];
     preset.defined = defined;
+    preset.name = name.toStdString();
     preset.pan = pan;
     preset.tilt = tilt;
     preset.zoom = zoom;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -344,7 +344,8 @@ void MainWindow::setupUI()
     statusTextLayout->setSpacing(6);
     m_statusChip = new QLabel(tr("Offline"), m_statusBanner);
     m_statusChip->setObjectName("statusChip");
-    statusTextLayout->addWidget(m_statusChip);
+    m_statusChip->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Preferred);
+    statusTextLayout->addWidget(m_statusChip, 0, Qt::AlignLeft);
 
     m_deviceInfoLabel = new QLabel(tr("Connecting to camera..."), m_statusBanner);
     m_deviceInfoLabel->setObjectName("deviceInfoLabel");

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -342,7 +342,7 @@ void MainWindow::setupUI()
     QVBoxLayout *statusTextLayout = new QVBoxLayout();
     statusTextLayout->setContentsMargins(0, 0, 0, 0);
     statusTextLayout->setSpacing(6);
-    m_statusChip = new QLabel(tr("Camera • Offline"), m_statusBanner);
+    m_statusChip = new QLabel(tr("Offline"), m_statusBanner);
     m_statusChip->setObjectName("statusChip");
     statusTextLayout->addWidget(m_statusChip);
 
@@ -948,7 +948,7 @@ void MainWindow::updatePreviewControls()
 void MainWindow::updateStatusBanner(bool connected)
 {
     m_statusBanner->setProperty("state", connected ? "connected" : "disconnected");
-    m_statusChip->setText(connected ? tr("Camera • Online") : tr("Camera • Offline"));
+    m_statusChip->setText(connected ? tr("Online") : tr("Offline"));
     m_statusBanner->style()->unpolish(m_statusBanner);
     m_statusBanner->style()->polish(m_statusBanner);
     m_statusBanner->update();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1172,7 +1172,7 @@ void MainWindow::updateStatus()
 
     QStringList statusParts;
     statusParts << QString("AI: %1").arg(state.autoFramingEnabled ? "On" : "Off");
-    statusParts << QString("Zoom: %1%").arg(state.zoomRatio);
+    statusParts << QString("Zoom: %1x").arg(state.zoom, 0, 'f', 2);
     statusParts << QString("HDR: %1").arg(state.hdrEnabled ? "On" : "Off");
     statusParts << QString("Face AE: %1").arg(state.faceAEEnabled ? "On" : "Off");
     statusParts << QString("Focus: %1").arg(state.autoFocusEnabled ? "Auto" : "Manual");

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -416,8 +416,8 @@ void MainWindow::setupUI()
     m_ptzWidget->setCameraSettingsWidget(m_settingsWidget);
     m_trackingWidget->setPositionPresetsWidget(
         m_ptzWidget->positionPresetsGroup());
-    m_settingsWidget->insertTopWidget(m_trackingWidget->focusGroup());
-    m_settingsWidget->insertTopWidget(m_ptzWidget->imagePresetsGroup());
+    m_settingsWidget->insertWidgetAt(0, m_ptzWidget->imagePresetsGroup());
+    m_settingsWidget->insertWidgetAt(2, m_trackingWidget->focusGroup());
     connect(m_ptzWidget, &PTZControlWidget::presetUpdated,
             this, &MainWindow::onPresetUpdated);
     connect(m_trackingWidget, &TrackingControlWidget::invertControlsChanged,
@@ -443,6 +443,12 @@ void MainWindow::setupUI()
     };
     addScrollableTab(m_trackingWidget, tr("Console"));
     addScrollableTab(m_settingsWidget, tr("Image"));
+    QWidget *morePage = new QWidget(m_tabWidget);
+    QVBoxLayout *morePageLayout = new QVBoxLayout(morePage);
+    morePageLayout->setContentsMargins(8, 8, 8, 14);
+    morePageLayout->addWidget(m_settingsWidget->moreGroup());
+    morePageLayout->addStretch();
+    addScrollableTab(morePage, tr("More"));
     m_effectsWidget = new VideoEffectsWidget(this);
     connect(m_effectsWidget, &VideoEffectsWidget::effectsChanged,
             this, &MainWindow::onVideoEffectsChanged);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -436,7 +436,12 @@ void MainWindow::setupUI()
     });
     QTimer::singleShot(0, this, &MainWindow::fitTabToCurrentPage);
 
-    QGroupBox *virtualCameraGroup = new QGroupBox(tr("Virtual Camera"), scrollContent);
+    QWidget *virtualCameraPage = new QWidget(m_tabWidget);
+    QVBoxLayout *virtualCameraPageLayout = new QVBoxLayout(virtualCameraPage);
+    virtualCameraPageLayout->setContentsMargins(8, 14, 8, 14);
+    virtualCameraPageLayout->setSpacing(14);
+
+    QGroupBox *virtualCameraGroup = new QGroupBox(tr("Virtual Camera"), virtualCameraPage);
     QVBoxLayout *virtualLayout = new QVBoxLayout(virtualCameraGroup);
     virtualLayout->setContentsMargins(16, 16, 16, 16);
     virtualLayout->setSpacing(10);
@@ -493,9 +498,16 @@ void MainWindow::setupUI()
     virtualResolutionHint->setWordWrap(true);
     virtualResolutionHint->setStyleSheet("color: palette(mid); font-size: 11px;");
     virtualLayout->addWidget(virtualResolutionHint);
-    scrollLayout->addWidget(virtualCameraGroup);
+    virtualCameraPageLayout->addWidget(virtualCameraGroup);
+    virtualCameraPageLayout->addStretch();
+    m_tabWidget->addTab(virtualCameraPage, tr("Virtual Camera"));
 
-    QGroupBox *snapshotGroup = new QGroupBox(tr("Snapshots"), scrollContent);
+    QWidget *settingsPage = new QWidget(m_tabWidget);
+    QVBoxLayout *settingsPageLayout = new QVBoxLayout(settingsPage);
+    settingsPageLayout->setContentsMargins(8, 14, 8, 14);
+    settingsPageLayout->setSpacing(14);
+
+    QGroupBox *snapshotGroup = new QGroupBox(tr("Snapshots"), settingsPage);
     QVBoxLayout *snapshotLayout = new QVBoxLayout(snapshotGroup);
     snapshotLayout->setContentsMargins(16, 16, 16, 16);
     snapshotLayout->setSpacing(10);
@@ -522,15 +534,18 @@ void MainWindow::setupUI()
     snapshotHint->setStyleSheet("color: palette(mid); font-size: 11px;");
     snapshotLayout->addWidget(snapshotHint);
 
-    scrollLayout->addWidget(snapshotGroup);
+    settingsPageLayout->addWidget(snapshotGroup);
 
-    scrollLayout->addStretch();
-
-    m_startMinimizedCheckbox = new QCheckBox(tr("Launch minimized / Close to tray"), scrollContent);
+    m_startMinimizedCheckbox = new QCheckBox(
+        tr("Launch minimized / Close to tray"), settingsPage);
     m_startMinimizedCheckbox->setObjectName("footerCheckbox");
     connect(m_startMinimizedCheckbox, &QCheckBox::toggled,
             this, &MainWindow::onStartMinimizedToggled);
-    scrollLayout->addWidget(m_startMinimizedCheckbox);
+    settingsPageLayout->addWidget(m_startMinimizedCheckbox);
+    settingsPageLayout->addStretch();
+    m_tabWidget->addTab(settingsPage, tr("Settings"));
+
+    scrollLayout->addStretch();
 
     m_statusLabel = new QLabel(tr("Status: Initializing..."), scrollContent);
     m_statusLabel->setObjectName("footerStatus");

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -337,21 +337,17 @@ void MainWindow::setupUI()
 
     QHBoxLayout *statusMainLayout = new QHBoxLayout();
     statusMainLayout->setContentsMargins(0, 0, 0, 0);
-    statusMainLayout->setSpacing(14);
+    statusMainLayout->setSpacing(10);
 
-    QVBoxLayout *statusTextLayout = new QVBoxLayout();
-    statusTextLayout->setContentsMargins(0, 0, 0, 0);
-    statusTextLayout->setSpacing(6);
-    m_statusChip = new QLabel(tr("Offline"), m_statusBanner);
+    m_statusChip = new QLabel(m_statusBanner);
     m_statusChip->setObjectName("statusChip");
-    m_statusChip->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Preferred);
-    statusTextLayout->addWidget(m_statusChip, 0, Qt::AlignLeft);
+    m_statusChip->setFixedSize(12, 12);
+    statusMainLayout->addWidget(m_statusChip, 0, Qt::AlignVCenter);
 
     m_deviceInfoLabel = new QLabel(tr("Connecting to camera..."), m_statusBanner);
     m_deviceInfoLabel->setObjectName("deviceInfoLabel");
     m_deviceInfoLabel->setWordWrap(true);
-    statusTextLayout->addWidget(m_deviceInfoLabel);
-    statusMainLayout->addLayout(statusTextLayout, 1);
+    statusMainLayout->addWidget(m_deviceInfoLabel, 1);
 
     QWidget *actionRow = new QWidget(m_statusBanner);
     actionRow->setObjectName("actionRow");
@@ -370,6 +366,8 @@ void MainWindow::setupUI()
     m_reconnectButton->setObjectName("secondaryAction");
     connect(m_reconnectButton, &QPushButton::clicked, this, [this]() {
         m_controller->disconnectFromCamera();
+        m_deviceInfoLabel->setText(tr("Connecting to camera..."));
+        m_statusLabel->setText(tr("Status: Connecting..."));
         m_controller->connectToCamera();
     });
     actionLayout->addWidget(m_reconnectButton);
@@ -381,6 +379,11 @@ void MainWindow::setupUI()
     m_cameraWarningLabel->setWordWrap(true);
     m_cameraWarningLabel->setVisible(false);
     statusLayout->addWidget(m_cameraWarningLabel);
+
+    m_statusLabel = new QLabel(tr("Status: Initializing..."), m_statusBanner);
+    m_statusLabel->setObjectName("footerStatus");
+    m_statusLabel->setWordWrap(true);
+    statusLayout->addWidget(m_statusLabel);
 
     scrollLayout->addWidget(m_statusBanner);
 
@@ -551,11 +554,6 @@ void MainWindow::setupUI()
 
     scrollLayout->addStretch();
 
-    m_statusLabel = new QLabel(tr("Status: Initializing..."), scrollContent);
-    m_statusLabel->setObjectName("footerStatus");
-    m_statusLabel->setWordWrap(true);
-    scrollLayout->addWidget(m_statusLabel);
-
     controlScroll->setWidget(scrollContent);
     controlLayout->addWidget(controlScroll);
 
@@ -695,12 +693,9 @@ void MainWindow::applyModernStyle()
             font-weight: 600;
         }
         QLabel#statusChip {
-            padding: 6px 12px;
-            border-radius: 14px;
+            border-radius: 6px;
             background-color: %7;
             color: %8;
-            font-weight: 600;
-            letter-spacing: 0.3px;
         }
         QFrame#statusBanner[state="connected"] QLabel#statusChip {
             background-color: %9;
@@ -949,7 +944,6 @@ void MainWindow::updatePreviewControls()
 void MainWindow::updateStatusBanner(bool connected)
 {
     m_statusBanner->setProperty("state", connected ? "connected" : "disconnected");
-    m_statusChip->setText(connected ? tr("Online") : tr("Offline"));
     m_statusBanner->style()->unpolish(m_statusBanner);
     m_statusBanner->style()->polish(m_statusBanner);
     m_statusBanner->update();
@@ -1115,7 +1109,7 @@ void MainWindow::onCameraConnected(const CameraController::CameraInfo &info)
 void MainWindow::onCameraDisconnected()
 {
     m_isCameraSwitch = false;
-    m_deviceInfoLabel->setText("❌ Camera Disconnected");
+    m_deviceInfoLabel->setText(tr("Camera disconnected"));
     updateStatusBanner(false);
     m_statusLabel->setText("Status: Not connected");
     m_cameraWarningLabel->setVisible(false);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1249,6 +1249,7 @@ void MainWindow::loadConfiguration()
     m_trackingWidget->setHumanSubMode(settings.aiSubMode);
     m_trackingWidget->setAutoZoomEnabled(settings.autoZoom);
     m_trackingWidget->setTrackSpeed(settings.trackSpeed);
+    m_trackingWidget->setTrackingStyle(settings.trackingStyle);
     m_trackingWidget->setAudioAutoGain(settings.audioAutoGain);
     m_settingsWidget->setHDREnabled(settings.hdr);
     m_settingsWidget->setFOVMode(settings.fov);
@@ -1386,6 +1387,7 @@ CameraController::CameraState MainWindow::getUIState() const
     state.aiSubMode = m_trackingWidget->currentHumanSubMode();
     state.autoZoomEnabled = m_trackingWidget->isAutoZoomEnabled();
     state.trackSpeedMode = m_trackingWidget->currentTrackSpeed();
+    state.trackingStyle = m_trackingWidget->currentTrackingStyle();
     state.audioAutoGainEnabled = m_trackingWidget->isAudioAutoGainEnabled();
     state.hdrEnabled = m_settingsWidget->isHDREnabled();
     state.fovMode = m_settingsWidget->getFOVMode();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1291,7 +1291,7 @@ void MainWindow::loadConfiguration()
     m_settingsWidget->setHDREnabled(settings.hdr);
     m_settingsWidget->setFOVMode(settings.fov);
     m_settingsWidget->setFaceAEEnabled(settings.faceAE);
-    m_settingsWidget->setFaceFocusEnabled(settings.faceFocus);
+    m_trackingWidget->setFaceFocusEnabled(settings.faceFocus);
 
     // Image controls
     m_settingsWidget->setBrightnessAuto(settings.brightnessAuto);
@@ -1432,7 +1432,7 @@ CameraController::CameraState MainWindow::getUIState() const
     state.hdrEnabled = m_settingsWidget->isHDREnabled();
     state.fovMode = m_settingsWidget->getFOVMode();
     state.faceAEEnabled = m_settingsWidget->isFaceAEEnabled();
-    state.faceFocusEnabled = m_settingsWidget->isFaceFocusEnabled();
+    state.faceFocusEnabled = m_trackingWidget->isFaceFocusEnabled();
 
     // Image controls
     state.brightnessAuto = m_settingsWidget->isBrightnessAuto();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -685,9 +685,6 @@ void MainWindow::applyModernStyle()
     const QColor comboSelectionBackground = withAlphaF(highlight, 0.75);
     const QColor comboSelectionText = accentChipText;
 
-    const QColor groupBorder = withAlphaF(blendColors(cardBorder, mutedTone, 0.35), 0.55);
-    const QColor tabBackground = withAlphaF(blendColors(button, cardBackground, 0.2), 0.5);
-
     const QColor footerStatusColor = withAlphaF(text, 0.65);
     const QColor footerCheckboxColor = withAlphaF(text, 0.7);
     const QColor detachCheckedText = highlight;
@@ -733,39 +730,15 @@ void MainWindow::applyModernStyle()
             border-radius: 12px;
             padding: 28px;
         }
-        QGroupBox {
-            border: 1px solid %14;
-            border-radius: 14px;
-            margin-top: 14px;
-        }
-        QGroupBox::title {
-            subcontrol-origin: margin;
-            left: 18px;
-            top: -2px;
-            padding: 0 8px;
-            font-weight: 600;
-            background-color: %1;
-        }
         QTabWidget#controlTabs::pane {
             border: none;
             margin-top: 10px;
         }
-        QTabWidget#controlTabs::tab-bar {
-            alignment: center;
-        }
-        QTabBar::tab {
-            padding: 6px 10px;
-            margin: 0 2px;
-            font-size: 13px;
-        }
-        QTabBar::tab:selected {
-            font-weight: 600;
-        }
         QLabel#footerStatus {
-            color: %15;
+            color: %14;
         }
         QCheckBox#footerCheckbox {
-            color: %16;
+            color: %15;
         }
     )")
         .arg(toCssColor(cardBackground))
@@ -781,7 +754,6 @@ void MainWindow::applyModernStyle()
         .arg(toCssColor(warningColor))
         .arg(toCssColor(previewPlaceholderText))
         .arg(toCssColor(previewPlaceholderBorder))
-        .arg(toCssColor(groupBorder))
         .arg(toCssColor(footerStatusColor))
         .arg(toCssColor(footerCheckboxColor));
 
@@ -1234,26 +1206,31 @@ void MainWindow::updateVirtualCameraAvailability(const QString &devicePath)
     const QString modprobeCommand = modprobeCommandForDevice(devicePath);
 
     QString statusText;
-    QString statusColor;
+    const bool darkTheme = palette().color(QPalette::Window).lightness() < 128;
+    QColor statusColor;
 
     if (deviceExists) {
         statusText = tr("Virtual camera available (%1)").arg(devicePath);
-        statusColor = QStringLiteral("#2e7d32");
+        statusColor = darkTheme ? QColor(QStringLiteral("#81c784"))
+                                : QColor(QStringLiteral("#2e7d32"));
         m_virtualCameraAvailable = true;
     } else if (moduleLoaded) {
         statusText = tr("v4l2loopback is loaded, but %1 does not exist.\nRun: %2")
                          .arg(devicePath, modprobeCommand);
-        statusColor = QStringLiteral("#b26a00");
+        statusColor = darkTheme ? QColor(QStringLiteral("#ffb74d"))
+                                : QColor(QStringLiteral("#b26a00"));
         m_virtualCameraAvailable = false;
     } else {
         statusText = tr("Virtual camera support is disabled.\nInstall the module and load it with:\n%1")
                          .arg(modprobeCommand);
-        statusColor = QStringLiteral("#b71c1c");
+        statusColor = darkTheme ? QColor(QStringLiteral("#ef9a9a"))
+                                : QColor(QStringLiteral("#b71c1c"));
         m_virtualCameraAvailable = false;
     }
 
     m_virtualCameraStatusLabel->setText(statusText);
-    m_virtualCameraStatusLabel->setStyleSheet(QStringLiteral("color: %1;").arg(statusColor));
+    m_virtualCameraStatusLabel->setStyleSheet(
+        QStringLiteral("color: %1;").arg(statusColor.name()));
     if (m_virtualCameraCheckbox) {
         m_virtualCameraCheckbox->setToolTip(statusText);
     }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -368,7 +368,13 @@ void MainWindow::setupUI()
         m_controller->disconnectFromCamera();
         m_deviceInfoLabel->setText(tr("Connecting to camera..."));
         m_statusLabel->setText(tr("Status: Connecting..."));
-        m_controller->connectToCamera();
+        updateStatusBanner(false);
+        // Let Qt paint the connecting state before SDK discovery starts. If
+        // the SDK already has the camera cached, connectToCamera() can emit
+        // cameraConnected synchronously and otherwise skip this visible state.
+        QTimer::singleShot(100, this, [this]() {
+            m_controller->connectToCamera();
+        });
     });
     actionLayout->addWidget(m_reconnectButton);
     statusMainLayout->addWidget(actionRow, 0, Qt::AlignVCenter);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -327,7 +327,7 @@ void MainWindow::setupUI()
     scrollContent->setMinimumWidth(0);  // allow shrinking to viewport so content is not clipped
     QVBoxLayout *scrollLayout = new QVBoxLayout(scrollContent);
     scrollLayout->setContentsMargins(18, 20, 18, 20);
-    scrollLayout->setSpacing(18);
+    scrollLayout->setSpacing(12);
 
     m_statusBanner = new QFrame(scrollContent);
     m_statusBanner->setObjectName("statusBanner");
@@ -448,7 +448,7 @@ void MainWindow::setupUI()
 
     QWidget *virtualCameraPage = new QWidget(m_tabWidget);
     QVBoxLayout *virtualCameraPageLayout = new QVBoxLayout(virtualCameraPage);
-    virtualCameraPageLayout->setContentsMargins(8, 14, 8, 14);
+    virtualCameraPageLayout->setContentsMargins(8, 8, 8, 14);
     virtualCameraPageLayout->setSpacing(14);
 
     QGroupBox *virtualCameraGroup = new QGroupBox(tr("Virtual Camera"), virtualCameraPage);
@@ -514,7 +514,7 @@ void MainWindow::setupUI()
 
     QWidget *settingsPage = new QWidget(m_tabWidget);
     QVBoxLayout *settingsPageLayout = new QVBoxLayout(settingsPage);
-    settingsPageLayout->setContentsMargins(8, 14, 8, 14);
+    settingsPageLayout->setContentsMargins(8, 8, 8, 14);
     settingsPageLayout->setSpacing(14);
 
     QGroupBox *snapshotGroup = new QGroupBox(tr("Snapshots"), settingsPage);
@@ -733,7 +733,7 @@ void MainWindow::applyModernStyle()
         }
         QTabWidget#controlTabs::pane {
             border: none;
-            margin-top: 18px;
+            margin-top: 10px;
         }
         QTabWidget#controlTabs::tab-bar {
             alignment: center;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -421,13 +421,15 @@ void MainWindow::setupUI()
     m_ptzWidget = new PTZControlWidget(m_controller, this);
     m_settingsWidget = new CameraSettingsWidget(m_controller, this);
     m_ptzWidget->setCameraSettingsWidget(m_settingsWidget);
+    m_trackingWidget->setPositionPresetsWidget(
+        m_ptzWidget->positionPresetsGroup());
     connect(m_ptzWidget, &PTZControlWidget::presetUpdated,
             this, &MainWindow::onPresetUpdated);
 
     m_tabWidget = new QTabWidget(scrollContent);
     m_tabWidget->setObjectName("controlTabs");
     m_tabWidget->setDocumentMode(true);
-    m_tabWidget->addTab(m_trackingWidget, tr("Tracking"));
+    m_tabWidget->addTab(m_trackingWidget, tr("Console"));
     m_tabWidget->addTab(m_ptzWidget, tr("Presets"));
     m_tabWidget->addTab(m_settingsWidget, tr("Image"));
     m_effectsWidget = new VideoEffectsWidget(this);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -946,7 +946,10 @@ void MainWindow::updateStatusBanner(bool connected)
     m_statusBanner->setProperty("state", connected ? "connected" : "disconnected");
     m_statusBanner->style()->unpolish(m_statusBanner);
     m_statusBanner->style()->polish(m_statusBanner);
+    m_statusChip->style()->unpolish(m_statusChip);
+    m_statusChip->style()->polish(m_statusChip);
     m_statusBanner->update();
+    m_statusChip->update();
 }
 
 void MainWindow::onTogglePreview(bool enabled)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -161,6 +161,7 @@ MainWindow::MainWindow(QWidget *parent)
     , m_snapshotToClipboard(false)
     , m_virtualCameraErrorNotified(false)
     , m_virtualCameraAvailable(false)
+    , m_pollTick(3)
 {
     setWindowTitle("OBSBOT Control");
     setWindowIcon(QIcon(":/icons/camera.svg"));
@@ -210,7 +211,7 @@ MainWindow::MainWindow(QWidget *parent)
     // Update status periodically
     m_statusTimer = new QTimer(this);
     connect(m_statusTimer, &QTimer::timeout, this, &MainWindow::updateStatus);
-    m_statusTimer->start(2000);
+    m_statusTimer->start(500);
 }
 
 MainWindow::~MainWindow()
@@ -438,6 +439,7 @@ void MainWindow::setupUI()
 
     // Resize tab widget to fit the current tab (QTabWidget normally sizes to the tallest)
     connect(m_tabWidget, &QTabWidget::currentChanged, this, [this](int) {
+        m_pollTick = 3; // Refresh newly visible image controls on the next tick.
         fitTabToCurrentPage();
     });
     QTimer::singleShot(0, this, &MainWindow::fitTabToCurrentPage);
@@ -1168,7 +1170,15 @@ void MainWindow::updateStatus()
         return;
     }
 
-    auto state = m_controller->getCurrentState();
+    const bool background = !isVisible() || isMinimized();
+    const int desiredInterval = background ? 3000 : 500;
+    if (m_statusTimer->interval() != desiredInterval)
+        m_statusTimer->setInterval(desiredInterval);
+
+    const bool imageTabVisible = !background
+        && m_tabWidget->currentWidget() == m_settingsWidget;
+    const bool pollImageControls = imageTabVisible && (++m_pollTick % 4 == 0);
+    auto state = m_controller->pollCurrentState(pollImageControls);
 
     QStringList statusParts;
     statusParts << QString("AI: %1").arg(state.autoFramingEnabled ? "On" : "Off");

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1060,7 +1060,14 @@ void MainWindow::onCameraConnected(const CameraController::CameraInfo &info)
     // the camera's initial state. Capture the configured/user-intended values
     // now, otherwise that initial state (Tiny 4K boots with Wide FOV) replaces
     // the UI value before the delayed reapply runs.
-    const CameraController::CameraState intendedState = getUIState();
+    CameraController::CameraState intendedState = getUIState();
+    const auto savedSettings = m_controller->getConfig().getSettings();
+    intendedState.zoom = savedSettings.zoom;
+    intendedState.pan = savedSettings.pan;
+    intendedState.tilt = savedSettings.tilt;
+    intendedState.autoFocusEnabled = savedSettings.focus < 0;
+    intendedState.manualFocusValue =
+        intendedState.autoFocusEnabled ? 0 : savedSettings.focus;
     QTimer::singleShot(100, this, [this, intendedState]() {
         if (m_isCameraSwitch) {
             // Pull the new camera's actual state into the UI

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1103,6 +1103,13 @@ void MainWindow::onCameraDisconnected()
 
 void MainWindow::onStateChanged(const CameraController::CameraState &state)
 {
+    // Re-sync mode-dependent visibility: the connection can upgrade from
+    // the V4L2 fallback to a full SDK session after onCameraConnected ran,
+    // and a snapshot taken there would hide these controls forever.
+    bool v4l2Mode = m_controller->isV4l2Only();
+    m_trackingWidget->setV4l2Mode(v4l2Mode);
+    m_settingsWidget->setV4l2Mode(v4l2Mode);
+
     // Update all widgets with new state
     m_trackingWidget->updateFromState(state);
     m_settingsWidget->updateFromState(state);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -335,25 +335,22 @@ void MainWindow::setupUI()
     statusLayout->setContentsMargins(16, 18, 16, 16);
     statusLayout->setSpacing(10);
 
-    QHBoxLayout *statusHeader = new QHBoxLayout();
-    statusHeader->setContentsMargins(0, 0, 0, 0);
-    statusHeader->setSpacing(10);
+    QHBoxLayout *statusMainLayout = new QHBoxLayout();
+    statusMainLayout->setContentsMargins(0, 0, 0, 0);
+    statusMainLayout->setSpacing(14);
+
+    QVBoxLayout *statusTextLayout = new QVBoxLayout();
+    statusTextLayout->setContentsMargins(0, 0, 0, 0);
+    statusTextLayout->setSpacing(6);
     m_statusChip = new QLabel(tr("Camera • Offline"), m_statusBanner);
     m_statusChip->setObjectName("statusChip");
-    statusHeader->addWidget(m_statusChip);
-    statusHeader->addStretch();
-    statusLayout->addLayout(statusHeader);
+    statusTextLayout->addWidget(m_statusChip);
 
     m_deviceInfoLabel = new QLabel(tr("Connecting to camera..."), m_statusBanner);
     m_deviceInfoLabel->setObjectName("deviceInfoLabel");
     m_deviceInfoLabel->setWordWrap(true);
-    statusLayout->addWidget(m_deviceInfoLabel);
-
-    m_cameraWarningLabel = new QLabel(QString(), m_statusBanner);
-    m_cameraWarningLabel->setObjectName("warningLabel");
-    m_cameraWarningLabel->setWordWrap(true);
-    m_cameraWarningLabel->setVisible(false);
-    statusLayout->addWidget(m_cameraWarningLabel);
+    statusTextLayout->addWidget(m_deviceInfoLabel);
+    statusMainLayout->addLayout(statusTextLayout, 1);
 
     QWidget *actionRow = new QWidget(m_statusBanner);
     actionRow->setObjectName("actionRow");
@@ -375,7 +372,14 @@ void MainWindow::setupUI()
         m_controller->connectToCamera();
     });
     actionLayout->addWidget(m_reconnectButton);
-    statusLayout->addWidget(actionRow);
+    statusMainLayout->addWidget(actionRow, 0, Qt::AlignVCenter);
+    statusLayout->addLayout(statusMainLayout);
+
+    m_cameraWarningLabel = new QLabel(QString(), m_statusBanner);
+    m_cameraWarningLabel->setObjectName("warningLabel");
+    m_cameraWarningLabel->setWordWrap(true);
+    m_cameraWarningLabel->setVisible(false);
+    statusLayout->addWidget(m_cameraWarningLabel);
 
     scrollLayout->addWidget(m_statusBanner);
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1061,7 +1061,7 @@ void MainWindow::onCameraConnected(const CameraController::CameraInfo &info)
     if (info.version.isEmpty()) {
         deviceText = info.name;
     } else {
-        deviceText = QString("%1\n(v%2)")
+        deviceText = QString("%1 (v%2)")
             .arg(info.name)
             .arg(info.version);
     }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -432,13 +432,6 @@ void MainWindow::setupUI()
     m_effectsWidget = new VideoEffectsWidget(this);
     connect(m_effectsWidget, &VideoEffectsWidget::effectsChanged,
             this, &MainWindow::onVideoEffectsChanged);
-    // Mirror checkbox in tracking tab syncs with Creative FX horizontal flip
-    connect(m_trackingWidget, &TrackingControlWidget::mirrorToggled,
-            this, [this](bool mirrored) {
-                auto settings = m_effectsWidget->settings();
-                settings.horizontalFlip = mirrored;
-                m_effectsWidget->applySettings(settings);
-            });
     m_tabWidget->addTab(m_effectsWidget, tr("Creative FX"));
     scrollLayout->addWidget(m_tabWidget);
     m_effectsWidget->reset();
@@ -1959,7 +1952,6 @@ void MainWindow::onVideoEffectsChanged(const FilterPreviewWidget::VideoEffectsSe
         return;
     }
     m_previewWidget->setVideoEffects(settings);
-    m_trackingWidget->setMirrored(settings.horizontalFlip);
 }
 
 void MainWindow::onSnapshotCaptured(const QImage &image)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1263,6 +1263,9 @@ void MainWindow::loadConfiguration()
     m_settingsWidget->setContrast(settings.contrast);
     m_settingsWidget->setSaturationAuto(settings.saturationAuto);
     m_settingsWidget->setSaturation(settings.saturation);
+    m_settingsWidget->setHue(settings.hue);
+    m_settingsWidget->setSharpness(settings.sharpness);
+    m_settingsWidget->setAntiFlicker(settings.antiFlicker);
     m_settingsWidget->setWhiteBalance(settings.whiteBalance);
     m_previewWidget->setPreferredFormatId(QString::fromStdString(settings.previewFormat));
 
@@ -1401,6 +1404,9 @@ CameraController::CameraState MainWindow::getUIState() const
     state.contrast = m_settingsWidget->getContrast();
     state.saturationAuto = m_settingsWidget->isSaturationAuto();
     state.saturation = m_settingsWidget->getSaturation();
+    state.hue = m_settingsWidget->getHue();
+    state.sharpness = m_settingsWidget->getSharpness();
+    state.antiFlicker = m_settingsWidget->getAntiFlicker();
     state.whiteBalance = m_settingsWidget->getWhiteBalance();
     state.whiteBalanceKelvin = m_settingsWidget->getWhiteBalanceKelvin();
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -133,6 +133,7 @@ private:
 
     // Status timer
     QTimer *m_statusTimer;
+    int m_pollTick;
 
     // Track preview state before minimize
     bool m_previewStateBeforeMinimize;

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -54,7 +54,8 @@ private slots:
     void onPreviewStarted();
     void onPreviewFailed(const QString &error);
     void onPreviewFormatChanged(const QString &formatId);
-    void onPresetUpdated(int index, double pan, double tilt, double zoom, bool defined);
+    void onPresetUpdated(int index, double pan, double tilt, double zoom,
+                         bool defined, const QString &name);
     void onTrayIconActivated(QSystemTrayIcon::ActivationReason reason);
     void onShowHideAction();
     void onQuitAction();

--- a/src/gui/PTZControlWidget.cpp
+++ b/src/gui/PTZControlWidget.cpp
@@ -209,7 +209,7 @@ void PTZControlWidget::onStoreImagePreset()
     preset.state.hdrEnabled = m_settingsWidget->isHDREnabled();
     preset.state.fovMode = m_settingsWidget->getFOVMode();
     preset.state.faceAE = m_settingsWidget->isFaceAEEnabled();
-    preset.state.faceFocus = m_settingsWidget->isFaceFocusEnabled();
+    preset.state.faceFocus = m_controller->getCurrentState().faceFocusEnabled;
     preset.state.brightnessAuto = m_settingsWidget->isBrightnessAuto();
     preset.state.brightness = m_settingsWidget->getBrightness();
     preset.state.contrastAuto = m_settingsWidget->isContrastAuto();
@@ -246,7 +246,7 @@ void PTZControlWidget::onRecallImagePreset()
     m_settingsWidget->setHDREnabled(preset.state.hdrEnabled);
     m_settingsWidget->setFOVMode(preset.state.fovMode);
     m_settingsWidget->setFaceAEEnabled(preset.state.faceAE);
-    m_settingsWidget->setFaceFocusEnabled(preset.state.faceFocus);
+    m_controller->setFaceFocus(preset.state.faceFocus);
     m_settingsWidget->setBrightnessAuto(preset.state.brightnessAuto);
     m_settingsWidget->setBrightness(preset.state.brightness);
     m_settingsWidget->setContrastAuto(preset.state.contrastAuto);

--- a/src/gui/PTZControlWidget.cpp
+++ b/src/gui/PTZControlWidget.cpp
@@ -131,6 +131,10 @@ void PTZControlWidget::onRecallPreset()
         return;
     }
 
+    if (m_controller->hasTiny4kCapabilities()
+            && m_controller->recallHardwarePreset(index)) {
+        return;
+    }
     m_controller->setPanTilt(preset.pan, preset.tilt);
     m_controller->setZoom(preset.zoom);
 }
@@ -154,6 +158,9 @@ void PTZControlWidget::onStorePreset()
     preset.zoom = state.zoom;
     updatePresetLabel(index);
 
+    if (m_controller->hasTiny4kCapabilities()) {
+        m_controller->saveHardwarePreset(index);
+    }
     emit presetUpdated(index, preset.pan, preset.tilt, preset.zoom, true);
 }
 

--- a/src/gui/PTZControlWidget.cpp
+++ b/src/gui/PTZControlWidget.cpp
@@ -2,6 +2,7 @@
 #include "CameraSettingsWidget.h"
 #include <QVBoxLayout>
 #include <QHBoxLayout>
+#include <QMenu>
 
 PTZControlWidget::PTZControlWidget(CameraController *controller, QWidget *parent)
     : QWidget(parent)
@@ -14,41 +15,51 @@ PTZControlWidget::PTZControlWidget(CameraController *controller, QWidget *parent
     layout->setSpacing(14);
 
     // Presets section
-    m_positionPresetGroup = new QGroupBox("Position Presets", this);
-    QVBoxLayout *presetLayout = new QVBoxLayout(m_positionPresetGroup);
+    m_positionPresetGroup = new QGroupBox("Presets", this);
+    QHBoxLayout *presetLayout = new QHBoxLayout(m_positionPresetGroup);
     presetLayout->setContentsMargins(16, 16, 16, 16);
     presetLayout->setSpacing(8);
 
     for (int i = 0; i < 3; ++i) {
         PresetUi presetUi{};
         presetUi.defined = false;
+        presetUi.name = QString::number(i + 1);
         presetUi.pan = 0.0;
         presetUi.tilt = 0.0;
         presetUi.zoom = 1.0;
 
-        QHBoxLayout *row = new QHBoxLayout();
-        row->setSpacing(8);
-        QLabel *titleLabel = new QLabel(QString("Preset %1").arg(i + 1), this);
-        titleLabel->setStyleSheet("font-weight: 600; font-size: 11px;");
-        row->addWidget(titleLabel);
-
-        presetUi.statusLabel = new QLabel("Empty", this);
-        presetUi.statusLabel->setStyleSheet("color: palette(mid); font-size: 11px;");
-        row->addWidget(presetUi.statusLabel, 1);
-
-        presetUi.recallButton = new QPushButton("Recall", this);
+        presetUi.stack = new QStackedWidget(m_positionPresetGroup);
+        presetUi.recallButton = new QPushButton(presetUi.name, presetUi.stack);
         presetUi.recallButton->setProperty("presetIndex", i);
-        presetUi.recallButton->setEnabled(false);
+        presetUi.recallButton->setContextMenuPolicy(Qt::CustomContextMenu);
         connect(presetUi.recallButton, &QPushButton::clicked, this, &PTZControlWidget::onRecallPreset);
-        row->addWidget(presetUi.recallButton);
-
-        presetUi.saveButton = new QPushButton("Save", this);
-        presetUi.saveButton->setProperty("presetIndex", i);
-        connect(presetUi.saveButton, &QPushButton::clicked, this, &PTZControlWidget::onStorePreset);
-        row->addWidget(presetUi.saveButton);
-
-        presetLayout->addLayout(row);
+        connect(presetUi.recallButton, &QPushButton::customContextMenuRequested,
+                this, &PTZControlWidget::showPresetMenu);
+        presetUi.renameEditor = new QLineEdit(presetUi.stack);
+        presetUi.renameEditor->setAlignment(Qt::AlignCenter);
+        presetUi.renameEditor->setMaxLength(32);
+        presetUi.renameEditor->setProperty("presetIndex", i);
+        presetUi.stack->addWidget(presetUi.recallButton);
+        presetUi.stack->addWidget(presetUi.renameEditor);
+        presetLayout->addWidget(presetUi.stack, 1);
         m_presets[static_cast<size_t>(i)] = presetUi;
+        connect(presetUi.renameEditor, &QLineEdit::editingFinished,
+                this, [this, i]() {
+            auto &preset = m_presets[static_cast<size_t>(i)];
+            if (preset.stack->currentWidget() != preset.renameEditor) {
+                return;
+            }
+            QString name = preset.renameEditor->text().trimmed();
+            if (!name.isEmpty()) {
+                name.replace('\n', ' ');
+                name.replace('\r', ' ');
+                preset.name = name;
+            }
+            preset.stack->setCurrentWidget(preset.recallButton);
+            updatePresetLabel(i);
+            emit presetUpdated(i, preset.pan, preset.tilt, preset.zoom,
+                               preset.defined, preset.name);
+        });
         updatePresetLabel(i);
     }
 
@@ -99,6 +110,8 @@ void PTZControlWidget::applyPresetStates(const std::array<PresetState, 3> &prese
         auto &ui = m_presets[static_cast<size_t>(i)];
         const auto &preset = presets[static_cast<size_t>(i)];
         ui.defined = preset.defined;
+        ui.name = preset.name.trimmed().isEmpty()
+            ? QString::number(i + 1) : preset.name;
         ui.pan = preset.pan;
         ui.tilt = preset.tilt;
         ui.zoom = preset.zoom;
@@ -111,7 +124,9 @@ std::array<PTZControlWidget::PresetState, 3> PTZControlWidget::currentPresets() 
     std::array<PresetState, 3> out{};
     for (int i = 0; i < 3; ++i) {
         const auto &ui = m_presets[static_cast<size_t>(i)];
-        out[static_cast<size_t>(i)] = {ui.defined, ui.pan, ui.tilt, ui.zoom};
+        out[static_cast<size_t>(i)] = {
+            ui.defined, ui.name, ui.pan, ui.tilt, ui.zoom
+        };
     }
     return out;
 }
@@ -140,13 +155,8 @@ void PTZControlWidget::onRecallPreset()
     m_controller->setZoom(preset.zoom);
 }
 
-void PTZControlWidget::onStorePreset()
+void PTZControlWidget::storePreset(int index)
 {
-    auto *button = qobject_cast<QPushButton*>(sender());
-    if (!button) {
-        return;
-    }
-    int index = button->property("presetIndex").toInt();
     if (index < 0 || index >= static_cast<int>(m_presets.size())) {
         return;
     }
@@ -162,7 +172,67 @@ void PTZControlWidget::onStorePreset()
     if (m_controller->hasTiny4kCapabilities()) {
         m_controller->saveHardwarePreset(index);
     }
-    emit presetUpdated(index, preset.pan, preset.tilt, preset.zoom, true);
+    emit presetUpdated(index, preset.pan, preset.tilt, preset.zoom,
+                       true, preset.name);
+}
+
+void PTZControlWidget::deletePreset(int index)
+{
+    if (index < 0 || index >= static_cast<int>(m_presets.size())) {
+        return;
+    }
+    auto &preset = m_presets[static_cast<size_t>(index)];
+    preset.defined = false;
+    preset.name = QString::number(index + 1);
+    updatePresetLabel(index);
+    emit presetUpdated(index, preset.pan, preset.tilt, preset.zoom,
+                       false, preset.name);
+}
+
+void PTZControlWidget::beginPresetRename(int index)
+{
+    if (index < 0 || index >= static_cast<int>(m_presets.size())) {
+        return;
+    }
+    auto &preset = m_presets[static_cast<size_t>(index)];
+    preset.renameEditor->setText(preset.name);
+    preset.stack->setCurrentWidget(preset.renameEditor);
+    preset.renameEditor->setFocus();
+    preset.renameEditor->selectAll();
+}
+
+void PTZControlWidget::showPresetMenu(const QPoint &position)
+{
+    auto *button = qobject_cast<QPushButton*>(sender());
+    if (!button) {
+        return;
+    }
+    const int index = button->property("presetIndex").toInt();
+    if (index < 0 || index >= static_cast<int>(m_presets.size())) {
+        return;
+    }
+
+    const auto &preset = m_presets[static_cast<size_t>(index)];
+    QMenu menu(this);
+    if (!preset.defined) {
+        QAction *setAction = menu.addAction("Set");
+        if (menu.exec(button->mapToGlobal(position)) == setAction) {
+            storePreset(index);
+        }
+        return;
+    }
+
+    QAction *updateAction = menu.addAction("Update");
+    QAction *deleteAction = menu.addAction("Delete");
+    QAction *renameAction = menu.addAction("Rename");
+    QAction *selected = menu.exec(button->mapToGlobal(position));
+    if (selected == updateAction) {
+        storePreset(index);
+    } else if (selected == deleteAction) {
+        deletePreset(index);
+    } else if (selected == renameAction) {
+        beginPresetRename(index);
+    }
 }
 
 void PTZControlWidget::updatePresetLabel(int index)
@@ -171,23 +241,21 @@ void PTZControlWidget::updatePresetLabel(int index)
         return;
     }
     auto &preset = m_presets[static_cast<size_t>(index)];
-    if (!preset.statusLabel) {
+    if (!preset.recallButton) {
         return;
     }
 
-    if (preset.defined) {
-        preset.statusLabel->setText(
-            QString("Pan %1, Tilt %2, Zoom %3x")
-                .arg(preset.pan, 0, 'f', 2)
-                .arg(preset.tilt, 0, 'f', 2)
-                .arg(preset.zoom, 0, 'f', 1));
-    } else {
-        preset.statusLabel->setText("Empty");
-    }
-
-    if (preset.recallButton) {
-        preset.recallButton->setEnabled(preset.defined);
-    }
+    preset.recallButton->setText(preset.name);
+    preset.recallButton->setStyleSheet(
+        preset.defined
+            ? QString()
+            : QString("color: palette(mid); background-color: palette(midlight);"));
+    preset.recallButton->setToolTip(preset.defined
+        ? QString("Pan %1, Tilt %2, Zoom %3x")
+              .arg(preset.pan, 0, 'f', 2)
+              .arg(preset.tilt, 0, 'f', 2)
+              .arg(preset.zoom, 0, 'f', 2)
+        : QString("Empty preset"));
 }
 
 void PTZControlWidget::onStoreImagePreset()

--- a/src/gui/PTZControlWidget.cpp
+++ b/src/gui/PTZControlWidget.cpp
@@ -67,7 +67,7 @@ PTZControlWidget::PTZControlWidget(CameraController *controller, QWidget *parent
     layout->addWidget(m_positionPresetGroup);
 
     // Image Quality Presets section
-    m_imagePresetGroup = new QGroupBox("Image Quality Presets", this);
+    m_imagePresetGroup = new QGroupBox("Presets", this);
     QHBoxLayout *imagePresetLayout = new QHBoxLayout(m_imagePresetGroup);
     imagePresetLayout->setContentsMargins(16, 16, 16, 16);
     imagePresetLayout->setSpacing(8);

--- a/src/gui/PTZControlWidget.cpp
+++ b/src/gui/PTZControlWidget.cpp
@@ -11,7 +11,7 @@ PTZControlWidget::PTZControlWidget(CameraController *controller, QWidget *parent
     , m_positionPresetGroup(nullptr)
 {
     QVBoxLayout *layout = new QVBoxLayout(this);
-    layout->setContentsMargins(8, 14, 8, 14);
+    layout->setContentsMargins(8, 8, 8, 14);
     layout->setSpacing(14);
 
     // Presets section

--- a/src/gui/PTZControlWidget.cpp
+++ b/src/gui/PTZControlWidget.cpp
@@ -250,12 +250,10 @@ void PTZControlWidget::updatePresetLabel(int index)
         preset.defined
             ? QString()
             : QString("color: palette(mid); background-color: palette(midlight);"));
-    preset.recallButton->setToolTip(preset.defined
-        ? QString("Pan %1, Tilt %2, Zoom %3x")
-              .arg(preset.pan, 0, 'f', 2)
-              .arg(preset.tilt, 0, 'f', 2)
-              .arg(preset.zoom, 0, 'f', 2)
-        : QString("Empty preset"));
+    // Hardware-backed models can save a real gimbal position while reporting
+    // zero for absolute pan/tilt, so do not present cached coordinates as fact.
+    preset.recallButton->setToolTip(
+        preset.defined ? "Saved camera preset" : "Empty preset");
 }
 
 void PTZControlWidget::onStoreImagePreset()

--- a/src/gui/PTZControlWidget.cpp
+++ b/src/gui/PTZControlWidget.cpp
@@ -9,6 +9,7 @@ PTZControlWidget::PTZControlWidget(CameraController *controller, QWidget *parent
     , m_controller(controller)
     , m_settingsWidget(nullptr)
     , m_positionPresetGroup(nullptr)
+    , m_imagePresetGroup(nullptr)
 {
     QVBoxLayout *layout = new QVBoxLayout(this);
     layout->setContentsMargins(8, 8, 8, 14);
@@ -66,42 +67,44 @@ PTZControlWidget::PTZControlWidget(CameraController *controller, QWidget *parent
     layout->addWidget(m_positionPresetGroup);
 
     // Image Quality Presets section
-    QGroupBox *imagePresetGroup = new QGroupBox("Image Quality Presets", this);
-    QVBoxLayout *imagePresetLayout = new QVBoxLayout(imagePresetGroup);
+    m_imagePresetGroup = new QGroupBox("Image Quality Presets", this);
+    QHBoxLayout *imagePresetLayout = new QHBoxLayout(m_imagePresetGroup);
     imagePresetLayout->setContentsMargins(16, 16, 16, 16);
     imagePresetLayout->setSpacing(8);
 
     for (int i = 0; i < 3; ++i) {
         ImagePresetUi imagePresetUi{};
         imagePresetUi.state.defined = false;
-
-        QHBoxLayout *row = new QHBoxLayout();
-        row->setSpacing(8);
-        QLabel *titleLabel = new QLabel(QString("Preset %1").arg(i + 1), this);
-        titleLabel->setStyleSheet("font-weight: 600; font-size: 11px;");
-        row->addWidget(titleLabel);
-
-        imagePresetUi.statusLabel = new QLabel("Empty", this);
-        imagePresetUi.statusLabel->setStyleSheet("color: palette(mid); font-size: 11px;");
-        row->addWidget(imagePresetUi.statusLabel, 1);
-
-        imagePresetUi.recallButton = new QPushButton("Recall", this);
+        imagePresetUi.name = QString::number(i + 1);
+        imagePresetUi.stack = new QStackedWidget(m_imagePresetGroup);
+        imagePresetUi.recallButton =
+            new QPushButton(imagePresetUi.name, imagePresetUi.stack);
         imagePresetUi.recallButton->setProperty("presetIndex", i);
-        imagePresetUi.recallButton->setEnabled(false);
+        imagePresetUi.recallButton->setContextMenuPolicy(Qt::CustomContextMenu);
         connect(imagePresetUi.recallButton, &QPushButton::clicked, this, &PTZControlWidget::onRecallImagePreset);
-        row->addWidget(imagePresetUi.recallButton);
-
-        imagePresetUi.saveButton = new QPushButton("Save", this);
-        imagePresetUi.saveButton->setProperty("presetIndex", i);
-        connect(imagePresetUi.saveButton, &QPushButton::clicked, this, &PTZControlWidget::onStoreImagePreset);
-        row->addWidget(imagePresetUi.saveButton);
-
-        imagePresetLayout->addLayout(row);
+        connect(imagePresetUi.recallButton,
+                &QPushButton::customContextMenuRequested,
+                this, &PTZControlWidget::showImagePresetMenu);
+        imagePresetUi.renameEditor = new QLineEdit(imagePresetUi.stack);
+        imagePresetUi.renameEditor->setAlignment(Qt::AlignCenter);
+        imagePresetUi.renameEditor->setMaxLength(32);
+        imagePresetUi.stack->addWidget(imagePresetUi.recallButton);
+        imagePresetUi.stack->addWidget(imagePresetUi.renameEditor);
+        imagePresetLayout->addWidget(imagePresetUi.stack, 1);
         m_imagePresets[static_cast<size_t>(i)] = imagePresetUi;
+        connect(imagePresetUi.renameEditor, &QLineEdit::editingFinished,
+                this, [this, i]() {
+            auto &preset = m_imagePresets[static_cast<size_t>(i)];
+            if (preset.stack->currentWidget() != preset.renameEditor) return;
+            QString name = preset.renameEditor->text().trimmed();
+            if (!name.isEmpty()) preset.name = name;
+            preset.stack->setCurrentWidget(preset.recallButton);
+            updateImagePresetLabel(i);
+        });
         updateImagePresetLabel(i);
     }
 
-    layout->addWidget(imagePresetGroup);
+    layout->addWidget(m_imagePresetGroup);
     layout->addStretch();
 }
 void PTZControlWidget::applyPresetStates(const std::array<PresetState, 3> &presets)
@@ -252,21 +255,16 @@ void PTZControlWidget::updatePresetLabel(int index)
             : QString("color: palette(mid); background-color: palette(midlight);"));
     // Hardware-backed models can save a real gimbal position while reporting
     // zero for absolute pan/tilt, so do not present cached coordinates as fact.
-    preset.recallButton->setToolTip(
-        preset.defined ? "Saved camera preset" : "Empty preset");
+    preset.recallButton->setToolTip(preset.defined
+        ? "Right click to change"
+        : "Right click to set");
 }
 
-void PTZControlWidget::onStoreImagePreset()
+void PTZControlWidget::storeImagePreset(int index)
 {
     if (!m_settingsWidget) {
         return;
     }
-
-    auto *button = qobject_cast<QPushButton*>(sender());
-    if (!button) {
-        return;
-    }
-    int index = button->property("presetIndex").toInt();
     if (index < 0 || index >= static_cast<int>(m_imagePresets.size())) {
         return;
     }
@@ -288,6 +286,49 @@ void PTZControlWidget::onStoreImagePreset()
     updateImagePresetLabel(index);
 
     emit imagePresetUpdated(index);
+}
+
+void PTZControlWidget::deleteImagePreset(int index)
+{
+    if (index < 0 || index >= static_cast<int>(m_imagePresets.size())) return;
+    auto &preset = m_imagePresets[static_cast<size_t>(index)];
+    preset.state.defined = false;
+    preset.name = QString::number(index + 1);
+    updateImagePresetLabel(index);
+    emit imagePresetUpdated(index);
+}
+
+void PTZControlWidget::beginImagePresetRename(int index)
+{
+    if (index < 0 || index >= static_cast<int>(m_imagePresets.size())) return;
+    auto &preset = m_imagePresets[static_cast<size_t>(index)];
+    preset.renameEditor->setText(preset.name);
+    preset.stack->setCurrentWidget(preset.renameEditor);
+    preset.renameEditor->setFocus();
+    preset.renameEditor->selectAll();
+}
+
+void PTZControlWidget::showImagePresetMenu(const QPoint &position)
+{
+    auto *button = qobject_cast<QPushButton*>(sender());
+    if (!button) return;
+    const int index = button->property("presetIndex").toInt();
+    if (index < 0 || index >= static_cast<int>(m_imagePresets.size())) return;
+    const auto &preset = m_imagePresets[static_cast<size_t>(index)];
+    QMenu menu(this);
+    if (!preset.state.defined) {
+        QAction *setAction = menu.addAction("Set");
+        if (menu.exec(button->mapToGlobal(position)) == setAction)
+            storeImagePreset(index);
+        return;
+    }
+    QAction *updateAction = menu.addAction("Update");
+    QAction *deleteAction = menu.addAction("Delete");
+    QAction *renameAction = menu.addAction("Rename");
+    QAction *selected = menu.exec(button->mapToGlobal(position));
+    if (selected == updateAction) storeImagePreset(index);
+    else if (selected == deleteAction) deleteImagePreset(index);
+    else if (selected == renameAction) beginImagePresetRename(index);
 }
 
 void PTZControlWidget::onRecallImagePreset()
@@ -330,19 +371,16 @@ void PTZControlWidget::updateImagePresetLabel(int index)
         return;
     }
     auto &preset = m_imagePresets[static_cast<size_t>(index)];
-    if (!preset.statusLabel) {
+    if (!preset.recallButton) {
         return;
     }
-
-    if (preset.state.defined) {
-        preset.statusLabel->setText("Saved");
-    } else {
-        preset.statusLabel->setText("Empty");
-    }
-
-    if (preset.recallButton) {
-        preset.recallButton->setEnabled(preset.state.defined);
-    }
+    preset.recallButton->setText(preset.name);
+    preset.recallButton->setStyleSheet(preset.state.defined
+        ? QString()
+        : QString("color: palette(mid); background-color: palette(midlight);"));
+    preset.recallButton->setToolTip(preset.state.defined
+        ? "Right click to change"
+        : "Right click to set");
 }
 
 void PTZControlWidget::applyImagePresetStates(const std::array<ImagePresetState, 3> &presets)

--- a/src/gui/PTZControlWidget.cpp
+++ b/src/gui/PTZControlWidget.cpp
@@ -13,7 +13,7 @@ PTZControlWidget::PTZControlWidget(CameraController *controller, QWidget *parent
     layout->setSpacing(14);
 
     // Presets section
-    QGroupBox *presetGroup = new QGroupBox("Camera Presets", this);
+    QGroupBox *presetGroup = new QGroupBox("Position Presets", this);
     QVBoxLayout *presetLayout = new QVBoxLayout(presetGroup);
     presetLayout->setContentsMargins(16, 16, 16, 16);
     presetLayout->setSpacing(8);

--- a/src/gui/PTZControlWidget.cpp
+++ b/src/gui/PTZControlWidget.cpp
@@ -7,14 +7,15 @@ PTZControlWidget::PTZControlWidget(CameraController *controller, QWidget *parent
     : QWidget(parent)
     , m_controller(controller)
     , m_settingsWidget(nullptr)
+    , m_positionPresetGroup(nullptr)
 {
     QVBoxLayout *layout = new QVBoxLayout(this);
     layout->setContentsMargins(8, 14, 8, 14);
     layout->setSpacing(14);
 
     // Presets section
-    QGroupBox *presetGroup = new QGroupBox("Position Presets", this);
-    QVBoxLayout *presetLayout = new QVBoxLayout(presetGroup);
+    m_positionPresetGroup = new QGroupBox("Position Presets", this);
+    QVBoxLayout *presetLayout = new QVBoxLayout(m_positionPresetGroup);
     presetLayout->setContentsMargins(16, 16, 16, 16);
     presetLayout->setSpacing(8);
 
@@ -51,7 +52,7 @@ PTZControlWidget::PTZControlWidget(CameraController *controller, QWidget *parent
         updatePresetLabel(i);
     }
 
-    layout->addWidget(presetGroup);
+    layout->addWidget(m_positionPresetGroup);
 
     // Image Quality Presets section
     QGroupBox *imagePresetGroup = new QGroupBox("Image Quality Presets", this);

--- a/src/gui/PTZControlWidget.h
+++ b/src/gui/PTZControlWidget.h
@@ -28,6 +28,7 @@ public:
         m_settingsWidget = settingsWidget;
     }
     QGroupBox *positionPresetsGroup() const { return m_positionPresetGroup; }
+    QGroupBox *imagePresetsGroup() const { return m_imagePresetGroup; }
 
     struct PresetState {
         bool defined;
@@ -66,12 +67,13 @@ private slots:
     void onRecallPreset();
     void showPresetMenu(const QPoint &position);
     void onRecallImagePreset();
-    void onStoreImagePreset();
+    void showImagePresetMenu(const QPoint &position);
 
 private:
     CameraController *m_controller;
     CameraSettingsWidget *m_settingsWidget;
     QGroupBox *m_positionPresetGroup;
+    QGroupBox *m_imagePresetGroup;
 
     struct PresetUi {
         QPushButton *recallButton;
@@ -86,8 +88,9 @@ private:
 
     struct ImagePresetUi {
         QPushButton *recallButton;
-        QPushButton *saveButton;
-        QLabel *statusLabel;
+        QLineEdit *renameEditor;
+        QStackedWidget *stack;
+        QString name;
         ImagePresetState state;
     };
 
@@ -99,6 +102,9 @@ private:
     void deletePreset(int index);
     void beginPresetRename(int index);
     void updateImagePresetLabel(int index);
+    void storeImagePreset(int index);
+    void deleteImagePreset(int index);
+    void beginImagePresetRename(int index);
 };
 
 #endif // PTZCONTROLWIDGET_H

--- a/src/gui/PTZControlWidget.h
+++ b/src/gui/PTZControlWidget.h
@@ -6,6 +6,8 @@
 #include <QSlider>
 #include <QLabel>
 #include <QGroupBox>
+#include <QLineEdit>
+#include <QStackedWidget>
 #include <array>
 #include "CameraController.h"
 
@@ -29,6 +31,7 @@ public:
 
     struct PresetState {
         bool defined;
+        QString name;
         double pan;
         double tilt;
         double zoom;
@@ -55,12 +58,13 @@ public:
     std::array<ImagePresetState, 3> currentImagePresets() const;
 
 signals:
-    void presetUpdated(int index, double pan, double tilt, double zoom, bool defined);
+    void presetUpdated(int index, double pan, double tilt, double zoom,
+                       bool defined, const QString &name);
     void imagePresetUpdated(int index);
 
 private slots:
     void onRecallPreset();
-    void onStorePreset();
+    void showPresetMenu(const QPoint &position);
     void onRecallImagePreset();
     void onStoreImagePreset();
 
@@ -71,9 +75,10 @@ private:
 
     struct PresetUi {
         QPushButton *recallButton;
-        QPushButton *saveButton;
-        QLabel *statusLabel;
+        QLineEdit *renameEditor;
+        QStackedWidget *stack;
         bool defined;
+        QString name;
         double pan;
         double tilt;
         double zoom;
@@ -90,6 +95,9 @@ private:
     std::array<ImagePresetUi, 3> m_imagePresets;
 
     void updatePresetLabel(int index);
+    void storePreset(int index);
+    void deletePreset(int index);
+    void beginPresetRename(int index);
     void updateImagePresetLabel(int index);
 };
 

--- a/src/gui/PTZControlWidget.h
+++ b/src/gui/PTZControlWidget.h
@@ -25,6 +25,7 @@ public:
     void setCameraSettingsWidget(CameraSettingsWidget *settingsWidget) {
         m_settingsWidget = settingsWidget;
     }
+    QGroupBox *positionPresetsGroup() const { return m_positionPresetGroup; }
 
     struct PresetState {
         bool defined;
@@ -66,6 +67,7 @@ private slots:
 private:
     CameraController *m_controller;
     CameraSettingsWidget *m_settingsWidget;
+    QGroupBox *m_positionPresetGroup;
 
     struct PresetUi {
         QPushButton *recallButton;

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -159,7 +159,34 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     zoomGroupLayout->addLayout(fovLayout);
     layout->addWidget(zoomGroupBox);
 
-    // Manual pan/tilt/focus controls (disabled when auto-framing is enabled)
+    // Focus remains available while auto-framing is enabled.
+    QGroupBox *focusGroupBox = new QGroupBox("Focus", this);
+    focusGroupBox->setFlat(true);
+    QVBoxLayout *focusGroupLayout = new QVBoxLayout(focusGroupBox);
+    focusGroupLayout->setContentsMargins(16, 16, 16, 16);
+    focusGroupLayout->setSpacing(8);
+
+    m_faceFocusCheckBox = new QCheckBox("Face-based Auto Focus", this);
+    m_faceFocusCheckBox->setToolTip("Optimize focus for faces");
+    connect(m_faceFocusCheckBox, &QCheckBox::toggled,
+            this, &TrackingControlWidget::onFaceFocusToggled);
+    focusGroupLayout->addWidget(m_faceFocusCheckBox);
+
+    QHBoxLayout *focusLayout = new QHBoxLayout();
+    m_focusSlider = new QSlider(Qt::Horizontal, this);
+    m_focusSlider->setMinimum(0);
+    m_focusSlider->setMaximum(100);
+    m_focusSlider->setValue(50);
+    connect(m_focusSlider, &QSlider::valueChanged,
+            this, &TrackingControlWidget::onFocusChanged);
+    focusLayout->addWidget(m_focusSlider, 1);
+    m_focusLabel = new QLabel("50", this);
+    m_focusLabel->setMinimumWidth(40);
+    focusLayout->addWidget(m_focusLabel);
+    focusGroupLayout->addLayout(focusLayout);
+    layout->addWidget(focusGroupBox);
+
+    // Manual pan/tilt controls (disabled when auto-framing is enabled)
     m_ptzContainer = new QWidget(this);
     QVBoxLayout *ptzContainerLayout = new QVBoxLayout(m_ptzContainer);
     ptzContainerLayout->setContentsMargins(0, 0, 0, 0);
@@ -175,25 +202,9 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     QHBoxLayout *columnsLayout = new QHBoxLayout();
     columnsLayout->setSpacing(16);
 
-    // Left column: sliders and checkboxes
+    // Left column: manual-control options
     QVBoxLayout *leftColumn = new QVBoxLayout();
     leftColumn->addStretch();
-
-    // Focus slider
-    QHBoxLayout *focusLayout = new QHBoxLayout();
-    QLabel *focusLabel = new QLabel("Focus:", this);
-    focusLabel->setFixedWidth(40);
-    focusLayout->addWidget(focusLabel);
-    m_focusSlider = new QSlider(Qt::Horizontal, this);
-    m_focusSlider->setMinimum(0);
-    m_focusSlider->setMaximum(100);
-    m_focusSlider->setValue(50);
-    connect(m_focusSlider, &QSlider::valueChanged, this, &TrackingControlWidget::onFocusChanged);
-    focusLayout->addWidget(m_focusSlider);
-    m_focusLabel = new QLabel("50", this);
-    m_focusLabel->setMinimumWidth(40);
-    focusLayout->addWidget(m_focusLabel);
-    leftColumn->addLayout(focusLayout);
 
     // Invert controls checkbox
     m_invertControlsCheckBox = new QCheckBox(tr("Invert controls"), this);
@@ -248,6 +259,13 @@ void TrackingControlWidget::setAutoZoomEnabled(bool enabled)
 {
     QSignalBlocker blocker(m_autoZoomCheckBox);
     m_autoZoomCheckBox->setChecked(enabled);
+}
+
+void TrackingControlWidget::setFaceFocusEnabled(bool enabled)
+{
+    QSignalBlocker blocker(m_faceFocusCheckBox);
+    m_faceFocusCheckBox->setChecked(enabled);
+    m_focusSlider->setEnabled(!enabled);
 }
 
 void TrackingControlWidget::setTrackSpeed(int speedMode)
@@ -366,8 +384,17 @@ void TrackingControlWidget::updateFromState(const CameraController::CameraState 
         }
     }
 
-    // Sync focus slider from camera state (only when user isn't dragging)
-    if (!m_focusSlider->isSliderDown() && !commandInFlight && !isSettling) {
+    if (!commandInFlight && !isSettling
+            && m_faceFocusCheckBox->isChecked() != state.faceFocusEnabled) {
+        QSignalBlocker blocker(m_faceFocusCheckBox);
+        m_faceFocusCheckBox->setChecked(state.faceFocusEnabled);
+    }
+    m_focusSlider->setEnabled(!state.faceFocusEnabled);
+
+    // Face autofocus keeps reporting the current motor position even though
+    // the slider is read-only.
+    if (!m_focusSlider->isSliderDown()
+            && (!commandInFlight || state.faceFocusEnabled) && !isSettling) {
         if (m_focusSlider->value() != state.manualFocusValue) {
             m_focusSlider->blockSignals(true);
             m_focusSlider->setValue(state.manualFocusValue);
@@ -582,6 +609,14 @@ void TrackingControlWidget::onFocusChanged(int value)
     m_dirtyFocus = true;
     m_focusLabel->setText(QString::number(value));
     scheduleFlush();
+}
+
+void TrackingControlWidget::onFaceFocusToggled(bool checked)
+{
+    m_userInitiated = true;
+    m_focusSlider->setEnabled(!checked);
+    m_controller->setFaceFocus(checked);
+    m_commandTimer->start(1000);
 }
 
 void TrackingControlWidget::setV4l2Mode(bool v4l2Only)

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -149,7 +149,6 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     for (int mode = 0; mode < 3; ++mode) {
         m_fovButtons[mode] = new QPushButton(fovLabels[mode], this);
         m_fovButtons[mode]->setCheckable(true);
-        m_fovButtons[mode]->setAutoExclusive(true);
         connect(m_fovButtons[mode], &QPushButton::clicked, this, [this, mode]() {
             m_userInitiated = true;
             m_controller->setFOV(mode);
@@ -389,9 +388,11 @@ void TrackingControlWidget::updateFromState(const CameraController::CameraState 
     }
 
     if (!commandInFlight && !isSettling) {
+        static constexpr int presetZoom[] = {100, 105, 115};
+        const int currentZoom = qRound(state.zoom * 100.0);
         for (int mode = 0; mode < 3; ++mode) {
             m_fovButtons[mode]->blockSignals(true);
-            m_fovButtons[mode]->setChecked(state.fovMode == mode);
+            m_fovButtons[mode]->setChecked(currentZoom == presetZoom[mode]);
             m_fovButtons[mode]->blockSignals(false);
         }
     }

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -295,13 +295,6 @@ void TrackingControlWidget::updateFromState(const CameraController::CameraState 
     bool commandInFlight = m_commandTimer->isActive();
     bool isSettling = m_controller->isSettling();
 
-    int trackingStyleIndex = m_trackingStyleCombo->findData(state.trackingStyle);
-    if (trackingStyleIndex >= 0 && !m_userInitiated && !commandInFlight && !isSettling) {
-        m_trackingStyleCombo->blockSignals(true);
-        m_trackingStyleCombo->setCurrentIndex(trackingStyleIndex);
-        m_trackingStyleCombo->blockSignals(false);
-    }
-
     if (m_trackingCheckBox->isChecked() != shouldBeChecked && !m_userInitiated && !commandInFlight && !isSettling) {
         m_trackingCheckBox->blockSignals(true);
         m_trackingCheckBox->setChecked(shouldBeChecked);

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -150,7 +150,7 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
 
     QHBoxLayout *fovLayout = new QHBoxLayout();
     static const char *fovLabels[] = {
-        "Wide (86°)", "Medium (78°)", "Narrow (65°)"
+        "86°", "78°", "65°"
     };
     for (int mode = 0; mode < 3; ++mode) {
         m_fovButtons[mode] = new QPushButton(fovLabels[mode], this);

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -10,6 +10,10 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     // Create debounce timer for command completion
     m_commandTimer = new QTimer(this);
     m_commandTimer->setSingleShot(true);
+    connect(m_commandTimer, &QTimer::timeout, this, [this]() {
+        if (m_controller->isConnected())
+            m_controller->saveConfig();
+    });
 
     // Unified throttle for all manual controls (pan/tilt, zoom, focus)
     m_controlThrottle = new QTimer(this);
@@ -470,8 +474,7 @@ void TrackingControlWidget::onTrackingStyleChanged(int index)
 {
     if (index < 0 || !m_controller->hasOriginalTinyCapabilities()) return;
     m_userInitiated = true;
-    if (m_controller->setTrackingStyle(m_trackingStyleCombo->itemData(index).toInt()))
-        m_controller->saveConfig();
+    m_controller->setTrackingStyle(m_trackingStyleCombo->itemData(index).toInt());
     m_commandTimer->start(1000);
 }
 
@@ -515,6 +518,7 @@ void TrackingControlWidget::flushPendingCommands()
 
 void TrackingControlWidget::scheduleFlush()
 {
+    m_commandTimer->start(1000);
     // First change fires immediately, subsequent ones coalesce at 100ms
     if (!m_controlThrottle->isActive()) {
         flushPendingCommands();

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -464,11 +464,22 @@ void TrackingControlWidget::onAudioGainToggled(bool checked)
     m_commandTimer->start(1000);
 }
 
+void TrackingControlWidget::setTrackingStyle(int style)
+{
+    int index = m_trackingStyleCombo->findData(style);
+    if (index >= 0) {
+        m_trackingStyleCombo->blockSignals(true);
+        m_trackingStyleCombo->setCurrentIndex(index);
+        m_trackingStyleCombo->blockSignals(false);
+    }
+}
+
 void TrackingControlWidget::onTrackingStyleChanged(int index)
 {
     if (index < 0 || !m_controller->hasOriginalTinyCapabilities()) return;
     m_userInitiated = true;
-    m_controller->setTrackingStyle(m_trackingStyleCombo->itemData(index).toInt());
+    if (m_controller->setTrackingStyle(m_trackingStyleCombo->itemData(index).toInt()))
+        m_controller->saveConfig();
     m_commandTimer->start(1000);
 }
 

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -179,14 +179,6 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     m_invertControlsCheckBox->setStyleSheet("font-size: 10px;");
     leftColumn->addWidget(m_invertControlsCheckBox);
 
-    // Mirror checkbox — syncs with Creative FX horizontal flip
-    m_mirrorCheckBox = new QCheckBox(tr("Mirror preview / virtual camera"), this);
-    m_mirrorCheckBox->setStyleSheet("font-size: 10px;");
-    connect(m_mirrorCheckBox, &QCheckBox::toggled, this, [this](bool checked) {
-        emit mirrorToggled(checked);
-    });
-    leftColumn->addWidget(m_mirrorCheckBox);
-
     leftColumn->addStretch();
     columnsLayout->addLayout(leftColumn, 1);
 
@@ -563,14 +555,4 @@ void TrackingControlWidget::onFocusChanged(int value)
 void TrackingControlWidget::setV4l2Mode(bool v4l2Only)
 {
     m_trackingGroupBox->setVisible(!v4l2Only);
-}
-
-void TrackingControlWidget::setMirrored(bool mirrored)
-{
-    // Sync checkbox without re-emitting mirrorToggled
-    if (m_mirrorCheckBox->isChecked() != mirrored) {
-        m_mirrorCheckBox->blockSignals(true);
-        m_mirrorCheckBox->setChecked(mirrored);
-        m_mirrorCheckBox->blockSignals(false);
-    }
 }

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -337,17 +337,6 @@ void TrackingControlWidget::updateFromState(const CameraController::CameraState 
         }
     }
 
-    // Sync zoom slider from camera state (only when user isn't dragging)
-    if (!m_zoomSlider->isSliderDown() && !commandInFlight && !isSettling) {
-        int zoomSliderVal = static_cast<int>(state.zoom * 10.0 + 0.5);
-        if (m_zoomSlider->value() != zoomSliderVal) {
-            m_zoomSlider->blockSignals(true);
-            m_zoomSlider->setValue(zoomSliderVal);
-            m_zoomSlider->blockSignals(false);
-            m_zoomLabel->setText(QString("%1x").arg(zoomSliderVal / 10.0, 0, 'f', 1));
-        }
-    }
-
     // Sync focus slider from camera state (only when user isn't dragging)
     if (!m_focusSlider->isSliderDown() && !commandInFlight && !isSettling) {
         if (m_focusSlider->value() != state.manualFocusValue) {

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -1,5 +1,8 @@
 #include "TrackingControlWidget.h"
+#include <algorithm>
+#include <QFont>
 #include <QLabel>
+#include <QPalette>
 #include <dev/dev.hpp>
 
 TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidget *parent)
@@ -28,7 +31,6 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     layout->setSpacing(14);
 
     m_trackingGroupBox = new QGroupBox("AI Tracking", this);
-    m_trackingGroupBox->setFlat(true);
     QVBoxLayout *groupLayout = new QVBoxLayout(m_trackingGroupBox);
     groupLayout->setContentsMargins(16, 16, 16, 16);
     groupLayout->setSpacing(12);
@@ -171,7 +173,6 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
 
     // Focus remains available while auto-framing is enabled.
     m_focusGroupBox = new QGroupBox("Focus", this);
-    m_focusGroupBox->setFlat(true);
     QVBoxLayout *focusGroupLayout = new QVBoxLayout(m_focusGroupBox);
     focusGroupLayout->setContentsMargins(16, 16, 16, 16);
     focusGroupLayout->setSpacing(8);
@@ -203,7 +204,6 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     ptzContainerLayout->setSpacing(0);
 
     QGroupBox *ptzGroupBox = new QGroupBox("Vision and Gimbal", this);
-    ptzGroupBox->setFlat(true);
     QVBoxLayout *ptzGroupLayout = new QVBoxLayout(ptzGroupBox);
     ptzGroupLayout->setContentsMargins(16, 16, 16, 16);
     ptzGroupLayout->setSpacing(12);
@@ -240,7 +240,10 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     // Position label (full width below both columns)
     m_positionLabel = new QLabel("Position: Pan 0.00, Tilt 0.00", this);
     m_positionLabel->setAlignment(Qt::AlignCenter);
-    m_positionLabel->setStyleSheet("color: palette(mid); font-size: 11px;");
+    m_positionLabel->setForegroundRole(QPalette::PlaceholderText);
+    QFont positionFont = m_positionLabel->font();
+    positionFont.setPointSizeF(std::max(1.0, positionFont.pointSizeF() - 1.0));
+    m_positionLabel->setFont(positionFont);
     ptzGroupLayout->addWidget(m_positionLabel);
     ptzGroupLayout->addWidget(zoomControls);
 

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -170,9 +170,9 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     zoomGroupLayout->addLayout(fovLayout);
 
     // Focus remains available while auto-framing is enabled.
-    QGroupBox *focusGroupBox = new QGroupBox("Focus", this);
-    focusGroupBox->setFlat(true);
-    QVBoxLayout *focusGroupLayout = new QVBoxLayout(focusGroupBox);
+    m_focusGroupBox = new QGroupBox("Focus", this);
+    m_focusGroupBox->setFlat(true);
+    QVBoxLayout *focusGroupLayout = new QVBoxLayout(m_focusGroupBox);
     focusGroupLayout->setContentsMargins(16, 16, 16, 16);
     focusGroupLayout->setSpacing(8);
 
@@ -194,7 +194,7 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     m_focusLabel->setMinimumWidth(40);
     focusLayout->addWidget(m_focusLabel);
     focusGroupLayout->addLayout(focusLayout);
-    layout->addWidget(focusGroupBox);
+    layout->addWidget(m_focusGroupBox);
 
     // Manual pan/tilt controls (disabled when auto-framing is enabled)
     m_ptzContainer = new QWidget(this);
@@ -212,10 +212,21 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     QHBoxLayout *columnsLayout = new QHBoxLayout();
     columnsLayout->setSpacing(16);
 
-    // Invert controls checkbox
-    m_invertControlsCheckBox = new QCheckBox(tr("Invert controls"), this);
-    m_invertControlsCheckBox->setStyleSheet("font-size: 10px;");
-    ptzGroupLayout->addWidget(m_invertControlsCheckBox);
+    m_gimbalControlGroup = new QGroupBox(tr("Gimbal Control"), this);
+    QVBoxLayout *gimbalSettingsLayout =
+        new QVBoxLayout(m_gimbalControlGroup);
+    gimbalSettingsLayout->setContentsMargins(16, 16, 16, 16);
+    m_invertXCheckBox = new QCheckBox(tr("Invert X"), m_gimbalControlGroup);
+    m_invertYCheckBox = new QCheckBox(tr("Invert Y"), m_gimbalControlGroup);
+    gimbalSettingsLayout->addWidget(m_invertXCheckBox);
+    gimbalSettingsLayout->addWidget(m_invertYCheckBox);
+    auto emitInversion = [this]() {
+        emit invertControlsChanged(
+            m_invertXCheckBox->isChecked(),
+            m_invertYCheckBox->isChecked());
+    };
+    connect(m_invertXCheckBox, &QCheckBox::toggled, this, emitInversion);
+    connect(m_invertYCheckBox, &QCheckBox::toggled, this, emitInversion);
 
     // Centered XY pad for pan/tilt
     m_xyPad = new XYPad(this);
@@ -255,6 +266,14 @@ void TrackingControlWidget::setPositionPresetsWidget(QWidget *widget)
     if (auto *pageLayout = qobject_cast<QVBoxLayout*>(layout())) {
         pageLayout->insertWidget(0, widget);
     }
+}
+
+void TrackingControlWidget::setInvertControls(bool invertX, bool invertY)
+{
+    QSignalBlocker blockX(m_invertXCheckBox);
+    QSignalBlocker blockY(m_invertYCheckBox);
+    m_invertXCheckBox->setChecked(invertX);
+    m_invertYCheckBox->setChecked(invertY);
 }
 
 void TrackingControlWidget::setAiMode(int mode)
@@ -458,10 +477,8 @@ void TrackingControlWidget::updateFromState(const CameraController::CameraState 
         float padX = state.pan;
         float padY = state.tilt;
         // XY pad shows control position, so invert back when invert is active
-        if (m_invertControlsCheckBox->isChecked()) {
-            padX = -padX;
-            padY = -padY;
-        }
+        if (m_invertXCheckBox->isChecked()) padX = -padX;
+        if (m_invertYCheckBox->isChecked()) padY = -padY;
         m_xyPad->setPosition(padX, padY);
         m_positionLabel->setText(QString("Position: Pan %1, Tilt %2")
             .arg(state.pan, 0, 'f', 2)
@@ -583,7 +600,6 @@ void TrackingControlWidget::updatePTZControlsState()
     // Disable PTZ controls when auto-framing is enabled
     bool enabled = !m_trackingCheckBox->isChecked();
     m_xyPad->setEnabled(enabled);
-    m_invertControlsCheckBox->setEnabled(enabled);
     m_positionLabel->setEnabled(enabled);
     m_originalTinyContainer->setEnabled(!enabled);
 }
@@ -616,10 +632,8 @@ void TrackingControlWidget::scheduleFlush()
 
 void TrackingControlWidget::onXYPadChanged(float x, float y)
 {
-    if (m_invertControlsCheckBox->isChecked()) {
-        x = -x;
-        y = -y;
-    }
+    if (m_invertXCheckBox->isChecked()) x = -x;
+    if (m_invertYCheckBox->isChecked()) y = -y;
 
     m_pendingPan = x;
     m_pendingTilt = y;

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -33,9 +33,11 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     groupLayout->setContentsMargins(16, 16, 16, 16);
     groupLayout->setSpacing(12);
 
-    m_trackingCheckBox = new QCheckBox("Enable Auto-Framing", this);
+    m_trackingCheckBox = new QPushButton("Enable Auto-Framing", this);
+    m_trackingCheckBox->setCheckable(true);
     m_trackingCheckBox->setStyleSheet("font-weight: 600; font-size: 14px;");
-    connect(m_trackingCheckBox, &QCheckBox::toggled, this, &TrackingControlWidget::onTrackingToggled);
+    connect(m_trackingCheckBox, &QPushButton::toggled,
+            this, &TrackingControlWidget::onTrackingToggled);
     groupLayout->addWidget(m_trackingCheckBox);
 
     m_originalTinyContainer = new QWidget(this);
@@ -286,6 +288,8 @@ void TrackingControlWidget::setAudioAutoGain(bool enabled)
 void TrackingControlWidget::onTrackingToggled(bool checked)
 {
     m_userInitiated = true;
+    m_trackingCheckBox->setText(checked
+        ? "Disable Auto-Framing" : "Enable Auto-Framing");
 
     if (m_tiny2Capabilities) {
         int modeValue = m_modeCombo->currentData().toInt();
@@ -308,6 +312,9 @@ void TrackingControlWidget::onTrackingToggled(bool checked)
     }
 
     m_controller->enableAutoFraming(checked);
+    setFaceFocusEnabled(checked);
+    m_controller->setFaceFocus(checked);
+    m_controller->setFaceAE(checked);
 
     // Update PTZ controls state (disable when auto-framing is on)
     updatePTZControlsState();
@@ -335,6 +342,8 @@ void TrackingControlWidget::updateFromState(const CameraController::CameraState 
         m_trackingCheckBox->setChecked(shouldBeChecked);
         m_trackingCheckBox->blockSignals(false);
     }
+    m_trackingCheckBox->setText(m_trackingCheckBox->isChecked()
+        ? "Disable Auto-Framing" : "Enable Auto-Framing");
 
     if (!m_userInitiated && !commandInFlight && !isSettling) {
         updatePTZControlsState();

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -568,6 +568,7 @@ void TrackingControlWidget::updatePTZControlsState()
     // Disable PTZ controls when auto-framing is enabled
     bool enabled = !m_trackingCheckBox->isChecked();
     m_ptzContainer->setEnabled(enabled);
+    m_originalTinyContainer->setEnabled(!enabled);
 }
 
 void TrackingControlWidget::flushPendingCommands()

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -27,7 +27,7 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     layout->setContentsMargins(8, 14, 8, 14);
     layout->setSpacing(14);
 
-    m_trackingGroupBox = new QGroupBox("Face Tracking", this);
+    m_trackingGroupBox = new QGroupBox("AI Tracking", this);
     m_trackingGroupBox->setFlat(true);
     QVBoxLayout *groupLayout = new QVBoxLayout(m_trackingGroupBox);
     groupLayout->setContentsMargins(16, 16, 16, 16);
@@ -44,11 +44,17 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     QHBoxLayout *originalTinyLayout = new QHBoxLayout(m_originalTinyContainer);
     originalTinyLayout->setContentsMargins(0, 8, 0, 0);
     static const char *trackingStyleLabels[] = {
-        "Standard", "Headroom", "Motion"
+        "Headroom", "Standard", "Motion"
     };
-    for (int style = 0; style < 3; ++style) {
+    static constexpr int trackingStyles[] = {
+        Device::AiVTrackHeadroom,
+        Device::AiVTrackStandard,
+        Device::AiVTrackMotion
+    };
+    for (int position = 0; position < 3; ++position) {
+        const int style = trackingStyles[position];
         m_trackingStyleButtons[style] =
-            new QPushButton(trackingStyleLabels[style], this);
+            new QPushButton(trackingStyleLabels[position], this);
         m_trackingStyleButtons[style]->setCheckable(true);
         connect(m_trackingStyleButtons[style], &QPushButton::clicked,
                 this, [this, style]() { onTrackingStyleChanged(style); });
@@ -129,10 +135,9 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     layout->addWidget(m_trackingGroupBox);
 
     // Zoom remains available while auto-framing is enabled.
-    QGroupBox *zoomGroupBox = new QGroupBox("Zoom", this);
-    zoomGroupBox->setFlat(true);
-    QVBoxLayout *zoomGroupLayout = new QVBoxLayout(zoomGroupBox);
-    zoomGroupLayout->setContentsMargins(16, 16, 16, 16);
+    QWidget *zoomControls = new QWidget(this);
+    QVBoxLayout *zoomGroupLayout = new QVBoxLayout(zoomControls);
+    zoomGroupLayout->setContentsMargins(0, 12, 0, 0);
     zoomGroupLayout->setSpacing(8);
 
     QHBoxLayout *zoomLayout = new QHBoxLayout();
@@ -163,7 +168,6 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
         fovLayout->addWidget(m_fovButtons[mode]);
     }
     zoomGroupLayout->addLayout(fovLayout);
-    layout->addWidget(zoomGroupBox);
 
     // Focus remains available while auto-framing is enabled.
     QGroupBox *focusGroupBox = new QGroupBox("Focus", this);
@@ -198,7 +202,7 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     ptzContainerLayout->setContentsMargins(0, 0, 0, 0);
     ptzContainerLayout->setSpacing(0);
 
-    QGroupBox *ptzGroupBox = new QGroupBox("Manual Control", this);
+    QGroupBox *ptzGroupBox = new QGroupBox("Vision and Gimbal", this);
     ptzGroupBox->setFlat(true);
     QVBoxLayout *ptzGroupLayout = new QVBoxLayout(ptzGroupBox);
     ptzGroupLayout->setContentsMargins(16, 16, 16, 16);
@@ -232,6 +236,7 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     m_positionLabel->setAlignment(Qt::AlignCenter);
     m_positionLabel->setStyleSheet("color: palette(mid); font-size: 11px;");
     ptzGroupLayout->addWidget(m_positionLabel);
+    ptzGroupLayout->addWidget(zoomControls);
 
     ptzContainerLayout->addWidget(ptzGroupBox);
     layout->addWidget(m_ptzContainer);
@@ -240,6 +245,21 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     updatePTZControlsState();
 
     layout->addStretch();
+}
+
+void TrackingControlWidget::setPositionPresetsWidget(QWidget *widget)
+{
+    if (!widget) {
+        return;
+    }
+    if (QWidget *oldParent = widget->parentWidget()) {
+        if (QLayout *oldLayout = oldParent->layout()) {
+            oldLayout->removeWidget(widget);
+        }
+    }
+    if (auto *pageLayout = qobject_cast<QVBoxLayout*>(layout())) {
+        pageLayout->insertWidget(0, widget);
+    }
 }
 
 void TrackingControlWidget::setAiMode(int mode)
@@ -567,7 +587,9 @@ void TrackingControlWidget::updatePTZControlsState()
 {
     // Disable PTZ controls when auto-framing is enabled
     bool enabled = !m_trackingCheckBox->isChecked();
-    m_ptzContainer->setEnabled(enabled);
+    m_xyPad->setEnabled(enabled);
+    m_invertControlsCheckBox->setEnabled(enabled);
+    m_positionLabel->setEnabled(enabled);
     m_originalTinyContainer->setEnabled(!enabled);
 }
 

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -34,6 +34,19 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     connect(m_trackingCheckBox, &QCheckBox::toggled, this, &TrackingControlWidget::onTrackingToggled);
     groupLayout->addWidget(m_trackingCheckBox);
 
+    m_originalTinyContainer = new QWidget(this);
+    QHBoxLayout *originalTinyLayout = new QHBoxLayout(m_originalTinyContainer);
+    originalTinyLayout->setContentsMargins(0, 8, 0, 0);
+    originalTinyLayout->addWidget(new QLabel("Tracking Style", this));
+    m_trackingStyleCombo = new QComboBox(this);
+    m_trackingStyleCombo->addItem("Standard", Device::AiVTrackStandard);
+    m_trackingStyleCombo->addItem("Headroom", Device::AiVTrackHeadroom);
+    m_trackingStyleCombo->addItem("Motion", Device::AiVTrackMotion);
+    connect(m_trackingStyleCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, &TrackingControlWidget::onTrackingStyleChanged);
+    originalTinyLayout->addWidget(m_trackingStyleCombo, 1);
+    groupLayout->addWidget(m_originalTinyContainer);
+
     // Advanced controls container (Tiny 2 family)
     m_advancedContainer = new QWidget(this);
     QVBoxLayout *advancedLayout = new QVBoxLayout(m_advancedContainer);
@@ -282,6 +295,13 @@ void TrackingControlWidget::updateFromState(const CameraController::CameraState 
     bool commandInFlight = m_commandTimer->isActive();
     bool isSettling = m_controller->isSettling();
 
+    int trackingStyleIndex = m_trackingStyleCombo->findData(state.trackingStyle);
+    if (trackingStyleIndex >= 0 && !m_userInitiated && !commandInFlight && !isSettling) {
+        m_trackingStyleCombo->blockSignals(true);
+        m_trackingStyleCombo->setCurrentIndex(trackingStyleIndex);
+        m_trackingStyleCombo->blockSignals(false);
+    }
+
     if (m_trackingCheckBox->isChecked() != shouldBeChecked && !m_userInitiated && !commandInFlight && !isSettling) {
         m_trackingCheckBox->blockSignals(true);
         m_trackingCheckBox->setChecked(shouldBeChecked);
@@ -444,6 +464,14 @@ void TrackingControlWidget::onAudioGainToggled(bool checked)
     m_commandTimer->start(1000);
 }
 
+void TrackingControlWidget::onTrackingStyleChanged(int index)
+{
+    if (index < 0 || !m_controller->hasOriginalTinyCapabilities()) return;
+    m_userInitiated = true;
+    m_controller->setTrackingStyle(m_trackingStyleCombo->itemData(index).toInt());
+    m_commandTimer->start(1000);
+}
+
 void TrackingControlWidget::updateTiny2Visibility()
 {
     if (!m_advancedContainer) {
@@ -455,6 +483,7 @@ void TrackingControlWidget::updateTiny2Visibility()
     m_tiny2Capabilities = m_controller->hasTiny2Capabilities();
 
     m_advancedContainer->setVisible(m_tiny2Capabilities);
+    m_originalTinyContainer->setVisible(m_controller->hasOriginalTinyCapabilities());
     m_humanSubModeCombo->setEnabled(m_tiny2Capabilities && m_modeCombo->currentData().toInt() == Device::AiWorkModeHuman);
 }
 

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -128,7 +128,7 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     ptzContainerLayout->setContentsMargins(0, 0, 0, 0);
     ptzContainerLayout->setSpacing(0);
 
-    QGroupBox *ptzGroupBox = new QGroupBox("Manual Camera Control", this);
+    QGroupBox *ptzGroupBox = new QGroupBox("Manual Control", this);
     ptzGroupBox->setFlat(true);
     QVBoxLayout *ptzGroupLayout = new QVBoxLayout(ptzGroupBox);
     ptzGroupLayout->setContentsMargins(16, 16, 16, 16);

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -24,7 +24,7 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     m_tiny2Capabilities = m_controller->hasTiny2Capabilities();
 
     QVBoxLayout *layout = new QVBoxLayout(this);
-    layout->setContentsMargins(8, 14, 8, 14);
+    layout->setContentsMargins(8, 8, 8, 14);
     layout->setSpacing(14);
 
     m_trackingGroupBox = new QGroupBox("AI Tracking", this);
@@ -212,22 +212,17 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     QHBoxLayout *columnsLayout = new QHBoxLayout();
     columnsLayout->setSpacing(16);
 
-    // Left column: manual-control options
-    QVBoxLayout *leftColumn = new QVBoxLayout();
-    leftColumn->addStretch();
-
     // Invert controls checkbox
     m_invertControlsCheckBox = new QCheckBox(tr("Invert controls"), this);
     m_invertControlsCheckBox->setStyleSheet("font-size: 10px;");
-    leftColumn->addWidget(m_invertControlsCheckBox);
+    ptzGroupLayout->addWidget(m_invertControlsCheckBox);
 
-    leftColumn->addStretch();
-    columnsLayout->addLayout(leftColumn, 1);
-
-    // Right column: XY pad for pan/tilt
+    // Centered XY pad for pan/tilt
     m_xyPad = new XYPad(this);
     connect(m_xyPad, &XYPad::positionChanged, this, &TrackingControlWidget::onXYPadChanged);
+    columnsLayout->addStretch(1);
     columnsLayout->addWidget(m_xyPad);
+    columnsLayout->addStretch(1);
 
     ptzGroupLayout->addLayout(columnsLayout);
 

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -122,7 +122,45 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
 
     layout->addWidget(m_trackingGroupBox);
 
-    // Manual PTZ Controls (disabled when auto-framing is enabled)
+    // Zoom remains available while auto-framing is enabled.
+    QGroupBox *zoomGroupBox = new QGroupBox("Zoom", this);
+    zoomGroupBox->setFlat(true);
+    QVBoxLayout *zoomGroupLayout = new QVBoxLayout(zoomGroupBox);
+    zoomGroupLayout->setContentsMargins(16, 16, 16, 16);
+    zoomGroupLayout->setSpacing(8);
+
+    QHBoxLayout *zoomLayout = new QHBoxLayout();
+    m_zoomSlider = new QSlider(Qt::Horizontal, this);
+    m_zoomSlider->setMinimum(100);  // 1.00x
+    m_zoomSlider->setMaximum(200);  // 2.00x
+    m_zoomSlider->setValue(100);
+    connect(m_zoomSlider, &QSlider::valueChanged,
+            this, &TrackingControlWidget::onZoomChanged);
+    zoomLayout->addWidget(m_zoomSlider, 1);
+    m_zoomLabel = new QLabel("1.00x", this);
+    m_zoomLabel->setMinimumWidth(40);
+    zoomLayout->addWidget(m_zoomLabel);
+    zoomGroupLayout->addLayout(zoomLayout);
+
+    QHBoxLayout *fovLayout = new QHBoxLayout();
+    static const char *fovLabels[] = {
+        "Wide (86°)", "Medium (78°)", "Narrow (65°)"
+    };
+    for (int mode = 0; mode < 3; ++mode) {
+        m_fovButtons[mode] = new QPushButton(fovLabels[mode], this);
+        m_fovButtons[mode]->setCheckable(true);
+        m_fovButtons[mode]->setAutoExclusive(true);
+        connect(m_fovButtons[mode], &QPushButton::clicked, this, [this, mode]() {
+            m_userInitiated = true;
+            m_controller->setFOV(mode);
+            m_commandTimer->start(1000);
+        });
+        fovLayout->addWidget(m_fovButtons[mode]);
+    }
+    zoomGroupLayout->addLayout(fovLayout);
+    layout->addWidget(zoomGroupBox);
+
+    // Manual pan/tilt/focus controls (disabled when auto-framing is enabled)
     m_ptzContainer = new QWidget(this);
     QVBoxLayout *ptzContainerLayout = new QVBoxLayout(m_ptzContainer);
     ptzContainerLayout->setContentsMargins(0, 0, 0, 0);
@@ -141,22 +179,6 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     // Left column: sliders and checkboxes
     QVBoxLayout *leftColumn = new QVBoxLayout();
     leftColumn->addStretch();
-
-    // Zoom slider
-    QHBoxLayout *zoomLayout = new QHBoxLayout();
-    QLabel *zoomLabel = new QLabel("Zoom:", this);
-    zoomLabel->setFixedWidth(40);
-    zoomLayout->addWidget(zoomLabel);
-    m_zoomSlider = new QSlider(Qt::Horizontal, this);
-    m_zoomSlider->setMinimum(100);  // 1.00x
-    m_zoomSlider->setMaximum(200);  // 2.00x
-    m_zoomSlider->setValue(100);
-    connect(m_zoomSlider, &QSlider::valueChanged, this, &TrackingControlWidget::onZoomChanged);
-    zoomLayout->addWidget(m_zoomSlider);
-    m_zoomLabel = new QLabel("1.0x", this);
-    m_zoomLabel->setMinimumWidth(40);
-    zoomLayout->addWidget(m_zoomLabel);
-    leftColumn->addLayout(zoomLayout);
 
     // Focus slider
     QHBoxLayout *focusLayout = new QHBoxLayout();
@@ -366,6 +388,14 @@ void TrackingControlWidget::updateFromState(const CameraController::CameraState 
         }
     }
 
+    if (!commandInFlight && !isSettling) {
+        for (int mode = 0; mode < 3; ++mode) {
+            m_fovButtons[mode]->blockSignals(true);
+            m_fovButtons[mode]->setChecked(state.fovMode == mode);
+            m_fovButtons[mode]->blockSignals(false);
+        }
+    }
+
     // Sync XY pad and position label from camera state (skip during active drag)
     if (!m_xyPad->isDragging() && !commandInFlight && !isSettling) {
         float padX = state.pan;
@@ -460,6 +490,7 @@ void TrackingControlWidget::setTrackingStyle(int style)
         m_trackingStyleCombo->setCurrentIndex(index);
         m_trackingStyleCombo->blockSignals(false);
     }
+
 }
 
 void TrackingControlWidget::onTrackingStyleChanged(int index)

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -315,9 +315,6 @@ void TrackingControlWidget::onTrackingToggled(bool checked)
     }
 
     m_controller->enableAutoFraming(checked);
-    setFaceFocusEnabled(checked);
-    m_controller->setFaceFocus(checked);
-    m_controller->setFaceAE(checked);
 
     // Update PTZ controls state (disable when auto-framing is on)
     updatePTZControlsState();

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -33,7 +33,7 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     groupLayout->setContentsMargins(16, 16, 16, 16);
     groupLayout->setSpacing(12);
 
-    m_trackingCheckBox = new QPushButton("Enable Auto-Framing", this);
+    m_trackingCheckBox = new QPushButton("Enable", this);
     m_trackingCheckBox->setCheckable(true);
     m_trackingCheckBox->setStyleSheet("font-weight: 600; font-size: 14px;");
     connect(m_trackingCheckBox, &QPushButton::toggled,
@@ -44,13 +44,18 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     QHBoxLayout *originalTinyLayout = new QHBoxLayout(m_originalTinyContainer);
     originalTinyLayout->setContentsMargins(0, 8, 0, 0);
     originalTinyLayout->addWidget(new QLabel("Tracking Style", this));
-    m_trackingStyleCombo = new QComboBox(this);
-    m_trackingStyleCombo->addItem("Standard", Device::AiVTrackStandard);
-    m_trackingStyleCombo->addItem("Headroom", Device::AiVTrackHeadroom);
-    m_trackingStyleCombo->addItem("Motion", Device::AiVTrackMotion);
-    connect(m_trackingStyleCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
-            this, &TrackingControlWidget::onTrackingStyleChanged);
-    originalTinyLayout->addWidget(m_trackingStyleCombo, 1);
+    static const char *trackingStyleLabels[] = {
+        "Standard", "Headroom", "Motion"
+    };
+    for (int style = 0; style < 3; ++style) {
+        m_trackingStyleButtons[style] =
+            new QPushButton(trackingStyleLabels[style], this);
+        m_trackingStyleButtons[style]->setCheckable(true);
+        connect(m_trackingStyleButtons[style], &QPushButton::clicked,
+                this, [this, style]() { onTrackingStyleChanged(style); });
+        originalTinyLayout->addWidget(m_trackingStyleButtons[style], 1);
+    }
+    setTrackingStyle(Device::AiVTrackStandard);
     groupLayout->addWidget(m_originalTinyContainer);
 
     // Advanced controls container (Tiny 2 family)
@@ -288,8 +293,7 @@ void TrackingControlWidget::setAudioAutoGain(bool enabled)
 void TrackingControlWidget::onTrackingToggled(bool checked)
 {
     m_userInitiated = true;
-    m_trackingCheckBox->setText(checked
-        ? "Disable Auto-Framing" : "Enable Auto-Framing");
+    m_trackingCheckBox->setText(checked ? "Disable" : "Enable");
 
     if (m_tiny2Capabilities) {
         int modeValue = m_modeCombo->currentData().toInt();
@@ -342,8 +346,8 @@ void TrackingControlWidget::updateFromState(const CameraController::CameraState 
         m_trackingCheckBox->setChecked(shouldBeChecked);
         m_trackingCheckBox->blockSignals(false);
     }
-    m_trackingCheckBox->setText(m_trackingCheckBox->isChecked()
-        ? "Disable Auto-Framing" : "Enable Auto-Framing");
+    m_trackingCheckBox->setText(
+        m_trackingCheckBox->isChecked() ? "Disable" : "Enable");
 
     if (!m_userInitiated && !commandInFlight && !isSettling) {
         updatePTZControlsState();
@@ -353,6 +357,11 @@ void TrackingControlWidget::updateFromState(const CameraController::CameraState 
     // Refresh both Tiny2 and original-Tiny containers after every state
     // update so a late SDK connection can reveal the correct controls.
     updateTiny2Visibility();
+
+    if (m_controller->hasOriginalTinyCapabilities()
+            && !m_userInitiated && !commandInFlight && !isSettling) {
+        setTrackingStyle(state.trackingStyle);
+    }
 
     if (m_tiny2Capabilities && !m_userInitiated && !commandInFlight && !isSettling) {
         int modeIdx = m_modeCombo->findData(state.aiMode);
@@ -521,20 +530,25 @@ void TrackingControlWidget::onAudioGainToggled(bool checked)
 
 void TrackingControlWidget::setTrackingStyle(int style)
 {
-    int index = m_trackingStyleCombo->findData(style);
-    if (index >= 0) {
-        m_trackingStyleCombo->blockSignals(true);
-        m_trackingStyleCombo->setCurrentIndex(index);
-        m_trackingStyleCombo->blockSignals(false);
+    if (style < Device::AiVTrackStandard || style > Device::AiVTrackMotion) {
+        return;
     }
-
+    m_trackingStyle = style;
+    for (int buttonStyle = 0; buttonStyle < 3; ++buttonStyle) {
+        QSignalBlocker blocker(m_trackingStyleButtons[buttonStyle]);
+        m_trackingStyleButtons[buttonStyle]->setChecked(buttonStyle == style);
+    }
 }
 
-void TrackingControlWidget::onTrackingStyleChanged(int index)
+void TrackingControlWidget::onTrackingStyleChanged(int style)
 {
-    if (index < 0 || !m_controller->hasOriginalTinyCapabilities()) return;
+    if (style < Device::AiVTrackStandard || style > Device::AiVTrackMotion
+            || !m_controller->hasOriginalTinyCapabilities()) {
+        return;
+    }
     m_userInitiated = true;
-    m_controller->setTrackingStyle(m_trackingStyleCombo->itemData(index).toInt());
+    setTrackingStyle(style);
+    m_controller->setTrackingStyle(style);
     m_commandTimer->start(1000);
 }
 

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -461,6 +461,10 @@ void TrackingControlWidget::updateTiny2Visibility()
         return;
     }
 
+    // Re-read on every pass: the constructor runs before a camera is
+    // connected, so a value captured once there can never become true.
+    m_tiny2Capabilities = m_controller->hasTiny2Capabilities();
+
     m_advancedContainer->setVisible(m_tiny2Capabilities);
     m_humanSubModeCombo->setEnabled(m_tiny2Capabilities && m_modeCombo->currentData().toInt() == Device::AiWorkModeHuman);
 }

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -180,7 +180,7 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     leftColumn->addWidget(m_invertControlsCheckBox);
 
     // Mirror checkbox — syncs with Creative FX horizontal flip
-    m_mirrorCheckBox = new QCheckBox(tr("Mirror view"), this);
+    m_mirrorCheckBox = new QCheckBox(tr("Mirror preview / virtual camera"), this);
     m_mirrorCheckBox->setStyleSheet("font-size: 10px;");
     connect(m_mirrorCheckBox, &QCheckBox::toggled, this, [this](bool checked) {
         emit mirrorToggled(checked);

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -305,11 +305,10 @@ void TrackingControlWidget::updateFromState(const CameraController::CameraState 
         updatePTZControlsState();
     }
 
-    bool tiny2 = m_controller->hasTiny2Capabilities();
-    if (tiny2 != m_tiny2Capabilities) {
-        m_tiny2Capabilities = tiny2;
-        updateTiny2Visibility();
-    }
+    // Connection capabilities are unknown when this widget is constructed.
+    // Refresh both Tiny2 and original-Tiny containers after every state
+    // update so a late SDK connection can reveal the correct controls.
+    updateTiny2Visibility();
 
     if (m_tiny2Capabilities && !m_userInitiated && !commandInFlight && !isSettling) {
         int modeIdx = m_modeCombo->findData(state.aiMode);

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -43,7 +43,6 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     m_originalTinyContainer = new QWidget(this);
     QHBoxLayout *originalTinyLayout = new QHBoxLayout(m_originalTinyContainer);
     originalTinyLayout->setContentsMargins(0, 8, 0, 0);
-    originalTinyLayout->addWidget(new QLabel("Tracking Style", this));
     static const char *trackingStyleLabels[] = {
         "Standard", "Headroom", "Motion"
     };

--- a/src/gui/TrackingControlWidget.h
+++ b/src/gui/TrackingControlWidget.h
@@ -45,11 +45,7 @@ public:
     int currentTrackSpeed() const { return m_speedCombo->currentData().toInt(); }
     int currentTrackingStyle() const { return m_trackingStyleCombo->currentData().toInt(); }
     bool isAudioAutoGainEnabled() const { return m_audioGainCheckBox->isChecked(); }
-    void setMirrored(bool mirrored);
     bool isInvertControls() const { return m_invertControlsCheckBox->isChecked(); }
-
-signals:
-    void mirrorToggled(bool mirrored);
 
 private slots:
     void onTrackingToggled(bool checked);
@@ -83,7 +79,6 @@ private:
     // Manual PTZ controls
     XYPad *m_xyPad;
     QCheckBox *m_invertControlsCheckBox;
-    QCheckBox *m_mirrorCheckBox;
     QSlider *m_zoomSlider;
     QLabel *m_zoomLabel;
     QSlider *m_focusSlider;

--- a/src/gui/TrackingControlWidget.h
+++ b/src/gui/TrackingControlWidget.h
@@ -6,6 +6,7 @@
 #include <QComboBox>
 #include <QSlider>
 #include <QLabel>
+#include <QPushButton>
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QGroupBox>
@@ -81,6 +82,7 @@ private:
     QCheckBox *m_invertControlsCheckBox;
     QSlider *m_zoomSlider;
     QLabel *m_zoomLabel;
+    QPushButton *m_fovButtons[3];
     QSlider *m_focusSlider;
     QLabel *m_focusLabel;
     QLabel *m_positionLabel;

--- a/src/gui/TrackingControlWidget.h
+++ b/src/gui/TrackingControlWidget.h
@@ -32,8 +32,7 @@ public:
     void setTrackingEnabled(bool enabled) {
         m_trackingCheckBox->blockSignals(true);
         m_trackingCheckBox->setChecked(enabled);
-        m_trackingCheckBox->setText(enabled
-            ? "Disable Auto-Framing" : "Enable Auto-Framing");
+        m_trackingCheckBox->setText(enabled ? "Disable" : "Enable");
         m_trackingCheckBox->blockSignals(false);
     }
     void setAiMode(int mode);
@@ -46,7 +45,7 @@ public:
     int currentHumanSubMode() const { return m_humanSubModeCombo->currentData().toInt(); }
     bool isAutoZoomEnabled() const { return m_autoZoomCheckBox->isChecked(); }
     int currentTrackSpeed() const { return m_speedCombo->currentData().toInt(); }
-    int currentTrackingStyle() const { return m_trackingStyleCombo->currentData().toInt(); }
+    int currentTrackingStyle() const { return m_trackingStyle; }
     bool isAudioAutoGainEnabled() const { return m_audioGainCheckBox->isChecked(); }
     bool isFaceFocusEnabled() const { return m_faceFocusCheckBox->isChecked(); }
     void setFaceFocusEnabled(bool enabled);
@@ -77,7 +76,8 @@ private:
     QCheckBox *m_audioGainCheckBox;
     QWidget *m_advancedContainer;
     QWidget *m_originalTinyContainer;
-    QComboBox *m_trackingStyleCombo;
+    QPushButton *m_trackingStyleButtons[3];
+    int m_trackingStyle = Device::AiVTrackStandard;
     bool m_userInitiated;  // Track if change was user-initiated
     QTimer *m_commandTimer;  // Debounce timer for command completion
     bool m_tiny2Capabilities; // flag for advanced tracking features

--- a/src/gui/TrackingControlWidget.h
+++ b/src/gui/TrackingControlWidget.h
@@ -37,11 +37,13 @@ public:
     void setHumanSubMode(int subMode);
     void setAutoZoomEnabled(bool enabled);
     void setTrackSpeed(int speedMode);
+    void setTrackingStyle(int style);
     void setAudioAutoGain(bool enabled);
     int currentAiMode() const { return m_modeCombo->currentData().toInt(); }
     int currentHumanSubMode() const { return m_humanSubModeCombo->currentData().toInt(); }
     bool isAutoZoomEnabled() const { return m_autoZoomCheckBox->isChecked(); }
     int currentTrackSpeed() const { return m_speedCombo->currentData().toInt(); }
+    int currentTrackingStyle() const { return m_trackingStyleCombo->currentData().toInt(); }
     bool isAudioAutoGainEnabled() const { return m_audioGainCheckBox->isChecked(); }
     void setMirrored(bool mirrored);
     bool isInvertControls() const { return m_invertControlsCheckBox->isChecked(); }

--- a/src/gui/TrackingControlWidget.h
+++ b/src/gui/TrackingControlWidget.h
@@ -28,6 +28,7 @@ public:
 
     void updateFromState(const CameraController::CameraState &state);
     void setV4l2Mode(bool v4l2Only);
+    void setPositionPresetsWidget(QWidget *widget);
     bool isTrackingEnabled() const { return m_trackingCheckBox->isChecked(); }
     void setTrackingEnabled(bool enabled) {
         m_trackingCheckBox->blockSignals(true);

--- a/src/gui/TrackingControlWidget.h
+++ b/src/gui/TrackingControlWidget.h
@@ -56,6 +56,7 @@ private slots:
     void onAutoZoomToggled(bool checked);
     void onSpeedChanged(int index);
     void onAudioGainToggled(bool checked);
+    void onTrackingStyleChanged(int index);
 
     // Manual PTZ control slots
     void onXYPadChanged(float x, float y);
@@ -71,6 +72,8 @@ private:
     QComboBox *m_speedCombo;
     QCheckBox *m_audioGainCheckBox;
     QWidget *m_advancedContainer;
+    QWidget *m_originalTinyContainer;
+    QComboBox *m_trackingStyleCombo;
     bool m_userInitiated;  // Track if change was user-initiated
     QTimer *m_commandTimer;  // Debounce timer for command completion
     bool m_tiny2Capabilities; // flag for advanced tracking features

--- a/src/gui/TrackingControlWidget.h
+++ b/src/gui/TrackingControlWidget.h
@@ -29,6 +29,8 @@ public:
     void updateFromState(const CameraController::CameraState &state);
     void setV4l2Mode(bool v4l2Only);
     void setPositionPresetsWidget(QWidget *widget);
+    QGroupBox *focusGroup() const { return m_focusGroupBox; }
+    QGroupBox *gimbalControlGroup() const { return m_gimbalControlGroup; }
     bool isTrackingEnabled() const { return m_trackingCheckBox->isChecked(); }
     void setTrackingEnabled(bool enabled) {
         m_trackingCheckBox->blockSignals(true);
@@ -50,7 +52,12 @@ public:
     bool isAudioAutoGainEnabled() const { return m_audioGainCheckBox->isChecked(); }
     bool isFaceFocusEnabled() const { return m_faceFocusCheckBox->isChecked(); }
     void setFaceFocusEnabled(bool enabled);
-    bool isInvertControls() const { return m_invertControlsCheckBox->isChecked(); }
+    void setInvertControls(bool invertX, bool invertY);
+    bool isInvertX() const { return m_invertXCheckBox->isChecked(); }
+    bool isInvertY() const { return m_invertYCheckBox->isChecked(); }
+
+signals:
+    void invertControlsChanged(bool invertX, bool invertY);
 
 private slots:
     void onTrackingToggled(bool checked);
@@ -85,7 +92,8 @@ private:
 
     // Manual PTZ controls
     XYPad *m_xyPad;
-    QCheckBox *m_invertControlsCheckBox;
+    QCheckBox *m_invertXCheckBox;
+    QCheckBox *m_invertYCheckBox;
     QSlider *m_zoomSlider;
     QLabel *m_zoomLabel;
     QPushButton *m_fovButtons[3];
@@ -111,6 +119,8 @@ private:
     void updatePTZControlsState();
 
     QGroupBox *m_trackingGroupBox;
+    QGroupBox *m_focusGroupBox;
+    QGroupBox *m_gimbalControlGroup;
 };
 
 #endif // TRACKINGCONTROLWIDGET_H

--- a/src/gui/TrackingControlWidget.h
+++ b/src/gui/TrackingControlWidget.h
@@ -46,6 +46,8 @@ public:
     int currentTrackSpeed() const { return m_speedCombo->currentData().toInt(); }
     int currentTrackingStyle() const { return m_trackingStyleCombo->currentData().toInt(); }
     bool isAudioAutoGainEnabled() const { return m_audioGainCheckBox->isChecked(); }
+    bool isFaceFocusEnabled() const { return m_faceFocusCheckBox->isChecked(); }
+    void setFaceFocusEnabled(bool enabled);
     bool isInvertControls() const { return m_invertControlsCheckBox->isChecked(); }
 
 private slots:
@@ -56,6 +58,7 @@ private slots:
     void onSpeedChanged(int index);
     void onAudioGainToggled(bool checked);
     void onTrackingStyleChanged(int index);
+    void onFaceFocusToggled(bool checked);
 
     // Manual PTZ control slots
     void onXYPadChanged(float x, float y);
@@ -85,6 +88,7 @@ private:
     QPushButton *m_fovButtons[3];
     QSlider *m_focusSlider;
     QLabel *m_focusLabel;
+    QCheckBox *m_faceFocusCheckBox;
     QLabel *m_positionLabel;
     QWidget *m_ptzContainer;
 

--- a/src/gui/TrackingControlWidget.h
+++ b/src/gui/TrackingControlWidget.h
@@ -32,6 +32,8 @@ public:
     void setTrackingEnabled(bool enabled) {
         m_trackingCheckBox->blockSignals(true);
         m_trackingCheckBox->setChecked(enabled);
+        m_trackingCheckBox->setText(enabled
+            ? "Disable Auto-Framing" : "Enable Auto-Framing");
         m_trackingCheckBox->blockSignals(false);
     }
     void setAiMode(int mode);
@@ -67,7 +69,7 @@ private slots:
 
 private:
     CameraController *m_controller;
-    QCheckBox *m_trackingCheckBox;
+    QPushButton *m_trackingCheckBox;
     QComboBox *m_modeCombo;
     QComboBox *m_humanSubModeCombo;
     QCheckBox *m_autoZoomCheckBox;

--- a/src/gui/V4l2Backend.cpp
+++ b/src/gui/V4l2Backend.cpp
@@ -168,6 +168,16 @@ bool V4l2Backend::setAutoExposure(bool automatic)
 }
 
 bool V4l2Backend::setExposureAbsolute(int value) { return setControl(V4L2_CID_EXPOSURE_ABSOLUTE, value); }
+int V4l2Backend::getExposureAbsolute() { return getControl(V4L2_CID_EXPOSURE_ABSOLUTE); }
+V4l2Backend::ControlRange V4l2Backend::getExposureRange() { return queryRange(V4L2_CID_EXPOSURE_ABSOLUTE); }
+bool V4l2Backend::setGain(int value) { return setControl(V4L2_CID_GAIN, value); }
+int V4l2Backend::getGain() { return getControl(V4L2_CID_GAIN); }
+V4l2Backend::ControlRange V4l2Backend::getGainRange() { return queryRange(V4L2_CID_GAIN); }
+bool V4l2Backend::setBacklightCompensation(int value) { return setControl(V4L2_CID_BACKLIGHT_COMPENSATION, value); }
+int V4l2Backend::getBacklightCompensation() { return getControl(V4L2_CID_BACKLIGHT_COMPENSATION); }
+V4l2Backend::ControlRange V4l2Backend::getBacklightCompensationRange() {
+    return queryRange(V4L2_CID_BACKLIGHT_COMPENSATION);
+}
 
 bool V4l2Backend::setAutoFocus(bool enabled) { return setControl(V4L2_CID_FOCUS_AUTO, enabled ? 1 : 0); }
 bool V4l2Backend::getAutoFocus() { return getControl(V4L2_CID_FOCUS_AUTO) == 1; }

--- a/src/gui/V4l2Backend.cpp
+++ b/src/gui/V4l2Backend.cpp
@@ -164,11 +164,15 @@ V4l2Backend::ControlRange V4l2Backend::getZoomRange() { return queryRange(V4L2_C
 bool V4l2Backend::setAutoExposure(bool automatic)
 {
     return setControl(V4L2_CID_EXPOSURE_AUTO,
-                      automatic ? V4L2_EXPOSURE_AUTO : V4L2_EXPOSURE_MANUAL);
+                      automatic
+                          ? V4L2_EXPOSURE_APERTURE_PRIORITY
+                          : V4L2_EXPOSURE_MANUAL);
 }
 bool V4l2Backend::getAutoExposure()
 {
-    return getControl(V4L2_CID_EXPOSURE_AUTO) == V4L2_EXPOSURE_AUTO;
+    const int mode = getControl(V4L2_CID_EXPOSURE_AUTO);
+    return mode == V4L2_EXPOSURE_AUTO
+        || mode == V4L2_EXPOSURE_APERTURE_PRIORITY;
 }
 
 bool V4l2Backend::setExposureAbsolute(int value) { return setControl(V4L2_CID_EXPOSURE_ABSOLUTE, value); }

--- a/src/gui/V4l2Backend.cpp
+++ b/src/gui/V4l2Backend.cpp
@@ -163,16 +163,8 @@ V4l2Backend::ControlRange V4l2Backend::getZoomRange() { return queryRange(V4L2_C
 
 bool V4l2Backend::setAutoExposure(bool automatic)
 {
-    if (!automatic)
-        return setControl(V4L2_CID_EXPOSURE_AUTO, V4L2_EXPOSURE_MANUAL);
-
-    // Some UVC cameras (including Tiny 4K firmware 1.2.6.2) advertise the
-    // standard Auto value but mark it unavailable. Shutter Priority is their
-    // supported adaptive mode: shutter stays selected while gain follows
-    // changing light.
-    if (setControl(V4L2_CID_EXPOSURE_AUTO, V4L2_EXPOSURE_AUTO))
-        return true;
-    return setControl(V4L2_CID_EXPOSURE_AUTO, V4L2_EXPOSURE_SHUTTER_PRIORITY);
+    return setControl(V4L2_CID_EXPOSURE_AUTO,
+                      automatic ? V4L2_EXPOSURE_AUTO : V4L2_EXPOSURE_MANUAL);
 }
 
 bool V4l2Backend::setExposureAbsolute(int value) { return setControl(V4L2_CID_EXPOSURE_ABSOLUTE, value); }

--- a/src/gui/V4l2Backend.cpp
+++ b/src/gui/V4l2Backend.cpp
@@ -163,7 +163,16 @@ V4l2Backend::ControlRange V4l2Backend::getZoomRange() { return queryRange(V4L2_C
 
 bool V4l2Backend::setAutoExposure(bool automatic)
 {
-    return setControl(V4L2_CID_EXPOSURE_AUTO, automatic ? V4L2_EXPOSURE_AUTO : V4L2_EXPOSURE_MANUAL);
+    if (!automatic)
+        return setControl(V4L2_CID_EXPOSURE_AUTO, V4L2_EXPOSURE_MANUAL);
+
+    // Some UVC cameras (including Tiny 4K firmware 1.2.6.2) advertise the
+    // standard Auto value but mark it unavailable. Shutter Priority is their
+    // supported adaptive mode: shutter stays selected while gain follows
+    // changing light.
+    if (setControl(V4L2_CID_EXPOSURE_AUTO, V4L2_EXPOSURE_AUTO))
+        return true;
+    return setControl(V4L2_CID_EXPOSURE_AUTO, V4L2_EXPOSURE_SHUTTER_PRIORITY);
 }
 
 bool V4l2Backend::setExposureAbsolute(int value) { return setControl(V4L2_CID_EXPOSURE_ABSOLUTE, value); }

--- a/src/gui/V4l2Backend.cpp
+++ b/src/gui/V4l2Backend.cpp
@@ -165,13 +165,14 @@ bool V4l2Backend::setAutoExposure(bool automatic)
 {
     return setControl(V4L2_CID_EXPOSURE_AUTO,
                       automatic
-                          ? V4L2_EXPOSURE_APERTURE_PRIORITY
+                          ? V4L2_EXPOSURE_SHUTTER_PRIORITY
                           : V4L2_EXPOSURE_MANUAL);
 }
 bool V4l2Backend::getAutoExposure()
 {
     const int mode = getControl(V4L2_CID_EXPOSURE_AUTO);
     return mode == V4L2_EXPOSURE_AUTO
+        || mode == V4L2_EXPOSURE_SHUTTER_PRIORITY
         || mode == V4L2_EXPOSURE_APERTURE_PRIORITY;
 }
 

--- a/src/gui/V4l2Backend.cpp
+++ b/src/gui/V4l2Backend.cpp
@@ -166,6 +166,10 @@ bool V4l2Backend::setAutoExposure(bool automatic)
     return setControl(V4L2_CID_EXPOSURE_AUTO,
                       automatic ? V4L2_EXPOSURE_AUTO : V4L2_EXPOSURE_MANUAL);
 }
+bool V4l2Backend::getAutoExposure()
+{
+    return getControl(V4L2_CID_EXPOSURE_AUTO) == V4L2_EXPOSURE_AUTO;
+}
 
 bool V4l2Backend::setExposureAbsolute(int value) { return setControl(V4L2_CID_EXPOSURE_ABSOLUTE, value); }
 int V4l2Backend::getExposureAbsolute() { return getControl(V4L2_CID_EXPOSURE_ABSOLUTE); }

--- a/src/gui/V4l2Backend.h
+++ b/src/gui/V4l2Backend.h
@@ -63,6 +63,14 @@ public:
 
     bool setAutoExposure(bool automatic);
     bool setExposureAbsolute(int value);
+    int getExposureAbsolute();
+    ControlRange getExposureRange();
+    bool setGain(int value);
+    int getGain();
+    ControlRange getGainRange();
+    bool setBacklightCompensation(int value);
+    int getBacklightCompensation();
+    ControlRange getBacklightCompensationRange();
 
     bool setAutoFocus(bool enabled);
     bool getAutoFocus();

--- a/src/gui/V4l2Backend.h
+++ b/src/gui/V4l2Backend.h
@@ -62,6 +62,7 @@ public:
     ControlRange getZoomRange();
 
     bool setAutoExposure(bool automatic);
+    bool getAutoExposure();
     bool setExposureAbsolute(int value);
     int getExposureAbsolute();
     ControlRange getExposureRange();

--- a/src/gui/VideoEffectsWidget.cpp
+++ b/src/gui/VideoEffectsWidget.cpp
@@ -1,11 +1,14 @@
 #include "VideoEffectsWidget.h"
 
+#include <algorithm>
 #include <QCheckBox>
 #include <QColorDialog>
+#include <QFont>
 #include <QFormLayout>
 #include <QGroupBox>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QPalette>
 #include <QPushButton>
 #include <QSlider>
 #include <QVBoxLayout>
@@ -60,7 +63,10 @@ VideoEffectsWidget::VideoEffectsWidget(QWidget *parent)
            "They do not change the physical camera output."),
         this);
     infoLabel->setWordWrap(true);
-    infoLabel->setStyleSheet("color: palette(mid); font-size: 11px;");
+    infoLabel->setForegroundRole(QPalette::PlaceholderText);
+    QFont infoFont = infoLabel->font();
+    infoFont.setPointSizeF(std::max(1.0, infoFont.pointSizeF() - 1.0));
+    infoLabel->setFont(infoFont);
     rootLayout->addWidget(infoLabel);
 
     auto addSlider = [&](QVBoxLayout *groupLayout, const QString &label, float min, float max, float initial, std::function<void(float)> setter) {

--- a/src/gui/VideoEffectsWidget.cpp
+++ b/src/gui/VideoEffectsWidget.cpp
@@ -55,7 +55,10 @@ VideoEffectsWidget::VideoEffectsWidget(QWidget *parent)
     rootLayout->setContentsMargins(12, 12, 12, 12);
     rootLayout->setSpacing(12);
 
-    QLabel *infoLabel = new QLabel(tr("Creative adjustments are applied in software and do not change the camera's onboard settings."), this);
+    QLabel *infoLabel = new QLabel(
+        tr("Effects are applied only to the preview, snapshots, and virtual camera. "
+           "They do not change the physical camera output."),
+        this);
     infoLabel->setWordWrap(true);
     infoLabel->setStyleSheet("color: palette(mid); font-size: 11px;");
     rootLayout->addWidget(infoLabel);

--- a/src/gui/VideoEffectsWidget.cpp
+++ b/src/gui/VideoEffectsWidget.cpp
@@ -52,7 +52,7 @@ VideoEffectsWidget::VideoEffectsWidget(QWidget *parent)
     , m_highlightColorButton(nullptr)
 {
     auto *rootLayout = new QVBoxLayout(this);
-    rootLayout->setContentsMargins(12, 12, 12, 12);
+    rootLayout->setContentsMargins(12, 8, 12, 12);
     rootLayout->setSpacing(12);
 
     QLabel *infoLabel = new QLabel(

--- a/src/gui/VideoEffectsWidget.cpp
+++ b/src/gui/VideoEffectsWidget.cpp
@@ -194,7 +194,8 @@ VideoEffectsWidget::VideoEffectsWidget(QWidget *parent)
     QVBoxLayout *orientationLayout = new QVBoxLayout(orientationGroup);
     orientationLayout->setSpacing(6);
 
-    m_horizontalFlipCheckBox = new QCheckBox(tr("Mirror (horizontal flip)"), orientationGroup);
+    m_horizontalFlipCheckBox = new QCheckBox(
+        tr("Mirror preview / virtual camera"), orientationGroup);
     m_horizontalFlipCheckBox->setChecked(m_settings.horizontalFlip);
     connect(m_horizontalFlipCheckBox, &QCheckBox::toggled, this, [this](bool checked) {
         m_settings.horizontalFlip = checked;

--- a/src/gui/VideoEffectsWidget.cpp
+++ b/src/gui/VideoEffectsWidget.cpp
@@ -194,8 +194,7 @@ VideoEffectsWidget::VideoEffectsWidget(QWidget *parent)
     QVBoxLayout *orientationLayout = new QVBoxLayout(orientationGroup);
     orientationLayout->setSpacing(6);
 
-    m_horizontalFlipCheckBox = new QCheckBox(
-        tr("Mirror preview / virtual camera"), orientationGroup);
+    m_horizontalFlipCheckBox = new QCheckBox(tr("Mirror"), orientationGroup);
     m_horizontalFlipCheckBox->setChecked(m_settings.horizontalFlip);
     connect(m_horizontalFlipCheckBox, &QCheckBox::toggled, this, [this](bool checked) {
         m_settings.horizontalFlip = checked;


### PR DESCRIPTION
## Summary

- allow the asynchronous OBSBOT SDK discovery to complete before falling back to V4L2 (based on #53)
- invalidate delayed fallback work when the selected camera changes or disconnects
- use the original Tiny/Tiny 4K SDK APIs for target tracking, absolute zoom, gimbal positioning, and centering
- read tracking state from `ai_target` and zoom through the normalized SDK getter
- fix the duplicated, incorrectly-scaled zoom slider synchronization
- report Tiny 4K tracking correctly in the status bar

## Why

The Tiny 4K SDK handshake takes several seconds. The app previously committed to V4L2 fallback immediately, leaving the device labeled `OBSBOT Tiny 4K (V4L2)` and hiding SDK-only controls. Once connected through the SDK, several controls still called APIs documented for Meet or Tiny 2 rather than the original Tiny family.

Tested with an OBSBOT Tiny 4K (product type `ObsbotProdTiny4k`, firmware 1.2.6.2). SDK probing confirmed support for target selection, gimbal positioning/reset, normalized 1.0–2.0 zoom, HDR, FOV, face AE/focus, manual focus, image controls, white balance, exposure, and anti-flicker. Tiny 2-only auto zoom/audio gain/tracking-speed controls remain hidden.

## Verification

- `cmake --build build -j 32`
- SDK discovery identifies the connected camera as product type 1 instead of remaining in V4L2 fallback
- direct SDK getters/range queries verified against the connected Tiny 4K
- stale 8-second fallback callbacks are ignored after a reconnect, camera switch, or disconnect
- release build installed and launched through the KDE desktop entry

Includes and supersedes the Tiny 4K-relevant discovery fix proposed in #53.