### PR TITLE
Fix locale-dependent config parsing

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -5,6 +5,8 @@ int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
 
+    std::setlocale(LC_NUMERIC, "C");
+    
     MainWindow window;
     if (!window.isStartingMinimized()) {
         window.show();


### PR DESCRIPTION
## What does this change?
Forces `LC_NUMERIC` to the `C` locale in `main()` (in `src/gui/main.cpp`), right after the `QApplication` constructor and before `MainWindow` is constructed. This ensures floating-point config values are always parsed with a dot as the decimal separator.

## Why?
On systems with a non-English locale (e.g. `de_DE`, where the decimal separator is a comma), preset and PTZ values load with wrong values. `QApplication`'s constructor calls `setlocale(LC_ALL, "")`, which activates the system locale. After that, the `std::stod` calls in `Config.cpp` stop parsing at the `.` so `1.5` becomes `1`.

Starting the app with `LC_NUMERIC=C ./obsbot-gui` works around it, which confirmed the cause. This one-line fix makes it work correctly without any prefix, while keeping the rest of the UI (dates, text) in the user's locale.

## How to test
1. On a system with a non-English/comma-decimal locale (e.g. `de_DE.UTF-8`), define a couple of PTZ presets with non-integer pan/tilt values and restart the app, without the fix they load with truncated/wrong values.
2. With this change built in, restart the app normally (no` LC_NUMERIC=C` prefix) and confirm the presets load with their correct values.

## Checklist
- [x] Builds cleanly: `./build.sh build --confirm`
- [x] Tested with my camera (model: OBSBOT Tiny 2 Lite)
