### PR TITLE
feat: add table scenes and automatic paper crop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,12 @@ target_compile_definitions(obsbot-gui PRIVATE
 # CLI Application
 add_executable(obsbot-cli
     src/cli/meet2_test.cpp
+    src/cli/CliOptions.cpp
+    src/cli/CliOptions.h
+    src/cli/CameraSelection.cpp
+    src/cli/CameraSelection.h
+    src/cli/PresetCommand.cpp
+    src/cli/PresetCommand.h
     src/common/Config.cpp
     src/common/Config.h
 )
@@ -104,3 +110,26 @@ set_target_properties(obsbot-cli PROPERTIES
     BUILD_RPATH "${SDK_LIB_DIR}"
     INSTALL_RPATH "/usr/lib"
 )
+
+include(CTest)
+if(BUILD_TESTING)
+    add_executable(cli-options-test
+        tests/CliOptionsTest.cpp
+        src/cli/CliOptions.cpp
+        src/cli/CliOptions.h
+    )
+    target_include_directories(cli-options-test PRIVATE
+        ${CMAKE_SOURCE_DIR}/src/cli
+    )
+    add_test(NAME cli-options COMMAND cli-options-test)
+
+    add_executable(config-preset-validation-test
+        tests/ConfigPresetValidationTest.cpp
+        src/common/Config.cpp
+        src/common/Config.h
+    )
+    target_include_directories(config-preset-validation-test PRIVATE
+        ${CMAKE_SOURCE_DIR}/src/common
+    )
+    add_test(NAME config-preset-validation COMMAND config-preset-validation-test)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,102 @@ if(BUILD_TESTING)
     )
     add_test(NAME config-preset-validation COMMAND config-preset-validation-test)
 
+    add_executable(camera-controller-safety-test
+        tests/CameraControllerSafetyTest.cpp
+        src/gui/CameraController.cpp
+        src/gui/CameraController.h
+        src/gui/V4l2Backend.cpp
+        src/gui/V4l2Backend.h
+        src/common/Config.cpp
+        src/common/Config.h
+    )
+    target_include_directories(camera-controller-safety-test PRIVATE
+        ${SDK_INCLUDE_DIR}
+        ${CMAKE_SOURCE_DIR}/src/gui
+        ${CMAKE_SOURCE_DIR}/src/common
+    )
+    target_link_directories(camera-controller-safety-test PRIVATE ${SDK_LIB_DIR})
+    target_link_libraries(camera-controller-safety-test PRIVATE Qt6::Core dev)
+    set_target_properties(camera-controller-safety-test PROPERTIES
+        BUILD_RPATH "${SDK_LIB_DIR}"
+    )
+    add_test(NAME camera-controller-safety COMMAND camera-controller-safety-test)
+
+    add_executable(tracking-control-widget-test
+        tests/TrackingControlWidgetTest.cpp
+        src/gui/TrackingControlWidget.cpp
+        src/gui/TrackingControlWidget.h
+        src/gui/CameraController.cpp
+        src/gui/CameraController.h
+        src/gui/V4l2Backend.cpp
+        src/gui/V4l2Backend.h
+        src/gui/XYPad.cpp
+        src/gui/XYPad.h
+        src/common/Config.cpp
+        src/common/Config.h
+    )
+    target_include_directories(tracking-control-widget-test PRIVATE
+        ${SDK_INCLUDE_DIR}
+        ${CMAKE_SOURCE_DIR}/src/gui
+        ${CMAKE_SOURCE_DIR}/src/common
+    )
+    target_link_directories(tracking-control-widget-test PRIVATE ${SDK_LIB_DIR})
+    target_link_libraries(tracking-control-widget-test PRIVATE Qt6::Widgets dev)
+    set_target_properties(tracking-control-widget-test PROPERTIES
+        BUILD_RPATH "${SDK_LIB_DIR}"
+    )
+    add_test(NAME tracking-control-widget COMMAND tracking-control-widget-test)
+    set_tests_properties(tracking-control-widget PROPERTIES
+        ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+    )
+
+    add_executable(ptz-control-widget-test
+        tests/PTZControlWidgetTest.cpp
+        src/gui/PTZControlWidget.cpp
+        src/gui/PTZControlWidget.h
+        src/gui/CameraSettingsWidget.cpp
+        src/gui/CameraSettingsWidget.h
+        src/gui/TrackingControlWidget.cpp
+        src/gui/TrackingControlWidget.h
+        src/gui/VideoEffectsWidget.cpp
+        src/gui/VideoEffectsWidget.h
+        src/gui/PaperCropProcessor.cpp
+        src/gui/PaperCropProcessor.h
+        src/gui/PaperCropSettings.h
+        src/gui/CameraController.cpp
+        src/gui/CameraController.h
+        src/gui/V4l2Backend.cpp
+        src/gui/V4l2Backend.h
+        src/gui/XYPad.cpp
+        src/gui/XYPad.h
+        src/common/Config.cpp
+        src/common/Config.h
+    )
+    target_include_directories(ptz-control-widget-test PRIVATE
+        ${SDK_INCLUDE_DIR}
+        ${CMAKE_SOURCE_DIR}/src/gui
+        ${CMAKE_SOURCE_DIR}/src/common
+    )
+    target_link_directories(ptz-control-widget-test PRIVATE ${SDK_LIB_DIR})
+    target_link_libraries(ptz-control-widget-test PRIVATE
+        Qt6::Widgets
+        Qt6::OpenGLWidgets
+        Qt6::Multimedia
+        dev
+    )
+    if(OpenCV_FOUND)
+        target_compile_definitions(ptz-control-widget-test PRIVATE OBSBOT_HAS_OPENCV=1)
+        target_include_directories(ptz-control-widget-test PRIVATE ${OpenCV_INCLUDE_DIRS})
+        target_link_libraries(ptz-control-widget-test PRIVATE ${OpenCV_LIBS})
+    endif()
+    set_target_properties(ptz-control-widget-test PROPERTIES
+        BUILD_RPATH "${SDK_LIB_DIR}"
+    )
+    add_test(NAME ptz-control-widget COMMAND ptz-control-widget-test)
+    set_tests_properties(ptz-control-widget PROPERTIES
+        ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+    )
+
     add_executable(paper-crop-processor-test
         tests/PaperCropProcessorTest.cpp
         src/gui/PaperCropProcessor.cpp
@@ -164,4 +260,44 @@ if(BUILD_TESTING)
         target_link_libraries(paper-crop-processor-test PRIVATE ${OpenCV_LIBS})
     endif()
     add_test(NAME paper-crop-processor COMMAND paper-crop-processor-test)
+
+    add_executable(video-effects-widget-test
+        tests/VideoEffectsWidgetTest.cpp
+        src/gui/VideoEffectsWidget.cpp
+        src/gui/VideoEffectsWidget.h
+        src/gui/PaperCropProcessor.cpp
+        src/gui/PaperCropProcessor.h
+        src/gui/PaperCropSettings.h
+    )
+    target_include_directories(video-effects-widget-test PRIVATE
+        ${CMAKE_SOURCE_DIR}/src/gui
+    )
+    target_link_libraries(video-effects-widget-test PRIVATE
+        Qt6::Widgets
+        Qt6::OpenGLWidgets
+        Qt6::Multimedia
+    )
+    if(OpenCV_FOUND)
+        target_compile_definitions(video-effects-widget-test PRIVATE OBSBOT_HAS_OPENCV=1)
+        target_include_directories(video-effects-widget-test PRIVATE ${OpenCV_INCLUDE_DIRS})
+        target_link_libraries(video-effects-widget-test PRIVATE ${OpenCV_LIBS})
+    endif()
+    add_test(NAME video-effects-widget COMMAND video-effects-widget-test)
+    set_tests_properties(video-effects-widget PROPERTIES
+        ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+    )
+
+    add_executable(virtual-camera-streamer-test
+        tests/VirtualCameraStreamerTest.cpp
+        src/gui/VirtualCameraStreamer.cpp
+        src/gui/VirtualCameraStreamer.h
+    )
+    target_include_directories(virtual-camera-streamer-test PRIVATE
+        ${CMAKE_SOURCE_DIR}/src/gui
+    )
+    target_link_libraries(virtual-camera-streamer-test PRIVATE
+        Qt6::Core
+        Qt6::Gui
+    )
+    add_test(NAME virtual-camera-streamer COMMAND virtual-camera-streamer-test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_SOURCE_DIR}/bin)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_SOURCE_DIR}/bin)
 
 # Find Qt6
-find_package(Qt6 REQUIRED COMPONENTS Widgets Multimedia MultimediaWidgets OpenGLWidgets)
+find_package(Qt6 REQUIRED COMPONENTS Core DBus Widgets Multimedia MultimediaWidgets OpenGLWidgets)
+find_package(OpenCV QUIET COMPONENTS core imgproc)
 
 # SDK paths
 set(SDK_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/sdk/include)
@@ -35,6 +36,9 @@ add_executable(obsbot-gui
     src/gui/CameraSettingsWidget.h
     src/gui/FilterPreviewWidget.cpp
     src/gui/FilterPreviewWidget.h
+    src/gui/PaperCropProcessor.cpp
+    src/gui/PaperCropProcessor.h
+    src/gui/PaperCropSettings.h
     src/gui/CameraPreviewWidget.cpp
     src/gui/CameraPreviewWidget.h
     src/gui/VideoEffectsWidget.cpp
@@ -66,6 +70,7 @@ target_link_libraries(obsbot-gui PRIVATE
     Qt6::Multimedia
     Qt6::MultimediaWidgets
     Qt6::OpenGLWidgets
+    Qt6::DBus
     dev
 )
 
@@ -73,11 +78,19 @@ target_compile_definitions(obsbot-gui PRIVATE
     $<$<CONFIG:Debug>:OBSBOT_DEBUG_GEOMETRY>
 )
 
+if(OpenCV_FOUND)
+    target_compile_definitions(obsbot-gui PRIVATE OBSBOT_HAS_OPENCV=1)
+    target_include_directories(obsbot-gui PRIVATE ${OpenCV_INCLUDE_DIRS})
+    target_link_libraries(obsbot-gui PRIVATE ${OpenCV_LIBS})
+endif()
+
 # CLI Application
 add_executable(obsbot-cli
     src/cli/meet2_test.cpp
     src/cli/CliOptions.cpp
     src/cli/CliOptions.h
+    src/cli/GuiRemoteClient.cpp
+    src/cli/GuiRemoteClient.h
     src/cli/CameraSelection.cpp
     src/cli/CameraSelection.h
     src/cli/PresetCommand.cpp
@@ -96,6 +109,8 @@ target_link_directories(obsbot-cli PRIVATE
 )
 
 target_link_libraries(obsbot-cli PRIVATE
+    Qt6::Core
+    Qt6::DBus
     dev
 )
 
@@ -132,4 +147,21 @@ if(BUILD_TESTING)
         ${CMAKE_SOURCE_DIR}/src/common
     )
     add_test(NAME config-preset-validation COMMAND config-preset-validation-test)
+
+    add_executable(paper-crop-processor-test
+        tests/PaperCropProcessorTest.cpp
+        src/gui/PaperCropProcessor.cpp
+        src/gui/PaperCropProcessor.h
+        src/gui/PaperCropSettings.h
+    )
+    target_include_directories(paper-crop-processor-test PRIVATE
+        ${CMAKE_SOURCE_DIR}/src/gui
+    )
+    target_link_libraries(paper-crop-processor-test PRIVATE Qt6::Gui)
+    if(OpenCV_FOUND)
+        target_compile_definitions(paper-crop-processor-test PRIVATE OBSBOT_HAS_OPENCV=1)
+        target_include_directories(paper-crop-processor-test PRIVATE ${OpenCV_INCLUDE_DIRS})
+        target_link_libraries(paper-crop-processor-test PRIVATE ${OpenCV_LIBS})
+    endif()
+    add_test(NAME paper-crop-processor COMMAND paper-crop-processor-test)
 endif()

--- a/README.md
+++ b/README.md
@@ -83,11 +83,13 @@ The SDK also lists: Tiny (original), Tiny SE, Meet (original), Meet 4K, Me, Tail
 - CMake 3.16+
 - C++17 compiler (GCC/Clang)
 - OBSBOT SDK (included in `sdk/` directory)
+- OpenCV 4 (optional; enables automatic paper-boundary detection and perspective correction)
 
 ### Runtime Dependencies
 - Qt6 libraries
 - V4L2 (Video4Linux2) support
 - `lsof` for camera usage detection (optional but recommended)
+- OpenCV 4 is only required when automatic paper crop is desired; manual crop works without it
 
 ## Quick Start
 
@@ -263,13 +265,21 @@ When window is shown/restored:
 - Click "Show Camera Preview" again
 - Note: Controls work without preview!
 
-### Position Presets and Shortcuts
-1. Turn off auto-framing, then use **Tracking → Manual Camera Control** to frame the view.
-2. Include the desired zoom level—the saved zoom provides a repeatable crop around the paper or subject.
-3. Open **Presets** and save the position to slot 1, 2, or 3.
-4. Recall it with the slot's **Recall** button or `Ctrl+1`, `Ctrl+2`, or `Ctrl+3` while OBSBOT Control is active.
+### Scene Presets, Manual Positioning, and Paper Crop
 
-For a desktop-wide hotkey (including while another application is active), bind one of these commands in your desktop environment's keyboard-shortcut settings:
+Presets now save a complete scene: tracking/manual mode, AI mode, pan, tilt, zoom, and paper-crop settings.
+
+**Create a fixed table view:**
+1. In **Tracking**, check **Enable manual positioning (turns tracking off)**.
+2. Position and zoom the camera with the now-enabled manual controls.
+3. Enable the preview. In **Creative FX → Paper Crop**, choose **Manual rectangle** or **Automatic paper detection** and adjust the fallback crop sliders.
+4. In **Presets**, save this as the table scene.
+5. Re-enable tracking, configure the normal face view, disable paper crop, and save that as another scene.
+6. Recall scenes with their buttons or `Ctrl+1`, `Ctrl+2`, or `Ctrl+3`.
+
+For automatic framing in the **direct physical camera feed**, Tiny 2-family cameras can use **Use camera Desk mode for automatic paper framing**. Software paper detection and perspective correction affect the app preview, snapshots, and **OBSBOT Virtual Camera** output; conferencing software must select the virtual camera to receive that processed image.
+
+For a desktop-wide hotkey, bind:
 
 ```bash
 obsbot-cli --preset 1
@@ -277,9 +287,7 @@ obsbot-cli --preset 2
 obsbot-cli --preset 3
 ```
 
-Use `obsbot-cli --list-presets` to inspect saved slots. If multiple OBSBOT cameras are connected, add `--serial SERIAL` so a shortcut cannot target the wrong camera.
-
-Position presets store pan, tilt, and zoom. They do not detect paper edges. Tiny 2-family cameras can also try the camera's model-specific **Desk** tracking mode, but support and framing behavior vary by model and firmware.
+When the GUI is running, the CLI routes scene recall through it so tracking and software crop are restored too. Without the GUI, the CLI falls back to camera-side tracking/PTZ/zoom only. Use `obsbot-cli --list-presets` to inspect saved scenes. If multiple cameras are connected and the GUI is not running, add `--serial SERIAL`.
 
 ### Settings not saving
 - Check config directory exists: `~/.config/obsbot-control/`
@@ -304,8 +312,8 @@ See CLI help for available commands.
 Useful automation commands:
 
 ```bash
-obsbot-cli --list-presets              # Show saved position slots
-obsbot-cli --preset 1                  # Recall slot 1
+obsbot-cli --list-presets              # Show saved scenes
+obsbot-cli --preset 1                  # Recall scene 1
 obsbot-cli --preset 1 --serial ABC123  # Select an exact camera
 ```
 

--- a/README.md
+++ b/README.md
@@ -263,6 +263,24 @@ When window is shown/restored:
 - Click "Show Camera Preview" again
 - Note: Controls work without preview!
 
+### Position Presets and Shortcuts
+1. Turn off auto-framing, then use **Tracking → Manual Camera Control** to frame the view.
+2. Include the desired zoom level—the saved zoom provides a repeatable crop around the paper or subject.
+3. Open **Presets** and save the position to slot 1, 2, or 3.
+4. Recall it with the slot's **Recall** button or `Ctrl+1`, `Ctrl+2`, or `Ctrl+3` while OBSBOT Control is active.
+
+For a desktop-wide hotkey (including while another application is active), bind one of these commands in your desktop environment's keyboard-shortcut settings:
+
+```bash
+obsbot-cli --preset 1
+obsbot-cli --preset 2
+obsbot-cli --preset 3
+```
+
+Use `obsbot-cli --list-presets` to inspect saved slots. If multiple OBSBOT cameras are connected, add `--serial SERIAL` so a shortcut cannot target the wrong camera.
+
+Position presets store pan, tilt, and zoom. They do not detect paper edges. Tiny 2-family cameras can also try the camera's model-specific **Desk** tracking mode, but support and framing behavior vary by model and firmware.
+
 ### Settings not saving
 - Check config directory exists: `~/.config/obsbot-control/`
 - Verify write permissions
@@ -282,6 +300,14 @@ A CLI tool is also included for automation/scripting:
 ```
 
 See CLI help for available commands.
+
+Useful automation commands:
+
+```bash
+obsbot-cli --list-presets              # Show saved position slots
+obsbot-cli --preset 1                  # Recall slot 1
+obsbot-cli --preset 1 --serial ABC123  # Select an exact camera
+```
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -267,17 +267,19 @@ When window is shown/restored:
 
 ### Scene Presets, Manual Positioning, and Paper Crop
 
-Presets now save a complete scene: tracking/manual mode, AI mode, pan, tilt, zoom, and paper-crop settings.
+Presets now save a complete scene: tracking/manual mode, AI mode and its focus/zoom/speed profile, pan, tilt, zoom, and paper-crop settings.
+
+On Tiny 2-family cameras, **Group**, **Human**, **Hand**, **Whiteboard**, and **Desk** each retain an independent focus policy, saved manual-focus position, AI auto-zoom setting, and tracking speed. Select a mode before editing these controls; switching back restores that mode's profile. Turning tracking off disables face focus and restores the retained manual-focus position before manual movement is authorized.
 
 **Create a fixed table view:**
-1. In **Tracking**, check **Enable manual positioning (turns tracking off)**.
+1. In **Tracking**, check **Enable manual positioning (turns tracking off)**. Manual intent remains latched until you explicitly re-enable tracking. The controls briefly show a waiting state and unlock only after the camera freshly confirms that tracking is off; if confirmation fails, movement stays disabled and an error is shown.
 2. Position and zoom the camera with the now-enabled manual controls.
-3. Enable the preview. In **Creative FX → Paper Crop**, choose **Manual rectangle** or **Automatic paper detection** and adjust the fallback crop sliders.
+3. Enable the preview. In **Creative FX → Paper Crop**, choose **Manual rectangle** or **Automatic paper detection** and adjust the fallback crop sliders. Automatic mode needs all four paper edges visible. Its status reports whether the page is locked or still being searched for; brief detection loss holds the last good boundary before using the saved manual fallback.
 4. In **Presets**, save this as the table scene.
 5. Re-enable tracking, configure the normal face view, disable paper crop, and save that as another scene.
 6. Recall scenes with their buttons or `Ctrl+1`, `Ctrl+2`, or `Ctrl+3`.
 
-For automatic framing in the **direct physical camera feed**, Tiny 2-family cameras can use **Use camera Desk mode for automatic paper framing**. Software paper detection and perspective correction affect the app preview, snapshots, and **OBSBOT Virtual Camera** output; conferencing software must select the virtual camera to receive that processed image.
+On Tiny 2-family cameras, selecting or recalling **Automatic paper detection** also switches to the saved **Desk** profile and persists crop and tracking together. Turning paper crop off leaves Desk mode active until another mode is selected explicitly. Desk mode controls framing in the **direct physical camera feed**; software paper detection and perspective correction affect only the app preview, snapshots, and **OBSBOT Virtual Camera** output. Conferencing software must select the virtual camera to receive that processed image.
 
 For a desktop-wide hotkey, bind:
 

--- a/src/cli/CameraSelection.cpp
+++ b/src/cli/CameraSelection.cpp
@@ -1,0 +1,63 @@
+#include "CameraSelection.h"
+
+#include <algorithm>
+#include <chrono>
+#include <dev/devs.hpp>
+#include <list>
+#include <ostream>
+#include <thread>
+
+std::shared_ptr<Device> waitForSelectedCamera(const std::string &serial,
+                                              bool requireExplicitSelection,
+                                              int timeoutSeconds,
+                                              std::ostream &progress,
+                                              std::ostream &errors)
+{
+    Devices::get().setDevChangedCallback(
+        [](std::string, bool, void *) {},
+        nullptr);
+    Devices::get().setEnableMdnsScan(false);
+
+    progress << "Waiting for OBSBOT camera..." << '\n';
+    std::list<std::shared_ptr<Device>> devices;
+    for (int i = 0; i < timeoutSeconds * 10; ++i) {
+        devices = Devices::get().getDevList();
+        const bool targetFound = serial.empty()
+            ? !devices.empty()
+            : std::any_of(devices.begin(), devices.end(), [&](const auto &device) {
+                return device->devSn() == serial;
+            });
+        if (targetFound) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+            devices = Devices::get().getDevList();
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    if (devices.empty()) {
+        errors << "No OBSBOT devices found!" << '\n';
+        return {};
+    }
+
+    if (!serial.empty()) {
+        const auto match = std::find_if(devices.begin(), devices.end(), [&](const auto &device) {
+            return device->devSn() == serial;
+        });
+        if (match == devices.end()) {
+            errors << "No OBSBOT camera with serial " << serial << " was found." << '\n';
+            return {};
+        }
+        return *match;
+    }
+
+    if (requireExplicitSelection && devices.size() > 1) {
+        errors << "Multiple OBSBOT cameras found; use --serial to choose one:" << '\n';
+        for (const auto &device : devices) {
+            errors << "  " << device->devSn() << " (" << device->devName() << ")" << '\n';
+        }
+        return {};
+    }
+
+    return devices.front();
+}

--- a/src/cli/CameraSelection.h
+++ b/src/cli/CameraSelection.h
@@ -1,0 +1,16 @@
+#ifndef CAMERASELECTION_H
+#define CAMERASELECTION_H
+
+#include <iosfwd>
+#include <memory>
+#include <string>
+
+class Device;
+
+std::shared_ptr<Device> waitForSelectedCamera(const std::string &serial,
+                                              bool requireExplicitSelection,
+                                              int timeoutSeconds,
+                                              std::ostream &progress,
+                                              std::ostream &errors);
+
+#endif // CAMERASELECTION_H

--- a/src/cli/CliOptions.cpp
+++ b/src/cli/CliOptions.cpp
@@ -1,0 +1,128 @@
+#include "CliOptions.h"
+
+#include <charconv>
+#include <ostream>
+#include <string_view>
+
+namespace {
+
+bool parsePresetNumber(std::string_view value, int &presetNumber)
+{
+    if (value.empty()) {
+        return false;
+    }
+
+    int parsed = 0;
+    const char *begin = value.data();
+    const char *end = begin + value.size();
+    const auto result = std::from_chars(begin, end, parsed);
+    if (result.ec != std::errc() || result.ptr != end || parsed < 1 || parsed > 3) {
+        return false;
+    }
+
+    presetNumber = parsed;
+    return true;
+}
+
+bool selectAction(CliParseResult &result, CliAction action, const char *option)
+{
+    if (result.options.action != CliAction::ApplyConfig) {
+        result.error = std::string(option) + " cannot be combined with another action";
+        return false;
+    }
+
+    result.options.action = action;
+    return true;
+}
+
+} // namespace
+
+CliParseResult parseCliOptions(int argc, char *const argv[])
+{
+    CliParseResult result;
+
+    for (int i = 1; i < argc; ++i) {
+        const std::string_view argument(argv[i]);
+
+        if (argument == "-h" || argument == "--help") {
+            result.options.showHelp = true;
+            continue;
+        }
+
+        if (argument == "-i" || argument == "--interactive") {
+            if (!selectAction(result, CliAction::Interactive, argv[i])) {
+                return result;
+            }
+            continue;
+        }
+
+        if (argument == "--list-presets") {
+            if (!selectAction(result, CliAction::ListPresets, argv[i])) {
+                return result;
+            }
+            continue;
+        }
+
+        if (argument == "-p" || argument == "--preset") {
+            if (i + 1 >= argc || !parsePresetNumber(argv[++i], result.options.presetNumber)) {
+                result.error = std::string(argument) + " requires a preset number from 1 to 3";
+                return result;
+            }
+            if (!selectAction(result, CliAction::RecallPreset, argv[i - 1])) {
+                return result;
+            }
+            continue;
+        }
+
+        constexpr std::string_view presetPrefix = "--preset=";
+        if (argument.rfind(presetPrefix, 0) == 0) {
+            if (!parsePresetNumber(argument.substr(presetPrefix.size()), result.options.presetNumber)) {
+                result.error = "--preset requires a preset number from 1 to 3";
+                return result;
+            }
+            if (!selectAction(result, CliAction::RecallPreset, "--preset")) {
+                return result;
+            }
+            continue;
+        }
+
+        if (argument == "--serial") {
+            if (i + 1 >= argc || argv[i + 1][0] == '\0' || argv[i + 1][0] == '-') {
+                result.error = "--serial requires a camera serial number";
+                return result;
+            }
+            if (!result.options.serial.empty()) {
+                result.error = "--serial may only be specified once";
+                return result;
+            }
+            result.options.serial = argv[++i];
+            continue;
+        }
+
+        result.error = "unknown option: " + std::string(argument);
+        return result;
+    }
+
+    if (result.options.action == CliAction::ListPresets && !result.options.serial.empty()) {
+        result.error = "--serial cannot be combined with --list-presets";
+    }
+
+    return result;
+}
+
+void printCliUsage(std::ostream &out, const char *programName)
+{
+    out << "OBSBOT Control - CLI Tool\n"
+        << "\nUsage: " << programName << " [options]\n"
+        << "\nActions (choose at most one):\n"
+        << "  -i, --interactive       Run in interactive menu mode\n"
+        << "  -p, --preset N          Recall saved position preset N (1-3)\n"
+        << "      --list-presets      Show configured position presets and exit\n"
+        << "\nOptions:\n"
+        << "      --serial SERIAL     Target an exact camera serial number\n"
+        << "  -h, --help              Show this help message\n"
+        << "\nDefault behavior:\n"
+        << "  Loads ~/.config/obsbot-control/settings.conf, applies all settings,\n"
+        << "  and exits. Bind 'obsbot-cli --preset N' to a desktop global shortcut\n"
+        << "  for quick position changes.\n";
+}

--- a/src/cli/CliOptions.cpp
+++ b/src/cli/CliOptions.cpp
@@ -116,13 +116,13 @@ void printCliUsage(std::ostream &out, const char *programName)
         << "\nUsage: " << programName << " [options]\n"
         << "\nActions (choose at most one):\n"
         << "  -i, --interactive       Run in interactive menu mode\n"
-        << "  -p, --preset N          Recall saved position preset N (1-3)\n"
-        << "      --list-presets      Show configured position presets and exit\n"
+        << "  -p, --preset N          Recall saved scene preset N (1-3)\n"
+        << "      --list-presets      Show configured scene presets and exit\n"
         << "\nOptions:\n"
         << "      --serial SERIAL     Target an exact camera serial number\n"
         << "  -h, --help              Show this help message\n"
         << "\nDefault behavior:\n"
         << "  Loads ~/.config/obsbot-control/settings.conf, applies all settings,\n"
         << "  and exits. Bind 'obsbot-cli --preset N' to a desktop global shortcut\n"
-        << "  for quick position changes.\n";
+        << "  for quick scene changes.\n";
 }

--- a/src/cli/CliOptions.h
+++ b/src/cli/CliOptions.h
@@ -1,0 +1,31 @@
+#ifndef CLIOPTIONS_H
+#define CLIOPTIONS_H
+
+#include <iosfwd>
+#include <string>
+
+enum class CliAction {
+    ApplyConfig,
+    Interactive,
+    RecallPreset,
+    ListPresets
+};
+
+struct CliOptions {
+    CliAction action = CliAction::ApplyConfig;
+    int presetNumber = 0;
+    std::string serial;
+    bool showHelp = false;
+};
+
+struct CliParseResult {
+    CliOptions options;
+    std::string error;
+
+    bool ok() const { return error.empty(); }
+};
+
+CliParseResult parseCliOptions(int argc, char *const argv[]);
+void printCliUsage(std::ostream &out, const char *programName);
+
+#endif // CLIOPTIONS_H

--- a/src/cli/GuiRemoteClient.cpp
+++ b/src/cli/GuiRemoteClient.cpp
@@ -1,0 +1,31 @@
+#include "GuiRemoteClient.h"
+
+#include <QDBusInterface>
+#include <QDBusReply>
+#include <QString>
+
+GuiRemoteRecallResult recallPresetViaRunningGui(int presetNumber)
+{
+    QDBusInterface remote(
+        QStringLiteral("com.obsbot.CameraControl"),
+        QStringLiteral("/CameraControl"),
+        QStringLiteral("com.obsbot.CameraControl"),
+        QDBusConnection::sessionBus());
+
+    if (!remote.isValid()) {
+        return {GuiRemoteRecallResult::Status::GuiNotRunning, {}};
+    }
+
+    const QDBusReply<bool> reply = remote.call(QStringLiteral("recallPreset"), presetNumber);
+    if (!reply.isValid()) {
+        return {
+            GuiRemoteRecallResult::Status::Error,
+            reply.error().message().toStdString()
+        };
+    }
+
+    return reply.value()
+        ? GuiRemoteRecallResult{GuiRemoteRecallResult::Status::Accepted, {}}
+        : GuiRemoteRecallResult{GuiRemoteRecallResult::Status::Rejected,
+                                "The running GUI rejected the preset recall."};
+}

--- a/src/cli/GuiRemoteClient.h
+++ b/src/cli/GuiRemoteClient.h
@@ -1,0 +1,20 @@
+#ifndef GUIREMOTECLIENT_H
+#define GUIREMOTECLIENT_H
+
+#include <string>
+
+struct GuiRemoteRecallResult {
+    enum class Status {
+        GuiNotRunning,
+        Accepted,
+        Rejected,
+        Error
+    };
+
+    Status status = Status::GuiNotRunning;
+    std::string message;
+};
+
+GuiRemoteRecallResult recallPresetViaRunningGui(int presetNumber);
+
+#endif // GUIREMOTECLIENT_H

--- a/src/cli/PresetCommand.cpp
+++ b/src/cli/PresetCommand.cpp
@@ -1,0 +1,50 @@
+#include "PresetCommand.h"
+
+#include <cmath>
+#include <cstdint>
+#include <dev/dev.hpp>
+#include <ostream>
+
+void printPresetList(std::ostream &out, const Config::CameraSettings &settings)
+{
+    for (size_t i = 0; i < settings.presets.size(); ++i) {
+        const auto &preset = settings.presets[i];
+        out << "Preset " << (i + 1) << ": ";
+        if (preset.defined) {
+            out << "pan " << preset.pan << ", tilt " << preset.tilt
+                << ", zoom " << preset.zoom << "x";
+        } else {
+            out << "empty";
+        }
+        out << '\n';
+    }
+}
+
+bool applyPresetToCamera(std::shared_ptr<Device> device,
+                         const Config::CameraSettings::PresetSlot &preset,
+                         std::ostream &progress,
+                         std::ostream &errors)
+{
+    const bool valid = std::isfinite(preset.pan) && preset.pan >= -1.0 && preset.pan <= 1.0
+        && std::isfinite(preset.tilt) && preset.tilt >= -1.0 && preset.tilt <= 1.0
+        && std::isfinite(preset.zoom) && preset.zoom >= 1.0 && preset.zoom <= 2.0;
+    if (!preset.defined || !valid) {
+        errors << "Refusing to apply an undefined or invalid position preset." << '\n';
+        return false;
+    }
+
+    progress << "Applying position preset: pan " << preset.pan
+             << ", tilt " << preset.tilt << ", zoom " << preset.zoom << "x" << '\n';
+
+    const int32_t panTiltResult = device->cameraSetPanTiltAbsolute(preset.pan, preset.tilt);
+    if (panTiltResult != 0) {
+        errors << "  Failed to set pan/tilt (code: " << panTiltResult << ")" << '\n';
+    }
+
+    const int32_t zoomResult = device->cameraSetZoomAbsoluteR(preset.zoom);
+    if (zoomResult != 0) {
+        errors << "  Failed to set zoom (code: " << zoomResult << ")" << '\n';
+    }
+
+    return panTiltResult == 0 && zoomResult == 0;
+}

--- a/src/cli/PresetCommand.cpp
+++ b/src/cli/PresetCommand.cpp
@@ -11,6 +11,11 @@ void printPresetList(std::ostream &out, const Config::CameraSettings &settings)
         const auto &preset = settings.presets[i];
         out << "Preset " << (i + 1) << ": ";
         if (preset.defined) {
+            if (preset.sceneDefined) {
+                out << (preset.trackingEnabled ? "tracking" : "manual")
+                    << ", AI mode " << preset.aiMode
+                    << ", crop mode " << preset.paperCropMode << ", ";
+            }
             out << "pan " << preset.pan << ", tilt " << preset.tilt
                 << ", zoom " << preset.zoom << "x";
         } else {
@@ -29,12 +34,39 @@ bool applyPresetToCamera(std::shared_ptr<Device> device,
         && std::isfinite(preset.tilt) && preset.tilt >= -1.0 && preset.tilt <= 1.0
         && std::isfinite(preset.zoom) && preset.zoom >= 1.0 && preset.zoom <= 2.0;
     if (!preset.defined || !valid) {
-        errors << "Refusing to apply an undefined or invalid position preset." << '\n';
+        errors << "Refusing to apply an undefined or invalid scene preset." << '\n';
         return false;
     }
 
-    progress << "Applying position preset: pan " << preset.pan
+    progress << "Applying scene preset: pan " << preset.pan
              << ", tilt " << preset.tilt << ", zoom " << preset.zoom << "x" << '\n';
+
+    bool trackingApplied = true;
+    if (preset.sceneDefined && preset.trackingEnabled) {
+        const int32_t mediaResult = device->cameraSetMediaModeU(Device::MediaModeAutoFrame);
+        const int32_t aiResult = device->cameraSetAiModeU(
+            static_cast<Device::AiWorkModeType>(preset.aiMode), preset.aiSubMode);
+        const int32_t autoZoomResult = device->aiSetAiAutoZoomR(preset.autoZoom);
+        trackingApplied = mediaResult == 0 && aiResult == 0 && autoZoomResult == 0;
+        if (!trackingApplied) {
+            errors << "  Failed to restore the saved tracking mode." << '\n';
+        }
+    } else {
+        const int32_t aiResult = device->cameraSetAiModeU(Device::AiWorkModeNone);
+        const int32_t mediaResult = device->cameraSetMediaModeU(Device::MediaModeNormal);
+        trackingApplied = aiResult == 0 && mediaResult == 0;
+        if (!trackingApplied) {
+            errors << "  Failed to disable tracking before manual positioning." << '\n';
+        }
+    }
+
+    if (preset.paperCropMode != 0) {
+        progress << "  Software paper crop is applied by the running GUI/virtual camera." << '\n';
+    }
+
+    if (preset.sceneDefined && preset.trackingEnabled) {
+        return trackingApplied;
+    }
 
     const int32_t panTiltResult = device->cameraSetPanTiltAbsolute(preset.pan, preset.tilt);
     if (panTiltResult != 0) {
@@ -46,5 +78,5 @@ bool applyPresetToCamera(std::shared_ptr<Device> device,
         errors << "  Failed to set zoom (code: " << zoomResult << ")" << '\n';
     }
 
-    return panTiltResult == 0 && zoomResult == 0;
+    return trackingApplied && panTiltResult == 0 && zoomResult == 0;
 }

--- a/src/cli/PresetCommand.cpp
+++ b/src/cli/PresetCommand.cpp
@@ -1,9 +1,98 @@
 #include "PresetCommand.h"
 
+#include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <dev/dev.hpp>
 #include <ostream>
+#include <thread>
+
+namespace {
+
+bool isTiny2Family(const std::shared_ptr<Device> &device)
+{
+    const auto product = device->productType();
+    return product == ObsbotProdTiny2
+        || product == ObsbotProdTiny2Lite
+        || product == ObsbotProdTinySE;
+}
+
+bool isOriginalTinyFamily(const std::shared_ptr<Device> &device)
+{
+    const auto product = device->productType();
+    return product == ObsbotProdTiny || product == ObsbotProdTiny4k;
+}
+
+bool isMeetFamily(const std::shared_ptr<Device> &device)
+{
+    const auto product = device->productType();
+    return product == ObsbotProdMeet
+        || product == ObsbotProdMeet4k
+        || product == ObsbotProdMeet2
+        || product == ObsbotProdMeetSE;
+}
+
+bool waitForTiny2AiMode(const std::shared_ptr<Device> &device,
+                        int targetMode, int targetSubMode)
+{
+    constexpr int attempts = 20;
+    constexpr auto retryDelay = std::chrono::milliseconds(200);
+    for (int attempt = 0; attempt < attempts; ++attempt) {
+        Device::CameraStatus status{};
+        if (device->cameraGetCameraStatusU(status) == 0
+            && status.tiny.ai_mode == targetMode
+            && (targetMode != Device::AiWorkModeHuman
+                || status.tiny.ai_sub_mode == targetSubMode)) {
+            return true;
+        }
+        if (attempt + 1 < attempts) {
+            std::this_thread::sleep_for(retryDelay);
+        }
+    }
+    return false;
+}
+
+bool applyTiny2TrackingProfile(
+    const std::shared_ptr<Device> &device,
+    const TrackingModeProfile &profile,
+    bool trackingEnabled)
+{
+    if (!isValidTrackingModeProfile(profile)) {
+        return false;
+    }
+
+    bool speedApplied = true;
+    if (trackingEnabled) {
+        speedApplied = device->aiSetTrackSpeedTypeR(
+            static_cast<Device::AiTrackSpeedType>(profile.trackSpeed)) == 0;
+    }
+
+    int32_t firstFocusResult = -1;
+    int32_t secondFocusResult = -1;
+    switch (profile.focusPolicy) {
+    case TrackingFocusPolicy::Face:
+        firstFocusResult = device->cameraSetFocusAbsolute(
+            profile.manualFocusPosition, true);
+        secondFocusResult = device->cameraSetFaceFocusR(true);
+        break;
+    case TrackingFocusPolicy::Continuous:
+        firstFocusResult = device->cameraSetFaceFocusR(false);
+        secondFocusResult = device->cameraSetFocusAbsolute(
+            profile.manualFocusPosition, true);
+        break;
+    case TrackingFocusPolicy::Manual:
+        firstFocusResult = device->cameraSetFaceFocusR(false);
+        secondFocusResult = device->cameraSetFocusAbsolute(
+            profile.manualFocusPosition, false);
+        break;
+    }
+
+    return speedApplied
+        && firstFocusResult == 0
+        && secondFocusResult == 0;
+}
+
+} // namespace
 
 void printPresetList(std::ostream &out, const Config::CameraSettings &settings)
 {
@@ -27,6 +116,7 @@ void printPresetList(std::ostream &out, const Config::CameraSettings &settings)
 
 bool applyPresetToCamera(std::shared_ptr<Device> device,
                          const Config::CameraSettings::PresetSlot &preset,
+                         const Tiny2TrackingModeProfiles &modeProfiles,
                          std::ostream &progress,
                          std::ostream &errors)
 {
@@ -42,21 +132,104 @@ bool applyPresetToCamera(std::shared_ptr<Device> device,
              << ", tilt " << preset.tilt << ", zoom " << preset.zoom << "x" << '\n';
 
     bool trackingApplied = true;
-    if (preset.sceneDefined && preset.trackingEnabled) {
-        const int32_t mediaResult = device->cameraSetMediaModeU(Device::MediaModeAutoFrame);
-        const int32_t aiResult = device->cameraSetAiModeU(
-            static_cast<Device::AiWorkModeType>(preset.aiMode), preset.aiSubMode);
-        const int32_t autoZoomResult = device->aiSetAiAutoZoomR(preset.autoZoom);
-        trackingApplied = mediaResult == 0 && aiResult == 0 && autoZoomResult == 0;
+    const bool tiny2Family = isTiny2Family(device);
+    const TrackingIntentState storedTracking{
+        preset.trackingEnabled,
+        preset.aiMode,
+        preset.aiSubMode,
+        {
+            preset.focusPolicy,
+            preset.manualFocusPosition,
+            preset.autoZoom,
+            preset.trackSpeed
+        }
+    };
+    const TrackingIntentState effectiveIntent = preset.sceneDefined
+        ? applyAutomaticPaperCropTrackingPolicy(
+            preset.paperCropMode,
+            tiny2Family,
+            storedTracking,
+            modeProfiles)
+        : storedTracking;
+    const bool automaticDeskScene = tiny2Family
+        && preset.sceneDefined && preset.paperCropMode == 2;
+    const bool effectiveTracking =
+        preset.sceneDefined && effectiveIntent.enabled;
+    int effectiveMode = effectiveIntent.aiMode;
+    int effectiveSubMode = effectiveIntent.aiSubMode;
+    TrackingModeProfile effectiveProfile = effectiveIntent.profile;
+    if (automaticDeskScene) {
+        progress << "  Automatic paper crop selects Tiny 2 Desk mode."
+                 << '\n';
+    }
+
+    if (effectiveTracking) {
+        if (tiny2Family) {
+            if (effectiveMode == Device::AiWorkModeNone) {
+                effectiveMode = Device::AiWorkModeHuman;
+            }
+            if (effectiveMode != Device::AiWorkModeHuman) {
+                effectiveSubMode = 0;
+            }
+            const int32_t autoZoomResult =
+                device->aiSetAiAutoZoomR(effectiveProfile.autoZoom);
+            const int32_t aiResult = device->cameraSetAiModeU(
+                static_cast<Device::AiWorkModeType>(effectiveMode),
+                effectiveSubMode);
+            trackingApplied = autoZoomResult == 0 && aiResult == 0;
+            if (trackingApplied) {
+                trackingApplied = waitForTiny2AiMode(
+                    device, effectiveMode, effectiveSubMode);
+            }
+            if (trackingApplied) {
+                trackingApplied = applyTiny2TrackingProfile(
+                    device, effectiveProfile, true);
+            }
+        } else if (isOriginalTinyFamily(device)) {
+            trackingApplied = device->aiSetTargetSelectR(true) == 0;
+        } else if (isMeetFamily(device)) {
+            const int32_t mediaResult =
+                device->cameraSetMediaModeU(Device::MediaModeAutoFrame);
+            int32_t framingResult = -1;
+            if (mediaResult == 0) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(500));
+                framingResult = device->cameraSetAutoFramingModeU(
+                    Device::AutoFrmSingle, Device::AutoFrmUpperBody);
+            }
+            trackingApplied = mediaResult == 0 && framingResult == 0;
+        } else {
+            trackingApplied = false;
+        }
         if (!trackingApplied) {
-            errors << "  Failed to restore the saved tracking mode." << '\n';
+            errors << "  Failed to restore the saved tracking profile." << '\n';
         }
     } else {
-        const int32_t aiResult = device->cameraSetAiModeU(Device::AiWorkModeNone);
-        const int32_t mediaResult = device->cameraSetMediaModeU(Device::MediaModeNormal);
-        trackingApplied = aiResult == 0 && mediaResult == 0;
+        if (tiny2Family) {
+            effectiveProfile.focusPolicy = TrackingFocusPolicy::Manual;
+            effectiveProfile.autoZoom = false;
+            const int32_t autoZoomResult = device->aiSetAiAutoZoomR(false);
+            const int32_t aiResult =
+                device->cameraSetAiModeU(Device::AiWorkModeNone);
+            trackingApplied = autoZoomResult == 0 && aiResult == 0;
+            if (trackingApplied) {
+                trackingApplied = waitForTiny2AiMode(
+                    device, Device::AiWorkModeNone, 0);
+            }
+            if (trackingApplied) {
+                trackingApplied = applyTiny2TrackingProfile(
+                    device, effectiveProfile, false);
+            }
+        } else if (isOriginalTinyFamily(device)) {
+            trackingApplied = device->aiSetTargetSelectR(false) == 0;
+        } else if (isMeetFamily(device)) {
+            trackingApplied =
+                device->cameraSetMediaModeU(Device::MediaModeNormal) == 0;
+        } else {
+            trackingApplied = false;
+        }
         if (!trackingApplied) {
-            errors << "  Failed to disable tracking before manual positioning." << '\n';
+            errors << "  Failed to disable tracking and restore manual focus."
+                   << '\n';
         }
     }
 
@@ -64,13 +237,18 @@ bool applyPresetToCamera(std::shared_ptr<Device> device,
         progress << "  Software paper crop is applied by the running GUI/virtual camera." << '\n';
     }
 
-    if (preset.sceneDefined && preset.trackingEnabled) {
+    if (effectiveTracking) {
         return trackingApplied;
+    }
+
+    if (!trackingApplied) {
+        return false;
     }
 
     const int32_t panTiltResult = device->cameraSetPanTiltAbsolute(preset.pan, preset.tilt);
     if (panTiltResult != 0) {
         errors << "  Failed to set pan/tilt (code: " << panTiltResult << ")" << '\n';
+        return false;
     }
 
     const int32_t zoomResult = device->cameraSetZoomAbsoluteR(preset.zoom);
@@ -78,5 +256,5 @@ bool applyPresetToCamera(std::shared_ptr<Device> device,
         errors << "  Failed to set zoom (code: " << zoomResult << ")" << '\n';
     }
 
-    return trackingApplied && panTiltResult == 0 && zoomResult == 0;
+    return zoomResult == 0;
 }

--- a/src/cli/PresetCommand.h
+++ b/src/cli/PresetCommand.h
@@ -10,6 +10,7 @@ class Device;
 void printPresetList(std::ostream &out, const Config::CameraSettings &settings);
 bool applyPresetToCamera(std::shared_ptr<Device> device,
                          const Config::CameraSettings::PresetSlot &preset,
+                         const Tiny2TrackingModeProfiles &modeProfiles,
                          std::ostream &progress,
                          std::ostream &errors);
 

--- a/src/cli/PresetCommand.h
+++ b/src/cli/PresetCommand.h
@@ -1,0 +1,16 @@
+#ifndef PRESETCOMMAND_H
+#define PRESETCOMMAND_H
+
+#include <iosfwd>
+#include <memory>
+#include "Config.h"
+
+class Device;
+
+void printPresetList(std::ostream &out, const Config::CameraSettings &settings);
+bool applyPresetToCamera(std::shared_ptr<Device> device,
+                         const Config::CameraSettings::PresetSlot &preset,
+                         std::ostream &progress,
+                         std::ostream &errors);
+
+#endif // PRESETCOMMAND_H

--- a/src/cli/meet2_test.cpp
+++ b/src/cli/meet2_test.cpp
@@ -1,10 +1,12 @@
-#include <iostream>
-#include <thread>
 #include <chrono>
+#include <iostream>
 #include <string>
-#include <cstring>
+#include <thread>
 #include <dev/devs.hpp>
+#include "CameraSelection.h"
+#include "CliOptions.h"
 #include "Config.h"
+#include "PresetCommand.h"
 
 using namespace std;
 
@@ -15,97 +17,87 @@ void runInteractiveMode(shared_ptr<Device> dev);
 
 int main(int argc, char **argv)
 {
-    bool interactive = false;
-
-    // Parse command line arguments
-    for (int i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "-i") == 0 || strcmp(argv[i], "--interactive") == 0) {
-            interactive = true;
-        } else if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
-            cout << "OBSBOT Control - CLI Tool" << endl;
-            cout << "\nUsage: " << argv[0] << " [options]" << endl;
-            cout << "\nOptions:" << endl;
-            cout << "  -i, --interactive    Run in interactive menu mode" << endl;
-            cout << "  -h, --help           Show this help message" << endl;
-            cout << "\nDefault behavior:" << endl;
-            cout << "  Loads configuration from ~/.config/obsbot-control/settings.conf" << endl;
-            cout << "  Applies settings to camera and exits" << endl;
-            return 0;
-        }
+    const CliParseResult parsed = parseCliOptions(argc, argv);
+    if (!parsed.ok()) {
+        cerr << "Error: " << parsed.error << "\n\n";
+        printCliUsage(cerr, argv[0]);
+        return 2;
+    }
+    if (parsed.options.showHelp) {
+        printCliUsage(cout, argv[0]);
+        return 0;
     }
 
+    const CliAction action = parsed.options.action;
+    const bool interactive = action == CliAction::Interactive;
     cout << "OBSBOT Control" << (interactive ? " - Interactive Mode" : "") << endl;
 
-    // Load configuration
     Config config;
     vector<Config::ValidationError> errors;
     if (!config.load(errors)) {
-        // Config has validation errors
+        if (action == CliAction::RecallPreset || action == CliAction::ListPresets) {
+            cerr << "Configuration is invalid; preset actions never prompt for input." << endl;
+            for (const auto &error : errors) {
+                cerr << (error.lineNumber > 0 ? "Line " + to_string(error.lineNumber) + ": " : "")
+                     << error.message << endl;
+            }
+            return 2;
+        }
         if (!handleConfigErrors(config)) {
             cout << "Continuing without saving settings." << endl;
         }
+    } else if (!config.configExists()) {
+        cout << "No config file found. Using defaults." << endl;
     } else {
-        if (!config.configExists()) {
-            cout << "No config file found. Using defaults." << endl;
-        } else {
-            cout << "Configuration loaded from: " << config.getConfigPath() << endl;
+        cout << "Configuration loaded from: " << config.getConfigPath() << endl;
+    }
+
+    const auto settings = config.getSettings();
+    if (action == CliAction::ListPresets) {
+        printPresetList(cout, settings);
+        return 0;
+    }
+
+    const Config::CameraSettings::PresetSlot *requestedPreset = nullptr;
+    if (action == CliAction::RecallPreset) {
+        requestedPreset = &settings.presets[static_cast<size_t>(parsed.options.presetNumber - 1)];
+        if (!requestedPreset->defined) {
+            cerr << "Preset " << parsed.options.presetNumber
+                 << " is empty. Save it in the GUI before recalling it." << endl;
+            return 2;
         }
     }
 
-    // Device detection callback
-    bool device_connected = false;
-    auto onDevChanged = [&device_connected](std::string dev_sn, bool connected, void *param) {
-        if (connected) {
-            cout << "Device " << dev_sn << " connected" << endl;
-            device_connected = true;
-        } else {
-            cout << "Device " << dev_sn << " disconnected" << endl;
-        }
-    };
-
-    // Register device detection
-    Devices::get().setDevChangedCallback(onDevChanged, nullptr);
-    Devices::get().setEnableMdnsScan(false);  // USB only
-
-    // Wait for device detection with timeout
-    cout << "Waiting for OBSBOT camera..." << endl;
-    const int timeout_seconds = 10;
-    for (int i = 0; i < timeout_seconds * 10; i++) {
-        if (device_connected) {
-            // Give a moment for device list to be populated after callback
-            this_thread::sleep_for(chrono::milliseconds(200));
-            break;
-        }
-        this_thread::sleep_for(chrono::milliseconds(100));
-    }
-
-    auto dev_list = Devices::get().getDevList();
-    if (dev_list.empty()) {
-        cout << "No OBSBOT devices found!" << endl;
+    const auto dev = waitForSelectedCamera(
+        parsed.options.serial,
+        action == CliAction::RecallPreset,
+        10,
+        cout,
+        cerr);
+    if (!dev) {
         return 1;
     }
 
-    // Get first device
-    auto dev = dev_list.front();
     cout << "\nFound device:" << endl;
     cout << "  Name: " << dev->devName() << endl;
     cout << "  SN: " << dev->devSn() << endl;
     cout << "  Version: " << dev->devVersion() << endl;
     cout << "  Product Type: " << dev->productType() << endl;
 
-    // Note: This app was primarily tested with Meet 2, but may work with other models
     if (dev->productType() != ObsbotProdMeet2) {
         cout << "\nNote: This camera is not a Meet 2." << endl;
         cout << "      Some features may not work as expected." << endl;
     }
 
-    if (interactive) {
-        // Interactive mode - run menu
+    if (action == CliAction::RecallPreset) {
+        if (!applyPresetToCamera(dev, *requestedPreset, cout, cerr)) {
+            return 1;
+        }
+        cout << "Position preset " << parsed.options.presetNumber << " recalled." << endl;
+    } else if (interactive) {
         runInteractiveMode(dev);
     } else {
-        // Non-interactive mode - apply config and exit
         cout << "\nApplying configuration to camera..." << endl;
-        auto settings = config.getSettings();
         applyConfigToCamera(dev, settings);
         cout << "Configuration applied successfully." << endl;
         cout << "Camera settings have been updated." << endl;

--- a/src/cli/meet2_test.cpp
+++ b/src/cli/meet2_test.cpp
@@ -3,9 +3,11 @@
 #include <string>
 #include <thread>
 #include <dev/devs.hpp>
+#include <QCoreApplication>
 #include "CameraSelection.h"
 #include "CliOptions.h"
 #include "Config.h"
+#include "GuiRemoteClient.h"
 #include "PresetCommand.h"
 
 using namespace std;
@@ -17,6 +19,7 @@ void runInteractiveMode(shared_ptr<Device> dev);
 
 int main(int argc, char **argv)
 {
+    QCoreApplication application(argc, argv);
     const CliParseResult parsed = parseCliOptions(argc, argv);
     if (!parsed.ok()) {
         cerr << "Error: " << parsed.error << "\n\n";
@@ -68,6 +71,22 @@ int main(int argc, char **argv)
         }
     }
 
+    if (action == CliAction::RecallPreset && parsed.options.serial.empty()) {
+        const GuiRemoteRecallResult remote = recallPresetViaRunningGui(parsed.options.presetNumber);
+        if (remote.status == GuiRemoteRecallResult::Status::Accepted) {
+            cout << "Scene preset " << parsed.options.presetNumber
+                 << " recalled through the running GUI." << endl;
+            return 0;
+        }
+        if (remote.status == GuiRemoteRecallResult::Status::Rejected
+            || remote.status == GuiRemoteRecallResult::Status::Error) {
+            cerr << (remote.message.empty() ? "The running GUI could not recall the preset."
+                                           : remote.message)
+                 << endl;
+            return 1;
+        }
+    }
+
     const auto dev = waitForSelectedCamera(
         parsed.options.serial,
         action == CliAction::RecallPreset,
@@ -93,7 +112,7 @@ int main(int argc, char **argv)
         if (!applyPresetToCamera(dev, *requestedPreset, cout, cerr)) {
             return 1;
         }
-        cout << "Position preset " << parsed.options.presetNumber << " recalled." << endl;
+        cout << "Scene preset " << parsed.options.presetNumber << " recalled." << endl;
     } else if (interactive) {
         runInteractiveMode(dev);
     } else {

--- a/src/cli/meet2_test.cpp
+++ b/src/cli/meet2_test.cpp
@@ -12,9 +12,73 @@
 
 using namespace std;
 
+namespace {
+
+int32_t applyTrackingCommand(const shared_ptr<Device> &dev, bool enabled,
+                             int aiMode, int aiSubMode, bool autoZoom)
+{
+    const auto product = dev->productType();
+    const bool tiny2Family = product == ObsbotProdTiny2
+        || product == ObsbotProdTiny2Lite || product == ObsbotProdTinySE;
+    if (tiny2Family) {
+        int mode = enabled ? aiMode : Device::AiWorkModeNone;
+        if (enabled && mode == Device::AiWorkModeNone) {
+            mode = Device::AiWorkModeHuman;
+        }
+        const int subMode = mode == Device::AiWorkModeHuman ? aiSubMode : 0;
+        const int32_t zoomResult = dev->aiSetAiAutoZoomR(enabled && autoZoom);
+        const int32_t modeResult = dev->cameraSetAiModeU(
+            static_cast<Device::AiWorkModeType>(mode), subMode);
+        if (modeResult != 0) {
+            return modeResult;
+        }
+        if (zoomResult != 0) {
+            return zoomResult;
+        }
+
+        constexpr int confirmationAttempts = 20;
+        for (int attempt = 0; attempt < confirmationAttempts; ++attempt) {
+            Device::CameraStatus status{};
+            if (dev->cameraGetCameraStatusU(status) == 0
+                && status.tiny.ai_mode == mode
+                && (mode != Device::AiWorkModeHuman
+                    || status.tiny.ai_sub_mode == subMode)) {
+                return 0;
+            }
+            if (attempt + 1 < confirmationAttempts) {
+                this_thread::sleep_for(chrono::milliseconds(200));
+            }
+        }
+        return -1;
+    }
+
+    if (product == ObsbotProdTiny || product == ObsbotProdTiny4k) {
+        return dev->aiSetTargetSelectR(enabled);
+    }
+
+    const bool meetFamily = product == ObsbotProdMeet || product == ObsbotProdMeet4k
+        || product == ObsbotProdMeet2 || product == ObsbotProdMeetSE;
+    if (!meetFamily) {
+        return -1;
+    }
+    if (!enabled) {
+        return dev->cameraSetMediaModeU(Device::MediaModeNormal);
+    }
+
+    const int32_t mediaResult = dev->cameraSetMediaModeU(Device::MediaModeAutoFrame);
+    if (mediaResult != 0) {
+        return mediaResult;
+    }
+    this_thread::sleep_for(chrono::milliseconds(500));
+    return dev->cameraSetAutoFramingModeU(
+        Device::AutoFrmSingle, Device::AutoFrmUpperBody);
+}
+
+} // namespace
+
 // Forward declarations
 bool handleConfigErrors(Config &config);
-void applyConfigToCamera(shared_ptr<Device> dev, const Config::CameraSettings &settings);
+bool applyConfigToCamera(shared_ptr<Device> dev, const Config::CameraSettings &settings);
 void runInteractiveMode(shared_ptr<Device> dev);
 
 int main(int argc, char **argv)
@@ -109,7 +173,9 @@ int main(int argc, char **argv)
     }
 
     if (action == CliAction::RecallPreset) {
-        if (!applyPresetToCamera(dev, *requestedPreset, cout, cerr)) {
+        if (!applyPresetToCamera(
+                dev, *requestedPreset,
+                settings.trackingModeProfiles, cout, cerr)) {
             return 1;
         }
         cout << "Scene preset " << parsed.options.presetNumber << " recalled." << endl;
@@ -117,7 +183,10 @@ int main(int argc, char **argv)
         runInteractiveMode(dev);
     } else {
         cout << "\nApplying configuration to camera..." << endl;
-        applyConfigToCamera(dev, settings);
+        if (!applyConfigToCamera(dev, settings)) {
+            cerr << "Configuration was only partially applied." << endl;
+            return 1;
+        }
         cout << "Configuration applied successfully." << endl;
         cout << "Camera settings have been updated." << endl;
     }
@@ -178,102 +247,71 @@ bool handleConfigErrors(Config &config)
     }
 }
 
-void applyConfigToCamera(shared_ptr<Device> dev, const Config::CameraSettings &settings)
+bool applyConfigToCamera(shared_ptr<Device> dev, const Config::CameraSettings &settings)
 {
-    int32_t ret;
-
-    // Apply face tracking
-    if (settings.faceTracking) {
-        cout << "  Enabling face tracking..." << endl;
-        ret = dev->cameraSetMediaModeU(Device::MediaModeAutoFrame);
-        if (ret != 0) {
-            cout << "    Failed to set MediaMode (code: " << ret << ")" << endl;
-        } else {
-            this_thread::sleep_for(chrono::milliseconds(500));
-            ret = dev->cameraSetAutoFramingModeU(Device::AutoFrmSingle, Device::AutoFrmUpperBody);
-            if (ret != 0) {
-                cout << "    Failed to set AutoFraming mode (code: " << ret << ")" << endl;
-            }
+    bool success = true;
+    auto recordFailure = [&success](int32_t result) {
+        if (result != 0) {
+            cout << "    Failed (code: " << result << ")" << endl;
+            success = false;
         }
-    } else {
-        cout << "  Disabling face tracking..." << endl;
-        ret = dev->cameraSetMediaModeU(Device::MediaModeNormal);
-        if (ret != 0) {
-            cout << "    Failed to set MediaMode (code: " << ret << ")" << endl;
-        }
-    }
+    };
 
-    // Apply HDR
+    // Apply face tracking with the protocol for this camera family.
+    cout << "  " << (settings.faceTracking ? "Enabling" : "Disabling")
+         << " face tracking..." << endl;
+    const int32_t trackingResult = applyTrackingCommand(
+        dev, settings.faceTracking, settings.aiMode,
+        settings.aiSubMode, settings.autoZoom);
+    recordFailure(trackingResult);
+    const bool manualPositioningAllowed =
+        !settings.faceTracking && trackingResult == 0;
+
     cout << "  Setting HDR: " << (settings.hdr ? "On" : "Off") << endl;
-    ret = dev->cameraSetWdrR(settings.hdr ? Device::DevWdrModeDol2TO1 : Device::DevWdrModeNone);
-    if (ret != 0) {
-        cout << "    Failed (code: " << ret << ")" << endl;
-    }
+    recordFailure(dev->cameraSetWdrR(
+        settings.hdr ? Device::DevWdrModeDol2TO1 : Device::DevWdrModeNone));
 
-    // Apply FOV
     const char* fovNames[] = {"Wide (86°)", "Medium (78°)", "Narrow (65°)"};
     cout << "  Setting FOV: " << fovNames[settings.fov] << endl;
-    Device::FovType fovType = settings.fov == 0 ? Device::FovType86 :
-                               (settings.fov == 1 ? Device::FovType78 : Device::FovType65);
-    ret = dev->cameraSetFovU(fovType);
-    if (ret != 0) {
-        cout << "    Failed (code: " << ret << ")" << endl;
-    }
+    const Device::FovType fovType = settings.fov == 0 ? Device::FovType86 :
+        (settings.fov == 1 ? Device::FovType78 : Device::FovType65);
+    recordFailure(dev->cameraSetFovU(fovType));
 
-    // Apply Face AE
     cout << "  Setting Face AE: " << (settings.faceAE ? "On" : "Off") << endl;
-    ret = dev->cameraSetFaceAER(settings.faceAE);
-    if (ret != 0) {
-        cout << "    Failed (code: " << ret << ")" << endl;
-    }
+    recordFailure(dev->cameraSetFaceAER(settings.faceAE));
 
-    // Apply Face Focus
     cout << "  Setting Face Focus: " << (settings.faceFocus ? "On" : "Off") << endl;
-    ret = dev->cameraSetFaceFocusR(settings.faceFocus);
-    if (ret != 0) {
-        cout << "    Failed (code: " << ret << ")" << endl;
+    recordFailure(dev->cameraSetFaceFocusR(settings.faceFocus));
+
+    if (manualPositioningAllowed) {
+        cout << "  Setting Zoom: " << settings.zoom << "x" << endl;
+        recordFailure(dev->cameraSetZoomAbsoluteR(settings.zoom));
+
+        cout << "  Setting Pan/Tilt: " << settings.pan << ", " << settings.tilt << endl;
+        recordFailure(dev->cameraSetPanTiltAbsolute(settings.pan, settings.tilt));
+    } else {
+        cout << "  Skipping manual zoom and pan/tilt because tracking is enabled"
+             << " or could not be disabled." << endl;
     }
 
-    // Apply Zoom
-    cout << "  Setting Zoom: " << settings.zoom << "x" << endl;
-    ret = dev->cameraSetZoomAbsoluteR(settings.zoom);
-    if (ret != 0) {
-        cout << "    Failed (code: " << ret << ")" << endl;
-    }
-
-    // Apply Pan/Tilt
-    cout << "  Setting Pan/Tilt: " << settings.pan << ", " << settings.tilt << endl;
-    ret = dev->cameraSetPanTiltAbsolute(settings.pan, settings.tilt);
-    if (ret != 0) {
-        cout << "    Failed (code: " << ret << ")" << endl;
-    }
-
-    // Apply Image Controls
     cout << "  Setting Brightness: " << settings.brightness << endl;
-    ret = dev->cameraSetImageBrightnessR(settings.brightness);
-    if (ret != 0) {
-        cout << "    Failed (code: " << ret << ")" << endl;
-    }
+    recordFailure(dev->cameraSetImageBrightnessR(settings.brightness));
 
     cout << "  Setting Contrast: " << settings.contrast << endl;
-    ret = dev->cameraSetImageContrastR(settings.contrast);
-    if (ret != 0) {
-        cout << "    Failed (code: " << ret << ")" << endl;
-    }
+    recordFailure(dev->cameraSetImageContrastR(settings.contrast));
 
     cout << "  Setting Saturation: " << settings.saturation << endl;
-    ret = dev->cameraSetImageSaturationR(settings.saturation);
-    if (ret != 0) {
-        cout << "    Failed (code: " << ret << ")" << endl;
-    }
+    recordFailure(dev->cameraSetImageSaturationR(settings.saturation));
 
     const char* wbNames[] = {"Auto", "Daylight", "Fluorescent", "Tungsten", "Flash", "Fine", "Cloudy", "Shade"};
-    cout << "  Setting White Balance: " << wbNames[settings.whiteBalance] << endl;
-    Device::DevWhiteBalanceType wbType = static_cast<Device::DevWhiteBalanceType>(settings.whiteBalance);
-    ret = dev->cameraSetWhiteBalanceR(wbType, 0);
-    if (ret != 0) {
-        cout << "    Failed (code: " << ret << ")" << endl;
+    if (settings.whiteBalance >= 0 && settings.whiteBalance < 8) {
+        cout << "  Setting White Balance: " << wbNames[settings.whiteBalance] << endl;
+    } else {
+        cout << "  Setting White Balance mode: " << settings.whiteBalance << endl;
     }
+    const auto wbType = static_cast<Device::DevWhiteBalanceType>(settings.whiteBalance);
+    recordFailure(dev->cameraSetWhiteBalanceR(wbType, 0));
+    return success;
 }
 
 void runInteractiveMode(shared_ptr<Device> dev)
@@ -312,6 +350,17 @@ void runInteractiveMode(shared_ptr<Device> dev)
     const double ptz_step = 0.1;
     const double zoom_step = 0.1;
     const int focus_step = 5;  // 5% increments
+    // Start fail-closed: only a successful tracking-off command authorizes
+    // manual PTZ/zoom/focus commands in this raw SDK tool.
+    bool manualPositioningAllowed = false;
+    auto requireManualPositioning = [&manualPositioningAllowed]() {
+        if (manualPositioningAllowed) {
+            return true;
+        }
+        cout << "Refusing manual command until tracking is successfully disabled."
+             << endl;
+        return false;
+    };
 
     string cmd;
     cout << "\nEnter command: ";
@@ -325,23 +374,23 @@ void runInteractiveMode(shared_ptr<Device> dev)
         switch (choice) {
             case 1:
                 cout << "Enabling face tracking..." << endl;
-                ret = dev->cameraSetMediaModeU(Device::MediaModeAutoFrame);
-                if (ret == 0) {
-                    this_thread::sleep_for(chrono::milliseconds(500));
-                    ret = dev->cameraSetAutoFramingModeU(Device::AutoFrmSingle, Device::AutoFrmUpperBody);
-                    cout << (ret == 0 ? "Success" : "Failed") << endl;
-                } else {
-                    cout << "Failed (code: " << ret << ")" << endl;
-                }
+                ret = applyTrackingCommand(
+                    dev, true, Device::AiWorkModeHuman,
+                    Device::AiSubModeUpperBody, false);
+                manualPositioningAllowed = false;
+                cout << (ret == 0 ? "Success" : "Failed") << endl;
                 break;
 
             case 2:
                 cout << "Disabling face tracking..." << endl;
-                ret = dev->cameraSetMediaModeU(Device::MediaModeNormal);
+                ret = applyTrackingCommand(
+                    dev, false, Device::AiWorkModeNone, 0, false);
+                manualPositioningAllowed = ret == 0;
                 cout << (ret == 0 ? "Success" : "Failed") << endl;
                 break;
 
             case 3:
+                if (!requireManualPositioning()) break;
                 current_zoom += zoom_step;
                 if (current_zoom > 2.0) current_zoom = 2.0;
                 cout << "Zooming in (" << current_zoom << "x)..." << endl;
@@ -350,6 +399,7 @@ void runInteractiveMode(shared_ptr<Device> dev)
                 break;
 
             case 4:
+                if (!requireManualPositioning()) break;
                 current_zoom -= zoom_step;
                 if (current_zoom < 1.0) current_zoom = 1.0;
                 cout << "Zooming out (" << current_zoom << "x)..." << endl;
@@ -358,6 +408,7 @@ void runInteractiveMode(shared_ptr<Device> dev)
                 break;
 
             case 5:
+                if (!requireManualPositioning()) break;
                 current_pan -= ptz_step;
                 if (current_pan < -1.0) current_pan = -1.0;
                 cout << "Panning left..." << endl;
@@ -366,6 +417,7 @@ void runInteractiveMode(shared_ptr<Device> dev)
                 break;
 
             case 6:
+                if (!requireManualPositioning()) break;
                 current_pan += ptz_step;
                 if (current_pan > 1.0) current_pan = 1.0;
                 cout << "Panning right..." << endl;
@@ -374,6 +426,7 @@ void runInteractiveMode(shared_ptr<Device> dev)
                 break;
 
             case 7:
+                if (!requireManualPositioning()) break;
                 current_tilt += ptz_step;
                 if (current_tilt > 1.0) current_tilt = 1.0;
                 cout << "Tilting up..." << endl;
@@ -382,6 +435,7 @@ void runInteractiveMode(shared_ptr<Device> dev)
                 break;
 
             case 8:
+                if (!requireManualPositioning()) break;
                 current_tilt -= ptz_step;
                 if (current_tilt < -1.0) current_tilt = -1.0;
                 cout << "Tilting down..." << endl;
@@ -390,6 +444,7 @@ void runInteractiveMode(shared_ptr<Device> dev)
                 break;
 
             case 9:
+                if (!requireManualPositioning()) break;
                 current_pan = 0.0;
                 current_tilt = 0.0;
                 cout << "Centering view..." << endl;
@@ -409,6 +464,7 @@ void runInteractiveMode(shared_ptr<Device> dev)
             }
 
             case 'a': {
+                if (!requireManualPositioning()) break;
                 cout << "Enabling auto focus..." << endl;
                 int32_t ret = dev->cameraSetFocusAbsolute(0, true);
                 cout << (ret == 0 ? "Success" : "Failed") << endl;
@@ -416,6 +472,7 @@ void runInteractiveMode(shared_ptr<Device> dev)
             }
 
             case 'm': {
+                if (!requireManualPositioning()) break;
                 cout << "Enter focus value (0-100): ";
                 int focus_val;
                 cin >> focus_val;
@@ -429,6 +486,7 @@ void runInteractiveMode(shared_ptr<Device> dev)
             }
 
             case 'k': {
+                if (!requireManualPositioning()) break;
                 current_focus += focus_step;
                 if (current_focus > 100) current_focus = 100;
                 cout << "Increasing focus to " << current_focus << "..." << endl;
@@ -438,6 +496,7 @@ void runInteractiveMode(shared_ptr<Device> dev)
             }
 
             case 'j': {
+                if (!requireManualPositioning()) break;
                 current_focus -= focus_step;
                 if (current_focus < 0) current_focus = 0;
                 cout << "Decreasing focus to " << current_focus << "..." << endl;
@@ -473,7 +532,12 @@ void runInteractiveMode(shared_ptr<Device> dev)
                 cin >> ai_mode;
                 if (ai_mode >= 0 && ai_mode <= 5) {
                     cout << "Setting AI mode to " << ai_mode << "..." << endl;
-                    int32_t ret = dev->cameraSetAiModeU(static_cast<Device::AiWorkModeType>(ai_mode));
+                    const bool enableAi = ai_mode != Device::AiWorkModeNone;
+                    const int subMode = ai_mode == Device::AiWorkModeHuman
+                        ? Device::AiSubModeUpperBody : 0;
+                    const int32_t ret = applyTrackingCommand(
+                        dev, enableAi, ai_mode, subMode, false);
+                    manualPositioningAllowed = ret == 0 && !enableAi;
                     cout << (ret == 0 ? "Success" : "Failed") << endl;
                 } else {
                     cout << "Invalid AI mode (0-5)" << endl;
@@ -483,7 +547,9 @@ void runInteractiveMode(shared_ptr<Device> dev)
 
             case 'I': {
                 cout << "Disabling AI Mode..." << endl;
-                int32_t ret = dev->cameraSetAiModeU(Device::AiWorkModeNone);
+                const int32_t ret = applyTrackingCommand(
+                    dev, false, Device::AiWorkModeNone, 0, false);
+                manualPositioningAllowed = ret == 0;
                 cout << (ret == 0 ? "Success" : "Failed") << endl;
                 break;
             }

--- a/src/common/Config.cpp
+++ b/src/common/Config.cpp
@@ -5,6 +5,7 @@
 #include <cstdlib>
 #include <unordered_set>
 #include <algorithm>
+#include <cmath>
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -264,6 +265,16 @@ bool Config::parseLine(const std::string &line, int lineNumber, std::vector<Vali
         return false;
     };
 
+    auto parseFiniteDouble = [](const std::string &val, double &out) -> bool {
+        try {
+            size_t consumed = 0;
+            out = std::stod(val, &consumed);
+            return consumed == val.size() && std::isfinite(out);
+        } catch (...) {
+            return false;
+        }
+    };
+
     for (int i = 0; i < 3; ++i) {
         std::string base = "preset" + std::to_string(i + 1) + "_";
         if (key.rfind(base, 0) == 0) {
@@ -277,43 +288,40 @@ bool Config::parseLine(const std::string &line, int lineNumber, std::vector<Vali
                 }
                 return true;
             } else if (suffix == "pan") {
-                try {
-                    double pan = std::stod(value);
-                    if (pan < -1.0 || pan > 1.0) {
-                        addError(InvalidValue, base + "pan must be between -1.0 and 1.0");
-                        return false;
-                    }
-                    preset.pan = pan;
-                } catch (...) {
+                double pan = 0.0;
+                if (!parseFiniteDouble(value, pan)) {
                     addError(InvalidValue, base + "pan must be a number between -1.0 and 1.0");
                     return false;
                 }
+                if (pan < -1.0 || pan > 1.0) {
+                    addError(InvalidValue, base + "pan must be between -1.0 and 1.0");
+                    return false;
+                }
+                preset.pan = pan;
                 return true;
             } else if (suffix == "tilt") {
-                try {
-                    double tilt = std::stod(value);
-                    if (tilt < -1.0 || tilt > 1.0) {
-                        addError(InvalidValue, base + "tilt must be between -1.0 and 1.0");
-                        return false;
-                    }
-                    preset.tilt = tilt;
-                } catch (...) {
+                double tilt = 0.0;
+                if (!parseFiniteDouble(value, tilt)) {
                     addError(InvalidValue, base + "tilt must be a number between -1.0 and 1.0");
                     return false;
                 }
+                if (tilt < -1.0 || tilt > 1.0) {
+                    addError(InvalidValue, base + "tilt must be between -1.0 and 1.0");
+                    return false;
+                }
+                preset.tilt = tilt;
                 return true;
             } else if (suffix == "zoom") {
-                try {
-                    double zoom = std::stod(value);
-                    if (zoom < 1.0 || zoom > 2.0) {
-                        addError(InvalidValue, base + "zoom must be between 1.0 and 2.0");
-                        return false;
-                    }
-                    preset.zoom = zoom;
-                } catch (...) {
+                double zoom = 0.0;
+                if (!parseFiniteDouble(value, zoom)) {
                     addError(InvalidValue, base + "zoom must be a number between 1.0 and 2.0");
                     return false;
                 }
+                if (zoom < 1.0 || zoom > 2.0) {
+                    addError(InvalidValue, base + "zoom must be between 1.0 and 2.0");
+                    return false;
+                }
+                preset.zoom = zoom;
                 return true;
             }
         }
@@ -656,13 +664,13 @@ bool Config::validateSettings(std::vector<ValidationError> &errors)
         if (!preset.defined) {
             continue;
         }
-        if (preset.pan < -1.0 || preset.pan > 1.0) {
+        if (!std::isfinite(preset.pan) || preset.pan < -1.0 || preset.pan > 1.0) {
             addError("preset" + std::to_string(i + 1) + "_pan out of range (must be -1.0 to 1.0)");
         }
-        if (preset.tilt < -1.0 || preset.tilt > 1.0) {
+        if (!std::isfinite(preset.tilt) || preset.tilt < -1.0 || preset.tilt > 1.0) {
             addError("preset" + std::to_string(i + 1) + "_tilt out of range (must be -1.0 to 1.0)");
         }
-        if (preset.zoom < 1.0 || preset.zoom > 2.0) {
+        if (!std::isfinite(preset.zoom) || preset.zoom < 1.0 || preset.zoom > 2.0) {
             addError("preset" + std::to_string(i + 1) + "_zoom out of range (must be 1.0 to 2.0)");
         }
     }

--- a/src/common/Config.cpp
+++ b/src/common/Config.cpp
@@ -6,8 +6,137 @@
 #include <unordered_set>
 #include <algorithm>
 #include <cmath>
-#include <sys/stat.h>
-#include <sys/types.h>
+#include <filesystem>
+#include <system_error>
+#include <cerrno>
+#include <cstring>
+#include <fcntl.h>
+#include <unistd.h>
+
+namespace {
+
+bool writeConfigAtomically(const std::string &configPath,
+                           const std::string &configDir,
+                           const std::string &contents)
+{
+    std::string temporaryTemplate = configPath + ".tmp.XXXXXX";
+    std::vector<char> temporaryPath(
+        temporaryTemplate.begin(), temporaryTemplate.end());
+    temporaryPath.push_back('\0');
+
+    const int descriptor = ::mkstemp(temporaryPath.data());
+    if (descriptor < 0) {
+        std::cerr << "Failed to create temporary config file for "
+                  << configPath << ": " << std::strerror(errno)
+                  << std::endl;
+        return false;
+    }
+
+    const std::string temporaryName(temporaryPath.data());
+    const auto discardTemporary = [&]() {
+        ::unlink(temporaryName.c_str());
+    };
+
+    std::size_t offset = 0;
+    while (offset < contents.size()) {
+        const ssize_t written = ::write(
+            descriptor, contents.data() + offset,
+            contents.size() - offset);
+        if (written < 0 && errno == EINTR) {
+            continue;
+        }
+        if (written <= 0) {
+            const int writeError = errno;
+            ::close(descriptor);
+            discardTemporary();
+            std::cerr << "Failed to write temporary config file for "
+                      << configPath << ": "
+                      << std::strerror(writeError) << std::endl;
+            return false;
+        }
+        offset += static_cast<std::size_t>(written);
+    }
+
+    if (::fsync(descriptor) != 0) {
+        const int syncError = errno;
+        ::close(descriptor);
+        discardTemporary();
+        std::cerr << "Failed to sync temporary config file for "
+                  << configPath << ": " << std::strerror(syncError)
+                  << std::endl;
+        return false;
+    }
+    if (::close(descriptor) != 0) {
+        const int closeError = errno;
+        discardTemporary();
+        std::cerr << "Failed to close temporary config file for "
+                  << configPath << ": " << std::strerror(closeError)
+                  << std::endl;
+        return false;
+    }
+
+    if (::rename(temporaryName.c_str(), configPath.c_str()) != 0) {
+        const int renameError = errno;
+        discardTemporary();
+        std::cerr << "Failed to atomically replace config file "
+                  << configPath << ": " << std::strerror(renameError)
+                  << std::endl;
+        return false;
+    }
+
+    // The rename is already atomic. Sync the containing directory as a
+    // best-effort durability step without reporting a false rollback after
+    // the new file has become visible.
+    const int directoryDescriptor =
+        ::open(configDir.c_str(), O_RDONLY | O_DIRECTORY);
+    if (directoryDescriptor >= 0) {
+        if (::fsync(directoryDescriptor) != 0) {
+            std::cerr << "Warning: failed to sync config directory "
+                      << configDir << ": " << std::strerror(errno)
+                      << std::endl;
+        }
+        ::close(directoryDescriptor);
+    }
+    return true;
+}
+
+bool isTrackingProfileMetadataKey(const std::string &key)
+{
+    static const std::unordered_set<std::string> activeKeys = {
+        "tiny2_active_focus_policy",
+        "tiny2_active_manual_focus",
+        "tiny2_active_auto_zoom",
+        "tiny2_active_track_speed"
+        , "camera_pan_tilt_intent_defined"
+        , "camera_zoom_intent_defined"
+        , "camera_image_intent_defined"
+    };
+    if (activeKeys.count(key) > 0) {
+        return true;
+    }
+
+    for (std::size_t i = 0; i < 5; ++i) {
+        const std::string base =
+            "tiny2_" + std::string(tiny2TrackingModeName(i)) + "_";
+        if (key == base + "focus_policy"
+            || key == base + "manual_focus"
+            || key == base + "auto_zoom"
+            || key == base + "track_speed") {
+            return true;
+        }
+    }
+
+    if (key.rfind("preset", 0) == 0 && key.size() > 8
+        && key[6] >= '1' && key[6] <= '3' && key[7] == '_') {
+        const std::string suffix = key.substr(8);
+        return suffix == "focus_policy"
+            || suffix == "manual_focus"
+            || suffix == "track_speed";
+    }
+    return false;
+}
+
+} // namespace
 
 Config::Config()
     : m_savingEnabled(true)
@@ -29,12 +158,18 @@ void Config::setDefaults()
     m_settings.zoom = 1.0;            // No zoom
    m_settings.pan = 0.0;             // Centered
    m_settings.tilt = 0.0;            // Centered
+    m_settings.panTiltIntentDefined = true;
+    m_settings.zoomIntentDefined = true;
+    m_settings.imageIntentDefined = true;
 
     // AI / Tracking defaults
     m_settings.aiMode = 0;            // AiWorkModeNone
     m_settings.aiSubMode = 0;         // AiSubModeNormal
     m_settings.autoZoom = false;
     m_settings.trackSpeed = 2;        // AiTrackSpeedStandard
+    m_settings.activeTrackingProfile = {
+        TrackingFocusPolicy::Manual, 50, false, 2};
+    m_settings.trackingModeProfiles = defaultTiny2TrackingModeProfiles();
 
     // Image controls - use auto mode by default
     m_settings.brightnessAuto = true;
@@ -68,6 +203,9 @@ void Config::setDefaults()
         preset.aiMode = 0;
         preset.aiSubMode = 0;
         preset.autoZoom = false;
+        preset.focusPolicy = TrackingFocusPolicy::Manual;
+        preset.manualFocusPosition = 50;
+        preset.trackSpeed = 2;
         preset.paperCropMode = 0;
         preset.paperCropLeft = 0.0;
         preset.paperCropTop = 0.0;
@@ -120,7 +258,11 @@ bool Config::load(std::vector<ValidationError> &errors)
         return true;
     }
 
-    // Temporary storage for parsed values
+    // Parse transactionally. A malformed reload must not replace the last
+    // valid in-memory intent with a partially parsed configuration.
+    const CameraSettings previousSettings = m_settings;
+    setDefaults();
+
     std::map<std::string, std::string> values;
     std::vector<std::string> foundKeys;
 
@@ -130,15 +272,20 @@ bool Config::load(std::vector<ValidationError> &errors)
     while (std::getline(file, line)) {
         lineNumber++;
 
-        // Trim whitespace
         size_t start = line.find_first_not_of(" \t\r\n");
-        if (start == std::string::npos) continue;  // Empty line
+        if (start == std::string::npos) continue;
         line = line.substr(start);
 
-        // Skip comments
-        if (line[0] == '#') continue;
+        // New Tiny 2 profile fields are written as #@ metadata. Older
+        // binaries skip these lines as comments, preserving package rollback
+        // compatibility while the current loader validates them strictly.
+        const bool profileMetadata = line.rfind("#@", 0) == 0;
+        if (profileMetadata) {
+            line = line.substr(2);
+        } else if (line[0] == '#') {
+            continue;
+        }
 
-        // Parse key=value
         size_t equals = line.find('=');
         if (equals == std::string::npos) {
             ValidationError err;
@@ -152,24 +299,42 @@ bool Config::load(std::vector<ValidationError> &errors)
         std::string key = line.substr(0, equals);
         std::string value = line.substr(equals + 1);
 
-        // Trim key and value
-        key.erase(key.find_last_not_of(" \t\r\n") + 1);
-        value.erase(0, value.find_first_not_of(" \t\r\n"));
-        value.erase(value.find_last_not_of(" \t\r\n") + 1);
+        const size_t keyEnd = key.find_last_not_of(" \t\r\n");
+        if (keyEnd == std::string::npos) {
+            key.clear();
+        } else {
+            key.erase(keyEnd + 1);
+        }
+        const size_t valueStart = value.find_first_not_of(" \t\r\n");
+        value = valueStart == std::string::npos
+            ? std::string() : value.substr(valueStart);
+        const size_t valueEnd = value.find_last_not_of(" \t\r\n");
+        if (valueEnd != std::string::npos) {
+            value.erase(valueEnd + 1);
+        }
 
-        // Remove inline comments from value
         size_t comment = value.find('#');
         if (comment != std::string::npos) {
             value = value.substr(0, comment);
-            value.erase(value.find_last_not_of(" \t\r\n") + 1);
+            const size_t trimmedEnd = value.find_last_not_of(" \t\r\n");
+            value = trimmedEnd == std::string::npos
+                ? std::string() : value.substr(0, trimmedEnd + 1);
+        }
+
+        if (profileMetadata && !isTrackingProfileMetadataKey(key)) {
+            ValidationError err;
+            err.type = UnknownProperty;
+            err.message = "Unknown tracking profile metadata '" + key + "'";
+            err.lineNumber = lineNumber;
+            errors.push_back(err);
+            continue;
         }
 
         values[key] = value;
-        foundKeys.push_back(key);
-
-        if (!parseLine(key + "=" + value, lineNumber, errors)) {
-            // Error already added to errors vector
+        if (!profileMetadata) {
+            foundKeys.push_back(key);
         }
+        parseLine(key + "=" + value, lineNumber, errors);
     }
 
     file.close();
@@ -264,7 +429,17 @@ bool Config::load(std::vector<ValidationError> &errors)
         errors.push_back(err);
     }
 
-    return errors.empty();
+    if (!errors.empty()) {
+        m_settings = previousSettings;
+        return false;
+    }
+
+    migrateTrackingProfiles(values);
+    if (!validateSettings(errors)) {
+        m_settings = previousSettings;
+        return false;
+    }
+    return true;
 }
 
 bool Config::parseLine(const std::string &line, int lineNumber, std::vector<ValidationError> &errors)
@@ -326,6 +501,61 @@ bool Config::parseLine(const std::string &line, int lineNumber, std::vector<Vali
     auto parseCropMargin = [&](const std::string &val, double &out) -> bool {
         return parseFiniteDouble(val, out) && out >= 0.0 && out <= 0.45;
     };
+
+    auto parseProfileField = [&](const std::string &base,
+                                 TrackingModeProfile &profile) -> int {
+        if (key == base + "focus_policy") {
+            if (!parseTrackingFocusPolicy(value, profile.focusPolicy)) {
+                addError(InvalidValue,
+                         base + "focus_policy must be face, continuous, or manual");
+                return -1;
+            }
+            return 1;
+        }
+        if (key == base + "manual_focus") {
+            int focus = 0;
+            if (!parseInteger(value, focus) || focus < 0 || focus > 100) {
+                addError(InvalidValue,
+                         base + "manual_focus must be an integer between 0 and 100");
+                return -1;
+            }
+            profile.manualFocusPosition = focus;
+            return 1;
+        }
+        if (key == base + "auto_zoom") {
+            if (!parseBool(value, profile.autoZoom)) {
+                addError(InvalidValue,
+                         base + "auto_zoom must be true/false or enabled/disabled");
+                return -1;
+            }
+            return 1;
+        }
+        if (key == base + "track_speed") {
+            int speed = 0;
+            if (!parseInteger(value, speed) || speed < 0 || speed > 5) {
+                addError(InvalidValue,
+                         base + "track_speed must be an integer between 0 and 5");
+                return -1;
+            }
+            profile.trackSpeed = speed;
+            return 1;
+        }
+        return 0;
+    };
+
+    int profileFieldResult = parseProfileField(
+        "tiny2_active_", m_settings.activeTrackingProfile);
+    if (profileFieldResult != 0) {
+        return profileFieldResult > 0;
+    }
+    for (std::size_t i = 0; i < m_settings.trackingModeProfiles.size(); ++i) {
+        profileFieldResult = parseProfileField(
+            "tiny2_" + std::string(tiny2TrackingModeName(i)) + "_",
+            m_settings.trackingModeProfiles[i]);
+        if (profileFieldResult != 0) {
+            return profileFieldResult > 0;
+        }
+    }
 
     for (int i = 0; i < 3; ++i) {
         std::string base = "preset" + std::to_string(i + 1) + "_";
@@ -394,14 +624,38 @@ bool Config::parseLine(const std::string &line, int lineNumber, std::vector<Vali
                 }
                 return true;
             } else if (suffix == "ai_sub_mode") {
-                if (!parseInteger(value, preset.aiSubMode) || preset.aiSubMode < 0 || preset.aiSubMode > 5) {
-                    addError(InvalidValue, base + "ai_sub_mode must be between 0 and 5");
+                if (!parseInteger(value, preset.aiSubMode) || preset.aiSubMode < 0 || preset.aiSubMode > 4) {
+                    addError(InvalidValue, base + "ai_sub_mode must be between 0 and 4");
                     return false;
                 }
                 return true;
             } else if (suffix == "auto_zoom") {
                 if (!parseBool(value, preset.autoZoom)) {
                     addError(InvalidValue, base + "auto_zoom must be true/false or enabled/disabled");
+                    return false;
+                }
+                return true;
+            } else if (suffix == "focus_policy") {
+                if (!parseTrackingFocusPolicy(value, preset.focusPolicy)) {
+                    addError(InvalidValue,
+                             base + "focus_policy must be face, continuous, or manual");
+                    return false;
+                }
+                return true;
+            } else if (suffix == "manual_focus") {
+                if (!parseInteger(value, preset.manualFocusPosition)
+                    || preset.manualFocusPosition < 0
+                    || preset.manualFocusPosition > 100) {
+                    addError(InvalidValue,
+                             base + "manual_focus must be an integer between 0 and 100");
+                    return false;
+                }
+                return true;
+            } else if (suffix == "track_speed") {
+                if (!parseInteger(value, preset.trackSpeed)
+                    || preset.trackSpeed < 0 || preset.trackSpeed > 5) {
+                    addError(InvalidValue,
+                             base + "track_speed must be an integer between 0 and 5");
                     return false;
                 }
                 return true;
@@ -439,7 +693,25 @@ bool Config::parseLine(const std::string &line, int lineNumber, std::vector<Vali
         }
     }
 
-    if (key == "face_tracking") {
+    if (key == "camera_pan_tilt_intent_defined") {
+        if (!parseBool(value, m_settings.panTiltIntentDefined)) {
+            addError(InvalidValue,
+                     "camera_pan_tilt_intent_defined must be boolean");
+            return false;
+        }
+    } else if (key == "camera_zoom_intent_defined") {
+        if (!parseBool(value, m_settings.zoomIntentDefined)) {
+            addError(InvalidValue,
+                     "camera_zoom_intent_defined must be boolean");
+            return false;
+        }
+    } else if (key == "camera_image_intent_defined") {
+        if (!parseBool(value, m_settings.imageIntentDefined)) {
+            addError(InvalidValue,
+                     "camera_image_intent_defined must be boolean");
+            return false;
+        }
+    } else if (key == "face_tracking") {
         if (!parseBool(value, m_settings.faceTracking)) {
             addError(InvalidValue, "face_tracking must be true/false or enabled/disabled");
             return false;
@@ -471,85 +743,54 @@ bool Config::parseLine(const std::string &line, int lineNumber, std::vector<Vali
             return false;
         }
     } else if (key == "zoom") {
-        try {
-            double zoom = std::stod(value);
-            if (zoom == 0.0) {
-                m_settings.zoom = 0.0;
-            } else if (zoom < 1.0 || zoom > 2.0) {
-                addError(InvalidValue, "zoom must be between 1.0 and 2.0");
-                return false;
-            } else {
-                m_settings.zoom = zoom;
-            }
-        } catch (...) {
-            addError(InvalidValue, "zoom must be a number between 1.0 and 2.0");
+        double zoom = 0.0;
+        if (!parseFiniteDouble(value, zoom)
+            || (zoom != 0.0 && (zoom < 1.0 || zoom > 2.0))) {
+            addError(InvalidValue, "zoom must be 0 or a number between 1.0 and 2.0");
             return false;
         }
+        m_settings.zoom = zoom;
     } else if (key == "pan") {
-        try {
-            double pan = std::stod(value);
-            if (pan < -1.0 || pan > 1.0) {
-                addError(InvalidValue, "pan must be between -1.0 and 1.0");
-                return false;
-            }
-            m_settings.pan = pan;
-        } catch (...) {
+        double pan = 0.0;
+        if (!parseFiniteDouble(value, pan) || pan < -1.0 || pan > 1.0) {
             addError(InvalidValue, "pan must be a number between -1.0 and 1.0");
             return false;
         }
+        m_settings.pan = pan;
     } else if (key == "tilt") {
-        try {
-            double tilt = std::stod(value);
-            if (tilt < -1.0 || tilt > 1.0) {
-                addError(InvalidValue, "tilt must be between -1.0 and 1.0");
-                return false;
-            }
-            m_settings.tilt = tilt;
-        } catch (...) {
+        double tilt = 0.0;
+        if (!parseFiniteDouble(value, tilt) || tilt < -1.0 || tilt > 1.0) {
             addError(InvalidValue, "tilt must be a number between -1.0 and 1.0");
             return false;
         }
+        m_settings.tilt = tilt;
     } else if (key == "ai_mode") {
-        try {
-            int mode = std::stoi(value);
-            if (mode < 0 || mode > 6) {
-                addError(InvalidValue, "ai_mode must be between 0 and 6");
-                return false;
-            }
-            m_settings.aiMode = mode;
-        } catch (...) {
-            addError(InvalidValue, "ai_mode must be an integer between 0 and 6");
+        int mode = 0;
+        if (!parseInteger(value, mode) || mode < 0 || mode > 5) {
+            addError(InvalidValue, "ai_mode must be an integer between 0 and 5");
             return false;
         }
+        m_settings.aiMode = mode;
     } else if (key == "ai_sub_mode") {
-        try {
-            int subMode = std::stoi(value);
-            if (subMode < 0 || subMode > 5) {
-                addError(InvalidValue, "ai_sub_mode must be between 0 and 5");
-                return false;
-            }
-            m_settings.aiSubMode = subMode;
-        } catch (...) {
-            addError(InvalidValue, "ai_sub_mode must be an integer between 0 and 5");
+        int subMode = 0;
+        if (!parseInteger(value, subMode) || subMode < 0 || subMode > 4) {
+            addError(InvalidValue, "ai_sub_mode must be an integer between 0 and 4");
             return false;
         }
+        m_settings.aiSubMode = subMode;
     } else if (key == "auto_zoom") {
         if (!parseBool(value, m_settings.autoZoom)) {
             addError(InvalidValue, "auto_zoom must be true/false or enabled/disabled");
             return false;
         }
     } else if (key == "track_speed") {
-        try {
-            int trackSpeed = std::stoi(value);
-            if (trackSpeed < 0 || trackSpeed > 5) {
-                addError(InvalidValue, "track_speed must be between 0 and 5");
-                return false;
-            }
-            m_settings.trackSpeed = trackSpeed;
-        } catch (...) {
+        int trackSpeed = 0;
+        if (!parseInteger(value, trackSpeed)
+            || trackSpeed < 0 || trackSpeed > 5) {
             addError(InvalidValue, "track_speed must be an integer between 0 and 5");
             return false;
         }
+        m_settings.trackSpeed = trackSpeed;
     } else if (key == "brightness_auto") {
         if (!parseBool(value, m_settings.brightnessAuto)) {
             addError(InvalidValue, "brightness_auto must be true/false or enabled/disabled");
@@ -750,6 +991,88 @@ bool Config::parseLine(const std::string &line, int lineNumber, std::vector<Vali
     return true;
 }
 
+void Config::migrateTrackingProfiles(
+    const std::map<std::string, std::string> &parsedValues)
+{
+    const auto has = [&](const std::string &key) {
+        return parsedValues.find(key) != parsedValues.end();
+    };
+    const TrackingModeProfile legacy = legacyTrackingModeProfile(
+        m_settings.faceFocus, m_settings.focus,
+        m_settings.autoZoom, m_settings.trackSpeed);
+
+    if (!has("tiny2_active_focus_policy")) {
+        m_settings.activeTrackingProfile.focusPolicy = legacy.focusPolicy;
+    }
+    if (!has("tiny2_active_manual_focus")) {
+        m_settings.activeTrackingProfile.manualFocusPosition =
+            legacy.manualFocusPosition;
+    }
+    if (!has("tiny2_active_auto_zoom")) {
+        m_settings.activeTrackingProfile.autoZoom = legacy.autoZoom;
+    }
+    if (!has("tiny2_active_track_speed")) {
+        m_settings.activeTrackingProfile.trackSpeed = legacy.trackSpeed;
+    }
+
+    const bool hasExplicitActiveProfile =
+        has("tiny2_active_focus_policy")
+        || has("tiny2_active_manual_focus")
+        || has("tiny2_active_auto_zoom")
+        || has("tiny2_active_track_speed");
+    if (!m_settings.faceTracking && !hasExplicitActiveProfile) {
+        m_settings.activeTrackingProfile.focusPolicy =
+            TrackingFocusPolicy::Manual;
+        m_settings.activeTrackingProfile.autoZoom = false;
+    }
+
+    for (std::size_t i = 0; i < m_settings.trackingModeProfiles.size(); ++i) {
+        auto &profile = m_settings.trackingModeProfiles[i];
+        const std::string base =
+            "tiny2_" + std::string(tiny2TrackingModeName(i)) + "_";
+
+        // Legacy face-focus and auto-zoom were Human-mode controls. Preserve
+        // that intent only for Human; the approved Group/Hand/Whiteboard/Desk
+        // defaults remain independent.
+        if (i == 1 && !has(base + "focus_policy")) {
+            profile.focusPolicy = legacy.focusPolicy;
+        }
+        if (!has(base + "manual_focus")) {
+            profile.manualFocusPosition = legacy.manualFocusPosition;
+        }
+        if (i == 1 && !has(base + "auto_zoom")) {
+            profile.autoZoom = legacy.autoZoom;
+        }
+        if (!has(base + "track_speed")) {
+            profile.trackSpeed = legacy.trackSpeed;
+        }
+    }
+
+    for (std::size_t i = 0; i < m_settings.presets.size(); ++i) {
+        auto &preset = m_settings.presets[i];
+        const std::string base =
+            "preset" + std::to_string(i + 1) + "_";
+        if (!has(base + "focus_policy")) {
+            preset.focusPolicy = preset.trackingEnabled
+                ? m_settings.activeTrackingProfile.focusPolicy
+                : TrackingFocusPolicy::Manual;
+        }
+        if (!has(base + "manual_focus")) {
+            preset.manualFocusPosition =
+                m_settings.activeTrackingProfile.manualFocusPosition;
+        }
+        if (!has(base + "track_speed")) {
+            preset.trackSpeed = m_settings.activeTrackingProfile.trackSpeed;
+        }
+        if (preset.sceneDefined && !preset.trackingEnabled) {
+            // Older packages could persist auto zoom while a scene was
+            // tracking-off even though it could never be active. Normalize
+            // that legacy combination to the new safe off invariant.
+            preset.autoZoom = false;
+        }
+    }
+}
+
 bool Config::validateSettings(std::vector<ValidationError> &errors)
 {
     errors.clear();
@@ -762,32 +1085,76 @@ bool Config::validateSettings(std::vector<ValidationError> &errors)
         errors.push_back(err);
     };
 
+    const auto validCropMargin = [](double margin) {
+        return std::isfinite(margin) && margin >= 0.0 && margin <= 0.45;
+    };
+
     if (m_settings.fov < 0 || m_settings.fov > 2) {
         addError("fov out of range (must be 0-2)");
     }
 
-    if (m_settings.zoom != 0.0 && (m_settings.zoom < 1.0 || m_settings.zoom > 2.0)) {
-        addError("zoom out of range (must be 1.0-2.0)");
+    if (!std::isfinite(m_settings.zoom)
+        || (m_settings.zoom != 0.0
+            && (m_settings.zoom < 1.0 || m_settings.zoom > 2.0))) {
+        addError("zoom out of range (must be 0 or 1.0-2.0)");
     }
 
-    if (m_settings.pan < -1.0 || m_settings.pan > 1.0) {
+    if (!std::isfinite(m_settings.pan)
+        || m_settings.pan < -1.0 || m_settings.pan > 1.0) {
         addError("pan out of range (must be -1.0 to 1.0)");
     }
 
-    if (m_settings.tilt < -1.0 || m_settings.tilt > 1.0) {
+    if (!std::isfinite(m_settings.tilt)
+        || m_settings.tilt < -1.0 || m_settings.tilt > 1.0) {
         addError("tilt out of range (must be -1.0 to 1.0)");
     }
 
-    if (m_settings.aiMode < 0 || m_settings.aiMode > 6) {
-        addError("ai_mode out of range (must be 0-6)");
+    if (m_settings.aiMode < 0 || m_settings.aiMode > 5) {
+        addError("ai_mode out of range (must be 0-5)");
     }
 
-    if (m_settings.aiSubMode < 0 || m_settings.aiSubMode > 5) {
-        addError("ai_sub_mode out of range (must be 0-5)");
+    if (m_settings.aiSubMode < 0 || m_settings.aiSubMode > 4) {
+        addError("ai_sub_mode out of range (must be 0-4)");
     }
 
     if (m_settings.trackSpeed < 0 || m_settings.trackSpeed > 5) {
         addError("track_speed out of range (must be 0-5)");
+    }
+
+    if (m_settings.focus < -1 || m_settings.focus > 100) {
+        addError("focus out of range (must be -1 or 0-100)");
+    }
+
+    if (!isValidTrackingModeProfile(m_settings.activeTrackingProfile)) {
+        addError("tiny2 active tracking profile is invalid");
+    }
+    if (!m_settings.faceTracking
+        && (m_settings.activeTrackingProfile.focusPolicy
+                != TrackingFocusPolicy::Manual
+            || m_settings.activeTrackingProfile.autoZoom)) {
+        addError("tracking-off intent must use manual focus with auto zoom disabled");
+    }
+    for (std::size_t i = 0; i < m_settings.trackingModeProfiles.size(); ++i) {
+        if (!isValidTrackingModeProfile(m_settings.trackingModeProfiles[i])) {
+            addError("tiny2_" + std::string(tiny2TrackingModeName(i))
+                     + " tracking profile is invalid");
+        }
+    }
+
+    if (m_settings.paperCropMode < 0 || m_settings.paperCropMode > 2) {
+        addError("paper_crop_mode out of range (must be 0-2)");
+    }
+    if (!validCropMargin(m_settings.paperCropLeft)) {
+        addError("paper_crop_left out of range (must be 0.0-0.45)");
+    }
+    if (!validCropMargin(m_settings.paperCropTop)) {
+        addError("paper_crop_top out of range (must be 0.0-0.45)");
+    }
+    if (!validCropMargin(m_settings.paperCropRight)) {
+        addError("paper_crop_right out of range (must be 0.0-0.45)");
+    }
+    if (!validCropMargin(m_settings.paperCropBottom)) {
+        addError("paper_crop_bottom out of range (must be 0.0-0.45)");
     }
 
     if (m_settings.whiteBalance == 255) {
@@ -798,9 +1165,6 @@ bool Config::validateSettings(std::vector<ValidationError> &errors)
 
     for (size_t i = 0; i < m_settings.presets.size(); ++i) {
         const auto &preset = m_settings.presets[i];
-        if (!preset.defined) {
-            continue;
-        }
         if (!std::isfinite(preset.pan) || preset.pan < -1.0 || preset.pan > 1.0) {
             addError("preset" + std::to_string(i + 1) + "_pan out of range (must be -1.0 to 1.0)");
         }
@@ -809,6 +1173,44 @@ bool Config::validateSettings(std::vector<ValidationError> &errors)
         }
         if (!std::isfinite(preset.zoom) || preset.zoom < 1.0 || preset.zoom > 2.0) {
             addError("preset" + std::to_string(i + 1) + "_zoom out of range (must be 1.0 to 2.0)");
+        }
+        const std::string presetName =
+            "preset" + std::to_string(i + 1) + "_";
+        if (preset.aiMode < 0 || preset.aiMode > 5) {
+            addError(presetName + "ai_mode out of range (must be 0-5)");
+        }
+        if (preset.aiSubMode < 0 || preset.aiSubMode > 4) {
+            addError(presetName + "ai_sub_mode out of range (must be 0-4)");
+        }
+        const TrackingModeProfile presetProfile{
+            preset.focusPolicy,
+            preset.manualFocusPosition,
+            preset.autoZoom,
+            preset.trackSpeed
+        };
+        if (!isValidTrackingModeProfile(presetProfile)) {
+            addError(presetName + "tracking profile is invalid");
+        }
+        if (preset.sceneDefined && !preset.trackingEnabled
+            && (preset.focusPolicy != TrackingFocusPolicy::Manual
+                || preset.autoZoom)) {
+            addError(presetName
+                     + "tracking-off scene must use manual focus with auto zoom disabled");
+        }
+        if (preset.paperCropMode < 0 || preset.paperCropMode > 2) {
+            addError(presetName + "paper_crop_mode out of range (must be 0-2)");
+        }
+        if (!validCropMargin(preset.paperCropLeft)) {
+            addError(presetName + "paper_crop_left out of range (must be 0.0-0.45)");
+        }
+        if (!validCropMargin(preset.paperCropTop)) {
+            addError(presetName + "paper_crop_top out of range (must be 0.0-0.45)");
+        }
+        if (!validCropMargin(preset.paperCropRight)) {
+            addError(presetName + "paper_crop_right out of range (must be 0.0-0.45)");
+        }
+        if (!validCropMargin(preset.paperCropBottom)) {
+            addError(presetName + "paper_crop_bottom out of range (must be 0.0-0.45)");
         }
     }
 
@@ -848,24 +1250,30 @@ bool Config::save()
         return false;
     }
 
+    std::vector<ValidationError> validationErrors;
+    if (!validateSettings(validationErrors)) {
+        for (const auto &error : validationErrors) {
+            std::cerr << "[Config] refusing to save invalid settings: "
+                      << error.message << std::endl;
+        }
+        return false;
+    }
+
     std::string configPath = getConfigPath();
     std::string configDir = configPath.substr(0, configPath.find_last_of('/'));
 
-    // Create config directory if it doesn't exist
-    struct stat st;
-    if (stat(configDir.c_str(), &st) != 0) {
-        // Directory doesn't exist, create it
-        if (mkdir(configDir.c_str(), 0755) != 0) {
-            std::cerr << "Failed to create config directory: " << configDir << std::endl;
-            return false;
-        }
-    }
-
-    std::ofstream file(configPath);
-    if (!file.is_open()) {
-        std::cerr << "Failed to open config file for writing: " << configPath << std::endl;
+    std::error_code directoryError;
+    std::filesystem::create_directories(configDir, directoryError);
+    if (directoryError) {
+        std::cerr << "Failed to create config directory: " << configDir
+                  << " (" << directoryError.message() << ")" << std::endl;
         return false;
     }
+
+    // Serialize completely before touching the live path. The final helper
+    // writes and fsyncs a same-directory temporary file, then atomically
+    // renames it over the previous configuration.
+    std::ostringstream file;
 
     file << "# OBSBOT Control Configuration\n";
     file << "# Auto-generated settings file\n";
@@ -899,6 +1307,16 @@ bool Config::save()
 
     file << "# Tilt position (-1.0 to 1.0, 0 is center)\n";
     file << "tilt=" << m_settings.tilt << "\n\n";
+    file << "# Camera-bound intent categories (rollback-compatible metadata)\n";
+    file << "#@camera_pan_tilt_intent_defined="
+         << (m_settings.panTiltIntentDefined ? "enabled" : "disabled")
+         << "\n";
+    file << "#@camera_zoom_intent_defined="
+         << (m_settings.zoomIntentDefined ? "enabled" : "disabled")
+         << "\n";
+    file << "#@camera_image_intent_defined="
+         << (m_settings.imageIntentDefined ? "enabled" : "disabled")
+         << "\n\n";
 
     file << "# AI Tracking Mode (0=None,1=Group,2=Human,3=Hand,4=Whiteboard,5=Desk)\n";
     file << "ai_mode=" << m_settings.aiMode << "\n\n";
@@ -911,6 +1329,28 @@ bool Config::save()
 
     file << "# Tracking Speed (0=Lazy,1=Slow,2=Standard,3=Fast,4=Crazy,5=Auto)\n";
     file << "track_speed=" << m_settings.trackSpeed << "\n\n";
+
+    // Backward-compatible Tiny 2 profile metadata. The #@ prefix is parsed by
+    // this version and ignored as a comment by older packages.
+    const auto writeTrackingProfile = [&](const std::string &prefix,
+                                          const TrackingModeProfile &profile) {
+        file << "#@" << prefix << "focus_policy="
+             << trackingFocusPolicyToken(profile.focusPolicy) << "\n";
+        file << "#@" << prefix << "manual_focus="
+             << profile.manualFocusPosition << "\n";
+        file << "#@" << prefix << "auto_zoom="
+             << (profile.autoZoom ? "enabled" : "disabled") << "\n";
+        file << "#@" << prefix << "track_speed="
+             << profile.trackSpeed << "\n";
+    };
+    file << "# Tiny 2 mode-specific tracking profiles\n";
+    writeTrackingProfile("tiny2_active_", m_settings.activeTrackingProfile);
+    for (std::size_t i = 0; i < m_settings.trackingModeProfiles.size(); ++i) {
+        writeTrackingProfile(
+            "tiny2_" + std::string(tiny2TrackingModeName(i)) + "_",
+            m_settings.trackingModeProfiles[i]);
+    }
+    file << "\n";
 
     // Image controls
     file << "# Brightness Auto Mode (when enabled, brightness slider is read-only)\n";
@@ -961,6 +1401,12 @@ bool Config::save()
         file << "preset" << (i + 1) << "_ai_mode=" << preset.aiMode << "\n";
         file << "preset" << (i + 1) << "_ai_sub_mode=" << preset.aiSubMode << "\n";
         file << "preset" << (i + 1) << "_auto_zoom=" << (preset.autoZoom ? "enabled" : "disabled") << "\n";
+        file << "#@preset" << (i + 1) << "_focus_policy="
+             << trackingFocusPolicyToken(preset.focusPolicy) << "\n";
+        file << "#@preset" << (i + 1) << "_manual_focus="
+             << preset.manualFocusPosition << "\n";
+        file << "#@preset" << (i + 1) << "_track_speed="
+             << preset.trackSpeed << "\n";
         file << "preset" << (i + 1) << "_paper_crop_mode=" << preset.paperCropMode << "\n";
         file << "preset" << (i + 1) << "_paper_crop_left=" << preset.paperCropLeft << "\n";
         file << "preset" << (i + 1) << "_paper_crop_top=" << preset.paperCropTop << "\n";
@@ -993,7 +1439,15 @@ bool Config::save()
     file << "\n# Snapshot save directory (empty = ~/Pictures/obsbot-control/)\n";
     file << "snapshot_directory=" << m_settings.snapshotDirectory << "\n";
 
-    file.close();
+    if (!file.good()) {
+        std::cerr << "Failed to serialize config for " << configPath
+                  << std::endl;
+        return false;
+    }
+    const std::string serialized = file.str();
+    if (!writeConfigAtomically(configPath, configDir, serialized)) {
+        return false;
+    }
     std::cout << "[Config] Configuration saved successfully to " << configPath << std::endl;
     return true;
 }

--- a/src/common/Config.cpp
+++ b/src/common/Config.cpp
@@ -52,12 +52,27 @@ void Config::setDefaults()
 
     // Video / preview
     m_settings.previewFormat = "auto";
+    m_settings.paperCropMode = 0;
+    m_settings.paperCropLeft = 0.0;
+    m_settings.paperCropTop = 0.0;
+    m_settings.paperCropRight = 0.0;
+    m_settings.paperCropBottom = 0.0;
 
     for (auto &preset : m_settings.presets) {
         preset.defined = false;
         preset.pan = 0.0;
         preset.tilt = 0.0;
         preset.zoom = 1.0;
+        preset.sceneDefined = false;
+        preset.trackingEnabled = false;
+        preset.aiMode = 0;
+        preset.aiSubMode = 0;
+        preset.autoZoom = false;
+        preset.paperCropMode = 0;
+        preset.paperCropLeft = 0.0;
+        preset.paperCropTop = 0.0;
+        preset.paperCropRight = 0.0;
+        preset.paperCropBottom = 0.0;
     }
 
     // Application settings
@@ -186,6 +201,11 @@ bool Config::load(std::vector<ValidationError> &errors)
         "track_speed",
         "audio_auto_gain",
         "preview_format",
+        "paper_crop_mode",
+        "paper_crop_left",
+        "paper_crop_top",
+        "paper_crop_right",
+        "paper_crop_bottom",
         "virtual_camera_enabled",
         "virtual_camera_device",
         "virtual_camera_resolution",
@@ -213,7 +233,17 @@ bool Config::load(std::vector<ValidationError> &errors)
             "defined",
             "pan",
             "tilt",
-            "zoom"
+            "zoom",
+            "scene_defined",
+            "tracking_enabled",
+            "ai_mode",
+            "ai_sub_mode",
+            "auto_zoom",
+            "paper_crop_mode",
+            "paper_crop_left",
+            "paper_crop_top",
+            "paper_crop_right",
+            "paper_crop_bottom"
         };
         return presetSuffixes.count(suffix) > 0;
     };
@@ -275,6 +305,28 @@ bool Config::parseLine(const std::string &line, int lineNumber, std::vector<Vali
         }
     };
 
+    auto parseInteger = [](const std::string &val, int &out) -> bool {
+        try {
+            size_t consumed = 0;
+            out = std::stoi(val, &consumed);
+            return consumed == val.size();
+        } catch (...) {
+            return false;
+        }
+    };
+
+    auto parseCropMode = [&](const std::string &val, int &out) -> bool {
+        if (val == "off") out = 0;
+        else if (val == "manual") out = 1;
+        else if (val == "automatic" || val == "auto") out = 2;
+        else if (!parseInteger(val, out)) return false;
+        return out >= 0 && out <= 2;
+    };
+
+    auto parseCropMargin = [&](const std::string &val, double &out) -> bool {
+        return parseFiniteDouble(val, out) && out >= 0.0 && out <= 0.45;
+    };
+
     for (int i = 0; i < 3; ++i) {
         std::string base = "preset" + std::to_string(i + 1) + "_";
         if (key.rfind(base, 0) == 0) {
@@ -322,6 +374,66 @@ bool Config::parseLine(const std::string &line, int lineNumber, std::vector<Vali
                     return false;
                 }
                 preset.zoom = zoom;
+                return true;
+            } else if (suffix == "scene_defined") {
+                if (!parseBool(value, preset.sceneDefined)) {
+                    addError(InvalidValue, base + "scene_defined must be true/false or enabled/disabled");
+                    return false;
+                }
+                return true;
+            } else if (suffix == "tracking_enabled") {
+                if (!parseBool(value, preset.trackingEnabled)) {
+                    addError(InvalidValue, base + "tracking_enabled must be true/false or enabled/disabled");
+                    return false;
+                }
+                return true;
+            } else if (suffix == "ai_mode") {
+                if (!parseInteger(value, preset.aiMode) || preset.aiMode < 0 || preset.aiMode > 5) {
+                    addError(InvalidValue, base + "ai_mode must be between 0 and 5");
+                    return false;
+                }
+                return true;
+            } else if (suffix == "ai_sub_mode") {
+                if (!parseInteger(value, preset.aiSubMode) || preset.aiSubMode < 0 || preset.aiSubMode > 5) {
+                    addError(InvalidValue, base + "ai_sub_mode must be between 0 and 5");
+                    return false;
+                }
+                return true;
+            } else if (suffix == "auto_zoom") {
+                if (!parseBool(value, preset.autoZoom)) {
+                    addError(InvalidValue, base + "auto_zoom must be true/false or enabled/disabled");
+                    return false;
+                }
+                return true;
+            } else if (suffix == "paper_crop_mode") {
+                if (!parseCropMode(value, preset.paperCropMode)) {
+                    addError(InvalidValue, base + "paper_crop_mode must be off/manual/automatic or 0/1/2");
+                    return false;
+                }
+                return true;
+            } else if (suffix == "paper_crop_left") {
+                if (!parseCropMargin(value, preset.paperCropLeft)) {
+                    addError(InvalidValue, base + "paper_crop_left must be between 0.0 and 0.45");
+                    return false;
+                }
+                return true;
+            } else if (suffix == "paper_crop_top") {
+                if (!parseCropMargin(value, preset.paperCropTop)) {
+                    addError(InvalidValue, base + "paper_crop_top must be between 0.0 and 0.45");
+                    return false;
+                }
+                return true;
+            } else if (suffix == "paper_crop_right") {
+                if (!parseCropMargin(value, preset.paperCropRight)) {
+                    addError(InvalidValue, base + "paper_crop_right must be between 0.0 and 0.45");
+                    return false;
+                }
+                return true;
+            } else if (suffix == "paper_crop_bottom") {
+                if (!parseCropMargin(value, preset.paperCropBottom)) {
+                    addError(InvalidValue, base + "paper_crop_bottom must be between 0.0 and 0.45");
+                    return false;
+                }
                 return true;
             }
         }
@@ -558,6 +670,31 @@ bool Config::parseLine(const std::string &line, int lineNumber, std::vector<Vali
         }
     } else if (key == "preview_format") {
         m_settings.previewFormat = value;
+    } else if (key == "paper_crop_mode") {
+        if (!parseCropMode(value, m_settings.paperCropMode)) {
+            addError(InvalidValue, "paper_crop_mode must be off/manual/automatic or 0/1/2");
+            return false;
+        }
+    } else if (key == "paper_crop_left") {
+        if (!parseCropMargin(value, m_settings.paperCropLeft)) {
+            addError(InvalidValue, "paper_crop_left must be between 0.0 and 0.45");
+            return false;
+        }
+    } else if (key == "paper_crop_top") {
+        if (!parseCropMargin(value, m_settings.paperCropTop)) {
+            addError(InvalidValue, "paper_crop_top must be between 0.0 and 0.45");
+            return false;
+        }
+    } else if (key == "paper_crop_right") {
+        if (!parseCropMargin(value, m_settings.paperCropRight)) {
+            addError(InvalidValue, "paper_crop_right must be between 0.0 and 0.45");
+            return false;
+        }
+    } else if (key == "paper_crop_bottom") {
+        if (!parseCropMargin(value, m_settings.paperCropBottom)) {
+            addError(InvalidValue, "paper_crop_bottom must be between 0.0 and 0.45");
+            return false;
+        }
     } else if (key == "start_minimized") {
         if (!parseBool(value, m_settings.startMinimized)) {
             addError(InvalidValue, "start_minimized must be true/false or enabled/disabled");
@@ -819,6 +956,16 @@ bool Config::save()
         file << "preset" << (i + 1) << "_pan=" << preset.pan << "\n";
         file << "preset" << (i + 1) << "_tilt=" << preset.tilt << "\n";
         file << "preset" << (i + 1) << "_zoom=" << preset.zoom << "\n\n";
+        file << "preset" << (i + 1) << "_scene_defined=" << (preset.sceneDefined ? "enabled" : "disabled") << "\n";
+        file << "preset" << (i + 1) << "_tracking_enabled=" << (preset.trackingEnabled ? "enabled" : "disabled") << "\n";
+        file << "preset" << (i + 1) << "_ai_mode=" << preset.aiMode << "\n";
+        file << "preset" << (i + 1) << "_ai_sub_mode=" << preset.aiSubMode << "\n";
+        file << "preset" << (i + 1) << "_auto_zoom=" << (preset.autoZoom ? "enabled" : "disabled") << "\n";
+        file << "preset" << (i + 1) << "_paper_crop_mode=" << preset.paperCropMode << "\n";
+        file << "preset" << (i + 1) << "_paper_crop_left=" << preset.paperCropLeft << "\n";
+        file << "preset" << (i + 1) << "_paper_crop_top=" << preset.paperCropTop << "\n";
+        file << "preset" << (i + 1) << "_paper_crop_right=" << preset.paperCropRight << "\n";
+        file << "preset" << (i + 1) << "_paper_crop_bottom=" << preset.paperCropBottom << "\n\n";
     }
 
     file << "# Audio auto gain control\n";
@@ -826,6 +973,12 @@ bool Config::save()
 
     file << "# Preferred preview format (auto or WIDTHxHEIGHT@FPS)\n";
     file << "preview_format=" << (m_settings.previewFormat.empty() ? "auto" : m_settings.previewFormat) << "\n\n";
+    file << "# Paper crop (0=Off, 1=Manual rectangle, 2=Automatic detection)\n";
+    file << "paper_crop_mode=" << m_settings.paperCropMode << "\n";
+    file << "paper_crop_left=" << m_settings.paperCropLeft << "\n";
+    file << "paper_crop_top=" << m_settings.paperCropTop << "\n";
+    file << "paper_crop_right=" << m_settings.paperCropRight << "\n";
+    file << "paper_crop_bottom=" << m_settings.paperCropBottom << "\n\n";
 
     file << "# Application Settings\n";
     file << "# Start application minimized to system tray\n";

--- a/src/common/Config.h
+++ b/src/common/Config.h
@@ -36,6 +36,16 @@ public:
             double pan;
             double tilt;
             double zoom;
+            bool sceneDefined;
+            bool trackingEnabled;
+            int aiMode;
+            int aiSubMode;
+            bool autoZoom;
+            int paperCropMode;
+            double paperCropLeft;
+            double paperCropTop;
+            double paperCropRight;
+            double paperCropBottom;
         };
 
         bool faceTracking;
@@ -69,6 +79,11 @@ public:
 
         // Preview / video
         std::string previewFormat; // Encoded as "widthxheight@fps" or "auto"
+        int paperCropMode;         // 0=Off, 1=Manual, 2=Automatic
+        double paperCropLeft;      // Normalized margin, 0.0-0.45
+        double paperCropTop;
+        double paperCropRight;
+        double paperCropBottom;
 
         std::array<PresetSlot, 3> presets;
 

--- a/src/common/Config.h
+++ b/src/common/Config.h
@@ -5,6 +5,7 @@
 #include <map>
 #include <vector>
 #include <array>
+#include "TrackingModeProfile.h"
 
 /**
  * @brief Configuration manager for OBSBOT camera settings
@@ -41,6 +42,9 @@ public:
             int aiMode;
             int aiSubMode;
             bool autoZoom;
+            TrackingFocusPolicy focusPolicy;
+            int manualFocusPosition;
+            int trackSpeed;
             int paperCropMode;
             double paperCropLeft;
             double paperCropTop;
@@ -56,12 +60,22 @@ public:
         double zoom;          // 1.0 - 2.0
         double pan;           // -1.0 to 1.0
         double tilt;          // -1.0 to 1.0
+        // Camera-bound intent categories. A camera switch clears categories
+        // whose state cannot be read safely, preventing prior-camera values
+        // from being applied on reconnect.
+        bool panTiltIntentDefined;
+        bool zoomIntentDefined;
+        bool imageIntentDefined;
 
         // AI / Tracking
         int aiMode;           // Device::AiWorkModeType
         int aiSubMode;        // Device::AiSubModeType
         bool autoZoom;        // Enable adaptive auto zoom
         int trackSpeed;       // Device::AiTrackSpeedType
+        // Exact current Tiny 2 intent plus independent defaults for
+        // Group, Human, Hand, Whiteboard, and Desk.
+        TrackingModeProfile activeTrackingProfile;
+        Tiny2TrackingModeProfiles trackingModeProfiles;
 
         // Image controls
         bool brightnessAuto;  // Auto mode for brightness
@@ -155,6 +169,8 @@ private:
     void setDefaults();
     bool parseLine(const std::string &line, int lineNumber, std::vector<ValidationError> &errors);
     bool validateSettings(std::vector<ValidationError> &errors);
+    void migrateTrackingProfiles(
+        const std::map<std::string, std::string> &parsedValues);
     std::string getXdgConfigHome() const;
 };
 

--- a/src/common/TrackingModeProfile.h
+++ b/src/common/TrackingModeProfile.h
@@ -1,0 +1,176 @@
+#ifndef TRACKINGMODEPROFILE_H
+#define TRACKINGMODEPROFILE_H
+
+#include <array>
+#include <cstddef>
+#include <string_view>
+
+/**
+ * Tiny 2 focus behavior attached to an AI tracking mode.
+ *
+ * The retained manual position remains available when Face or Continuous
+ * focus is selected, so switching to Manual does not jump to an arbitrary
+ * motor position.
+ */
+enum class TrackingFocusPolicy {
+    Face,
+    Continuous,
+    Manual
+};
+
+struct TrackingModeProfile {
+    TrackingFocusPolicy focusPolicy = TrackingFocusPolicy::Continuous;
+    int manualFocusPosition = 50;
+    bool autoZoom = false;
+    int trackSpeed = 2;
+};
+
+inline bool operator==(const TrackingModeProfile &left,
+                       const TrackingModeProfile &right)
+{
+    return left.focusPolicy == right.focusPolicy
+        && left.manualFocusPosition == right.manualFocusPosition
+        && left.autoZoom == right.autoZoom
+        && left.trackSpeed == right.trackSpeed;
+}
+
+inline bool operator!=(const TrackingModeProfile &left,
+                       const TrackingModeProfile &right)
+{
+    return !(left == right);
+}
+
+using Tiny2TrackingModeProfiles = std::array<TrackingModeProfile, 5>;
+
+struct TrackingIntentState {
+    bool enabled = false;
+    int aiMode = 0;
+    int aiSubMode = 0;
+    TrackingModeProfile profile{};
+};
+
+inline bool operator==(const TrackingIntentState &left,
+                       const TrackingIntentState &right)
+{
+    return left.enabled == right.enabled
+        && left.aiMode == right.aiMode
+        && left.aiSubMode == right.aiSubMode
+        && left.profile == right.profile;
+}
+
+inline bool operator!=(const TrackingIntentState &left,
+                       const TrackingIntentState &right)
+{
+    return !(left == right);
+}
+
+inline int tiny2TrackingModeProfileIndex(int aiMode)
+{
+    // Persisted/SDK Tiny 2 mode values are Group=1 through Desk=5.
+    switch (aiMode) {
+    case 1: return 0;
+    case 2: return 1;
+    case 3: return 2;
+    case 4: return 3;
+    case 5: return 4;
+    default: return -1;
+    }
+}
+
+inline const char *tiny2TrackingModeName(std::size_t index)
+{
+    static constexpr std::array<const char *, 5> names{
+        "group", "human", "hand", "whiteboard", "desk"
+    };
+    return index < names.size() ? names[index] : "";
+}
+
+inline Tiny2TrackingModeProfiles defaultTiny2TrackingModeProfiles()
+{
+    // Group starts face-oriented. Human is migrated from legacy settings when
+    // a configuration is loaded. Hand, Whiteboard, and Desk deliberately use
+    // scene autofocus so they do not search for a face that may not exist.
+    return {{
+        {TrackingFocusPolicy::Face, 50, false, 2},
+        {TrackingFocusPolicy::Continuous, 50, false, 2},
+        {TrackingFocusPolicy::Continuous, 50, false, 2},
+        {TrackingFocusPolicy::Continuous, 50, false, 2},
+        {TrackingFocusPolicy::Continuous, 50, false, 2}
+    }};
+}
+
+inline bool isValidTrackingModeProfile(const TrackingModeProfile &profile)
+{
+    const bool focusPolicyValid =
+        profile.focusPolicy == TrackingFocusPolicy::Face
+        || profile.focusPolicy == TrackingFocusPolicy::Continuous
+        || profile.focusPolicy == TrackingFocusPolicy::Manual;
+    return focusPolicyValid
+        && profile.manualFocusPosition >= 0
+        && profile.manualFocusPosition <= 100
+        && profile.trackSpeed >= 0
+        && profile.trackSpeed <= 5;
+}
+
+inline const char *trackingFocusPolicyToken(TrackingFocusPolicy policy)
+{
+    switch (policy) {
+    case TrackingFocusPolicy::Face: return "face";
+    case TrackingFocusPolicy::Continuous: return "continuous";
+    case TrackingFocusPolicy::Manual: return "manual";
+    }
+    return "continuous";
+}
+
+inline bool parseTrackingFocusPolicy(std::string_view token,
+                                     TrackingFocusPolicy &policy)
+{
+    if (token == "face") {
+        policy = TrackingFocusPolicy::Face;
+        return true;
+    }
+    if (token == "continuous") {
+        policy = TrackingFocusPolicy::Continuous;
+        return true;
+    }
+    if (token == "manual") {
+        policy = TrackingFocusPolicy::Manual;
+        return true;
+    }
+    return false;
+}
+
+inline TrackingModeProfile legacyTrackingModeProfile(
+    bool faceFocus, int focus, bool autoZoom, int trackSpeed)
+{
+    TrackingModeProfile profile;
+    profile.focusPolicy = faceFocus
+        ? TrackingFocusPolicy::Face
+        : (focus >= 0 ? TrackingFocusPolicy::Manual
+                      : TrackingFocusPolicy::Continuous);
+    profile.manualFocusPosition = focus >= 0 ? focus : 50;
+    profile.autoZoom = autoZoom;
+    profile.trackSpeed = trackSpeed;
+    return profile;
+}
+
+inline TrackingIntentState applyAutomaticPaperCropTrackingPolicy(
+    int paperCropMode,
+    bool tiny2Capabilities,
+    TrackingIntentState current,
+    const Tiny2TrackingModeProfiles &modeProfiles)
+{
+    constexpr int kAutomaticPaperCropMode = 2;
+    constexpr int kDeskAiMode = 5;
+    if (!tiny2Capabilities || paperCropMode != kAutomaticPaperCropMode) {
+        return current;
+    }
+
+    current.enabled = true;
+    current.aiMode = kDeskAiMode;
+    current.aiSubMode = 0;
+    current.profile = modeProfiles[4];
+    return current;
+}
+
+#endif // TRACKINGMODEPROFILE_H

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -2,13 +2,97 @@
 #include <QThread>
 #include <QDebug>
 #include <algorithm>
+#include <cmath>
+#include <condition_variable>
+#include <mutex>
 
 static constexpr int kDefaultWhiteBalanceKelvin = 4800;
+static constexpr int kSdkDiscoveryGraceMs = 5000;
+static constexpr int kV4l2RescanIntervalMs = 3000;
+
+struct CameraController::DeviceCallbackGate
+    : std::enable_shared_from_this<CameraController::DeviceCallbackGate>
+{
+    struct Lease {
+        Lease() = default;
+        Lease(std::shared_ptr<DeviceCallbackGate> gate,
+              CameraController *controller)
+            : gate(std::move(gate)), controller(controller)
+        {
+        }
+        Lease(const Lease &) = delete;
+        Lease &operator=(const Lease &) = delete;
+        Lease(Lease &&other) noexcept
+            : gate(std::move(other.gate)), controller(other.controller)
+        {
+            other.controller = nullptr;
+        }
+        Lease &operator=(Lease &&) = delete;
+        ~Lease()
+        {
+            if (gate) {
+                gate->release();
+            }
+        }
+
+        CameraController *get() const { return controller; }
+
+        std::shared_ptr<DeviceCallbackGate> gate;
+        CameraController *controller = nullptr;
+    };
+
+    explicit DeviceCallbackGate(CameraController *controller)
+        : controller(controller)
+    {
+    }
+
+    Lease acquire()
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        if (stopping || !controller) {
+            return {};
+        }
+        ++activeCallbacks;
+        return Lease(shared_from_this(), controller);
+    }
+
+    void stop()
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        stopping = true;
+        controller = nullptr;
+    }
+
+    void waitForCallbacks()
+    {
+        std::unique_lock<std::mutex> lock(mutex);
+        callbacksDrained.wait(lock, [this]() { return activeCallbacks == 0; });
+    }
+
+private:
+    void release()
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        --activeCallbacks;
+        if (activeCallbacks == 0) {
+            callbacksDrained.notify_all();
+        }
+    }
+
+    std::mutex mutex;
+    std::condition_variable callbacksDrained;
+    CameraController *controller = nullptr;
+    size_t activeCallbacks = 0;
+    bool stopping = false;
+};
 
 CameraController::CameraController(QObject *parent)
     : QObject(parent)
+    , m_deviceCallbackGate(std::make_shared<DeviceCallbackGate>(this))
     , m_connected(false)
     , m_settlingTimer(nullptr)
+    , m_aiConfirmationTimer(nullptr)
+    , m_autoFramingModeTimer(nullptr)
 {
     m_currentState = {};
     m_cachedState = {};
@@ -22,106 +106,292 @@ CameraController::CameraController(QObject *parent)
     m_settlingTimer = new QTimer(this);
     m_settlingTimer->setSingleShot(true);
 
+    m_aiConfirmationTimer = new QTimer(this);
+    m_aiConfirmationTimer->setInterval(300);
+    connect(m_aiConfirmationTimer, &QTimer::timeout, this, [this]() {
+        if (!m_connected || m_v4l2Only || !m_pendingAiIntent) {
+            m_aiConfirmationTimer->stop();
+            return;
+        }
+        updateState();
+        if (!m_pendingAiIntent) {
+            m_aiConfirmationTimer->stop();
+        } else {
+            m_aiConfirmationTimer->setInterval(
+                m_pendingAiIntent->failureReported ? 1000 : 300);
+        }
+    });
+    connect(m_settlingTimer, &QTimer::timeout, this, [this]() {
+        if (!m_pendingAiIntent || !m_connected || m_v4l2Only) {
+            return;
+        }
+        updateState();
+        if (m_pendingAiIntent) {
+            m_aiConfirmationTimer->setInterval(
+                m_pendingAiIntent->failureReported ? 1000 : 300);
+            m_aiConfirmationTimer->start();
+        }
+    });
+
+    // Meet-series auto-framing has a delayed second step. Keep the timer owned
+    // so a newer manual/off intent can cancel that step deterministically.
+    m_autoFramingModeTimer = new QTimer(this);
+    m_autoFramingModeTimer->setSingleShot(true);
+    connect(m_autoFramingModeTimer, &QTimer::timeout, this, [this]() {
+        if (!m_autoFramingRequested || !m_connected || m_v4l2Only || !m_device) {
+            return;
+        }
+        const bool success = executeCommand("Set AutoFraming mode", [this]() {
+            return m_device->cameraSetAutoFramingModeU(
+                Device::AutoFrmSingle, Device::AutoFrmUpperBody);
+        });
+        m_autoFramingRequested = false;
+        if (success) {
+            emit trackingStateConfirmed(
+                true, m_autoFramingIntentGeneration);
+        } else {
+            emit trackingStateConfirmationFailed(
+                true, m_autoFramingIntentGeneration);
+        }
+    });
+
     resetControlRanges();
 }
 
 CameraController::~CameraController()
 {
+    // The SDK may invoke its callback from another thread. Stop new leases
+    // before unregistering, then drain callbacks that already acquired one so
+    // none can race this object's destruction while queuing a Qt continuation.
+    const auto callbackGate = m_deviceCallbackGate;
+    callbackGate->stop();
+    ++m_connectionGeneration;
+    if (m_deviceCallbackRegistered) {
+        Devices::get().setDevChangedCallback(Devices::devChangedCallback{}, nullptr);
+        m_deviceCallbackRegistered = false;
+    }
+    callbackGate->waitForCallbacks();
+    m_autoFramingRequested = false;
+    if (m_autoFramingModeTimer) {
+        m_autoFramingModeTimer->stop();
+    }
+    if (m_aiConfirmationTimer) {
+        m_aiConfirmationTimer->stop();
+    }
 }
 
 void CameraController::connectToCamera()
 {
-    connectToCamera(QString());
+    // Reconnect to the same physical target. The serial remains authoritative
+    // if /dev/video numbering changes across a disconnect.
+    connectToCamera(m_selectedDevicePath, m_selectedDeviceSerial);
 }
 
-void CameraController::connectToCamera(const QString &devicePath)
+void CameraController::selectCameraTarget(
+    const QString &devicePath, const QString &serialNumber)
 {
     m_selectedDevicePath = devicePath;
+    m_selectedDeviceSerial = serialNumber;
+}
 
-    auto pickDevice = [this](const std::list<std::shared_ptr<Device>> &list)
-        -> std::shared_ptr<Device>
-    {
-        if (list.empty()) return nullptr;
-        if (m_selectedDevicePath.isEmpty()) return list.front();
+void CameraController::connectToCamera(
+    const QString &devicePath, const QString &serialNumber)
+{
+    if (m_connected) {
+        qDebug() << "CameraController: ignoring connect request while already connected to"
+                 << getVideoDevicePath();
+        return;
+    }
+    if (m_v4l2ScanTimer) {
+        m_v4l2ScanTimer->stop();
+    }
 
-        for (const auto &dev : list) {
-            if (QString::fromStdString(dev->videoDevPath()) == m_selectedDevicePath)
-                return dev;
+    selectCameraTarget(devicePath, serialNumber);
+    m_pendingAiIntent.reset();
+    m_pendingTrackingProfile.reset();
+    m_autoFramingRequested = false;
+    ++m_trackingIntentGeneration;
+    m_pendingManualPosition.reset();
+    m_aiStateConfirmed = false;
+    m_manualMovementAuthorized = false;
+    m_autoFramingModeTimer->stop();
+    m_aiConfirmationTimer->stop();
+    const quint64 generation = ++m_connectionGeneration;
+
+    const auto callbackGate = m_deviceCallbackGate;
+    auto onDevChanged = [callbackGate, generation](
+                            std::string devSn, bool connected, void * /*param*/) {
+        // The SDK does not guarantee callback thread affinity. A lease keeps
+        // the QObject alive through invokeMethod(); the QObject context then
+        // owns cancellation of the queued continuation during destruction.
+        auto lease = callbackGate->acquire();
+        CameraController *controller = lease.get();
+        if (!controller) {
+            return;
         }
-        qDebug() << "CameraController: device" << m_selectedDevicePath
-                 << "not found in SDK list, using first available";
-        return list.front();
-    };
-
-    auto onDevChanged = [this, pickDevice](std::string /*dev_sn*/, bool connected, void * /*param*/) {
-        if (connected) {
-            auto dev_list = Devices::get().getDevList();
-            auto dev = pickDevice(dev_list);
-            if (dev) {
-                m_device = dev;
-                m_connected = true;
-                m_cameraInfo.name = QString::fromStdString(m_device->devName());
-                m_cameraInfo.serialNumber = QString::fromStdString(m_device->devSn());
-                m_cameraInfo.version = QString::fromStdString(m_device->devVersion());
-                m_cameraInfo.productType = m_device->productType();
-                m_cameraInfo.connected = true;
-                refreshControlRanges();
-                emit cameraConnected(m_cameraInfo);
-                updateState();
+        const QString changedSerial = QString::fromStdString(devSn);
+        QMetaObject::invokeMethod(controller, [controller, generation, changedSerial, connected]() {
+            if (controller->m_connectionGeneration != generation) {
+                return;
             }
-        } else {
-            m_connected = false;
-            m_cameraInfo.connected = false;
-            resetControlRanges();
-            emit cameraDisconnected();
-        }
+            if (!connected && !changedSerial.isEmpty()
+                && !controller->m_cameraInfo.serialNumber.isEmpty()
+                && changedSerial != controller->m_cameraInfo.serialNumber) {
+                return;
+            }
+
+            if (connected) {
+                if (!controller->m_connected) {
+                    controller->tryConnectSdkDevice();
+                }
+            } else if (controller->m_connected && !controller->m_v4l2Only) {
+                controller->m_device.reset();
+                controller->m_connected = false;
+                controller->m_cameraInfo.connected = false;
+                controller->m_pendingAiIntent.reset();
+                controller->m_pendingTrackingProfile.reset();
+                ++controller->m_trackingIntentGeneration;
+                controller->m_pendingManualPosition.reset();
+                controller->m_aiStateConfirmed = false;
+                controller->m_manualMovementAuthorized = false;
+                controller->m_autoFramingRequested = false;
+                controller->m_autoFramingModeTimer->stop();
+                controller->m_aiConfirmationTimer->stop();
+                controller->m_settlingTimer->stop();
+                controller->resetControlRanges();
+                emit controller->cameraDisconnected();
+                // Give the SDK a fresh chance to report a transient reconnect
+                // before considering the reduced-capability V4L2 backend.
+                controller->tryV4l2Fallback();
+            }
+        }, Qt::QueuedConnection);
     };
 
     Devices::get().setDevChangedCallback(onDevChanged, nullptr);
+    m_deviceCallbackRegistered = true;
     Devices::get().setEnableMdnsScan(false);
 
-    auto dev_list = Devices::get().getDevList();
-    if (!dev_list.empty() && !m_connected) {
-        auto dev = pickDevice(dev_list);
-        if (dev) {
-            m_device = dev;
-            m_connected = true;
-            m_cameraInfo.name = QString::fromStdString(m_device->devName());
-            m_cameraInfo.serialNumber = QString::fromStdString(m_device->devSn());
-            m_cameraInfo.version = QString::fromStdString(m_device->devVersion());
-            m_cameraInfo.productType = m_device->productType();
-            m_cameraInfo.connected = true;
-            refreshControlRanges();
-            emit cameraConnected(m_cameraInfo);
-            updateState();
-        }
-    } else {
+    if (!tryConnectSdkDevice()) {
         tryV4l2Fallback();
     }
 }
 
+std::shared_ptr<Device> CameraController::selectedSdkDevice() const
+{
+    const auto devices = Devices::get().getDevList();
+    if (devices.empty()) {
+        return nullptr;
+    }
+    if (!m_selectedDeviceSerial.isEmpty()) {
+        for (const auto &device : devices) {
+            if (QString::fromStdString(device->devSn())
+                == m_selectedDeviceSerial) {
+                return device;
+            }
+        }
+        return nullptr;
+    }
+    if (m_selectedDevicePath.isEmpty()) {
+        return devices.front();
+    }
+
+    for (const auto &device : devices) {
+        if (QString::fromStdString(device->videoDevPath())
+            == m_selectedDevicePath) {
+            return device;
+        }
+    }
+    // Exact selection is a safety boundary: never direct PTZ commands to an
+    // arbitrary first camera while the requested camera is still discovering.
+    return nullptr;
+}
+
+bool CameraController::connectSdkDevice(
+    const std::shared_ptr<Device> &device)
+{
+    if (m_connected) {
+        return !m_v4l2Only;
+    }
+    if (!device) {
+        return false;
+    }
+
+    if (m_v4l2ScanTimer) {
+        m_v4l2ScanTimer->stop();
+    }
+    m_device = device;
+    m_v4l2Only = false;
+    m_v4l2DevicePath.clear();
+    m_connected = true;
+    m_manualMovementAuthorized = false;
+    m_currentState.panTiltKnown = false;
+    m_currentState.zoomKnown = false;
+    m_currentState.imageSettingsKnown = false;
+    m_cameraInfo.name = QString::fromStdString(device->devName());
+    m_cameraInfo.serialNumber = QString::fromStdString(device->devSn());
+    m_selectedDevicePath = QString::fromStdString(device->videoDevPath());
+    m_selectedDeviceSerial = m_cameraInfo.serialNumber;
+    m_cameraInfo.version = QString::fromStdString(device->devVersion());
+    m_cameraInfo.productType = device->productType();
+    m_cameraInfo.connected = true;
+    refreshControlRanges();
+    qInfo() << "CameraController: connected through SDK"
+            << QString::fromStdString(device->videoDevPath())
+            << m_cameraInfo.serialNumber;
+    emit cameraConnected(m_cameraInfo);
+    updateState();
+    return true;
+}
+
+bool CameraController::tryConnectSdkDevice()
+{
+    return connectSdkDevice(selectedSdkDevice());
+}
+
 void CameraController::tryV4l2Fallback()
 {
-    auto path = V4l2Backend::findObsbotDevice();
-    if (!path.empty()) {
-        connectV4l2(path);
+    if (m_connected) {
         return;
     }
 
+    m_v4l2FallbackGeneration = m_connectionGeneration;
     if (!m_v4l2ScanTimer) {
         m_v4l2ScanTimer = new QTimer(this);
         m_v4l2ScanTimer->setSingleShot(false);
         connect(m_v4l2ScanTimer, &QTimer::timeout, this, [this]() {
-            if (m_connected)
-                return;
-            auto path = V4l2Backend::findObsbotDevice();
-            if (!path.empty()) {
+            if (m_v4l2FallbackGeneration != m_connectionGeneration
+                || m_connected) {
                 m_v4l2ScanTimer->stop();
+                return;
+            }
+
+            // A device callback can be queued at the same time as this timer.
+            // Re-read the SDK list before probing fallback so an available
+            // exact SDK target wins this arbitration point.
+            if (tryConnectSdkDevice()) {
+                return;
+            }
+
+            // A serial-bound target must never fall back by pathname: Linux
+            // may reuse /dev/videoN for another physical camera after hotplug.
+            std::string path;
+            if (m_selectedDeviceSerial.isEmpty()) {
+                path = m_selectedDevicePath.isEmpty()
+                    ? V4l2Backend::findObsbotDevice()
+                    : m_selectedDevicePath.toStdString();
+            }
+            if (!path.empty()) {
                 connectV4l2(path);
+            }
+            if (!m_connected) {
+                m_v4l2ScanTimer->setInterval(kV4l2RescanIntervalMs);
             }
         });
     }
-    m_v4l2ScanTimer->start(3000);
+    // Do not synchronously claim /dev/video* while the SDK discovery callback
+    // is queued on the Qt event loop. V4L2 remains a bounded fallback only.
+    m_v4l2ScanTimer->setInterval(kSdkDiscoveryGraceMs);
+    m_v4l2ScanTimer->start();
 }
 
 void CameraController::connectV4l2(const std::string &devicePath)
@@ -129,10 +399,28 @@ void CameraController::connectV4l2(const std::string &devicePath)
     if (!m_v4l2.open(devicePath))
         return;
 
+    // Close the final probe and prefer an SDK device that appeared while the
+    // V4L2 path was being opened. Keeping the shared Device candidate removes
+    // a second list lookup from this last arbitration point.
+    if (const auto sdkDevice = selectedSdkDevice()) {
+        m_v4l2.close();
+        connectSdkDevice(sdkDevice);
+        return;
+    }
+
+    if (m_v4l2ScanTimer) {
+        m_v4l2ScanTimer->stop();
+    }
+    if (m_deviceCallbackRegistered) {
+        Devices::get().setDevChangedCallback(Devices::devChangedCallback{}, nullptr);
+        m_deviceCallbackRegistered = false;
+    }
+    ++m_connectionGeneration;
     Devices::get().close();
 
     m_connected = true;
     m_v4l2Only = true;
+    m_manualMovementAuthorized = false;
     m_v4l2DevicePath = QString::fromStdString(devicePath);
 
     std::string card = m_v4l2.cardName();
@@ -148,10 +436,11 @@ void CameraController::connectV4l2(const std::string &devicePath)
     m_cameraInfo.connected = true;
 
     refreshV4l2ControlRanges();
+    qWarning() << "CameraController: SDK discovery grace expired; using fail-closed V4L2 fallback"
+               << m_v4l2DevicePath;
 
-    m_v4l2.setWhiteBalanceAuto(false);
-    m_v4l2.setWhiteBalanceTemperature(kDefaultWhiteBalanceKelvin);
-
+    // Do not write discovery-time defaults. onCameraConnected() applies the
+    // explicit Config intent; until then this backend remains observational.
     emit cameraConnected(m_cameraInfo);
     updateV4l2State();
 }
@@ -186,11 +475,13 @@ void CameraController::updateV4l2State()
         ? static_cast<int>(Device::DevWhiteBalanceAuto)
         : static_cast<int>(Device::DevWhiteBalanceManual);
     m_currentState.whiteBalanceKelvin = m_v4l2.getWhiteBalanceTemperature();
+    m_currentState.imageSettingsKnown = true;
 
     auto zoomRange = m_v4l2.getZoomRange();
     int zoomMax = zoomRange.valid ? zoomRange.max : 100;
     int zoomRaw = m_v4l2.getZoomAbsolute();
     m_currentState.zoom = (zoomMax > 0) ? (static_cast<double>(zoomRaw) / zoomMax + 1.0) : 1.0;
+    m_currentState.zoomKnown = zoomRange.valid && zoomMax > 0;
 
     auto panRange = m_v4l2.getPanRange();
     auto tiltRange = m_v4l2.getTiltRange();
@@ -198,6 +489,9 @@ void CameraController::updateV4l2State()
         m_currentState.pan = static_cast<double>(m_v4l2.getPanAbsolute()) / panRange.max;
     if (tiltRange.valid && tiltRange.max != 0)
         m_currentState.tilt = static_cast<double>(m_v4l2.getTiltAbsolute()) / tiltRange.max;
+    m_currentState.panTiltKnown =
+        panRange.valid && panRange.max != 0
+        && tiltRange.valid && tiltRange.max != 0;
 
     m_currentState.autoFocusEnabled = m_v4l2.getAutoFocus();
     m_currentState.manualFocusValue = m_v4l2.getFocusAbsolute();
@@ -207,13 +501,32 @@ void CameraController::updateV4l2State()
 
 void CameraController::disconnectFromCamera()
 {
+    ++m_connectionGeneration;
+    if (m_deviceCallbackRegistered) {
+        Devices::get().setDevChangedCallback(Devices::devChangedCallback{}, nullptr);
+        m_deviceCallbackRegistered = false;
+    }
+    m_pendingAiIntent.reset();
+    m_autoFramingRequested = false;
+    m_pendingTrackingProfile.reset();
+    ++m_trackingIntentGeneration;
+    m_pendingManualPosition.reset();
+    m_aiStateConfirmed = false;
+    m_manualMovementAuthorized = false;
+    m_autoFramingModeTimer->stop();
+    m_aiConfirmationTimer->stop();
+    m_settlingTimer->stop();
+    if (m_v4l2ScanTimer) {
+        m_v4l2ScanTimer->stop();
+    }
+
     if (m_connected) {
         if (m_v4l2Only) {
             m_v4l2.close();
             m_v4l2Only = false;
-        } else {
-            m_device.reset();
+            m_v4l2DevicePath.clear();
         }
+        m_device.reset();
         m_connected = false;
         m_cameraInfo.connected = false;
         resetControlRanges();
@@ -262,13 +575,15 @@ bool CameraController::hasTiny2Capabilities() const
 
 bool CameraController::enterAutoFramingMediaMode()
 {
-    if (!m_connected || m_v4l2Only) return false;
+    // cameraSetMediaModeU is a Meet-series API. Tiny tracking families use
+    // their dedicated AI protocols.
+    if (!m_connected || m_v4l2Only || !isMeetFamily()) return false;
 
     const bool success = executeCommand("Set MediaMode to AutoFrame", [this]() {
         return m_device->cameraSetMediaModeU(Device::MediaModeAutoFrame);
     });
     if (success) {
-        setFocusAbsolute(0, true);
+        setFocusAbsoluteUnchecked(0, true);
         m_currentState.autoFramingEnabled = true;
         emit stateChanged(m_currentState);
     }
@@ -277,54 +592,224 @@ bool CameraController::enterAutoFramingMediaMode()
 
 bool CameraController::enableAutoFraming(bool enabled)
 {
-    if (!m_connected || m_v4l2Only) return false;
+    if (!m_connected || m_v4l2Only || !isMeetFamily()) return false;
+
+    // Any ownership transition revokes raw movement immediately. Only the
+    // complete tracking-off transaction may grant it again.
+    m_manualMovementAuthorized = false;
+    m_autoFramingRequested = enabled;
+    m_autoFramingModeTimer->stop();
 
     if (enabled) {
-        // Step 1: Set MediaMode to AutoFrame
+        // Meet-series enable is a cancellable two-step transition.
         if (!enterAutoFramingMediaMode()) {
+            m_autoFramingRequested = false;
             return false;
         }
-
-        // Step 2: Set auto-framing mode after a brief delay (non-blocking)
-        QTimer::singleShot(500, [this]() {
-            executeCommand("Set AutoFraming mode", [this]() {
-                return m_device->cameraSetAutoFramingModeU(Device::AutoFrmSingle, Device::AutoFrmUpperBody);
-            });
-        });
-
-        return true;  // First command succeeded, second is pending
-    } else {
-        bool success = executeCommand("Disable AutoFraming", [this]() {
-            return m_device->cameraSetMediaModeU(Device::MediaModeNormal);
-        });
-        if (success) {
-            // Switch to manual focus when auto-framing is disabled
-            setFocusAbsolute(m_currentState.manualFocusValue, false);
-
-            m_currentState.autoFramingEnabled = false;
-            emit stateChanged(m_currentState);
-        }
-        return success;
+        m_autoFramingModeTimer->start(500);
+        return true;
     }
+
+    const bool success = executeCommand("Disable AutoFraming", [this]() {
+        return m_device->cameraSetMediaModeU(Device::MediaModeNormal);
+    });
+    if (success) {
+        // Preserve the legacy immediate focus restoration. setTrackingState()
+        // follows with the caller's exact retained snapshot before authorizing
+        // movement.
+        setFocusAbsoluteUnchecked(m_currentState.manualFocusValue, false);
+        m_currentState.autoFramingEnabled = false;
+        emit stateChanged(m_currentState);
+    }
+    return success;
 }
 
 bool CameraController::setAiMode(int mode, int subMode)
 {
     if (!m_connected || m_v4l2Only) return false;
 
-    auto workMode = static_cast<Device::AiWorkModeType>(mode);
-    bool success = executeCommand("Set AI Mode", [this, workMode, subMode]() {
+    const auto previousIntent = m_pendingAiIntent;
+    const int previousMode = m_currentState.aiMode;
+    const int previousSubMode = m_currentState.aiSubMode;
+    const bool previousTracking = m_currentState.autoFramingEnabled;
+    const bool previousAiStateConfirmed = m_aiStateConfirmed;
+    const bool confirmationWasActive = m_aiConfirmationTimer->isActive();
+    m_aiConfirmationTimer->stop();
+
+    const bool previousModeTracks = previousMode > Device::AiWorkModeNone
+        && previousMode <= Device::AiWorkModeDesk;
+    const bool requestedModeTracks = mode > Device::AiWorkModeNone
+        && mode <= Device::AiWorkModeDesk;
+    const int failSafeMode = previousModeTracks
+        ? previousMode
+        : (requestedModeTracks ? mode : Device::AiWorkModeHuman);
+    const int failSafeSubMode = failSafeMode == Device::AiWorkModeHuman
+        ? (previousMode == Device::AiWorkModeHuman ? previousSubMode
+           : (mode == Device::AiWorkModeHuman ? subMode : Device::AiSubModeNormal))
+        : 0;
+
+    m_pendingAiIntent = PendingAiIntent{
+        mode, subMode, failSafeMode, failSafeSubMode,
+        m_trackingIntentGeneration};
+    m_aiStateConfirmed = false;
+    m_manualMovementAuthorized = false;
+    const auto workMode = static_cast<Device::AiWorkModeType>(mode);
+    const bool success = executeCommand("Set AI Mode", [this, workMode, subMode]() {
         return m_device->cameraSetAiModeU(workMode, subMode);
     });
 
-    if (success) {
-        m_currentState.aiMode = mode;
-        m_currentState.aiSubMode = subMode;
-        m_currentState.autoFramingEnabled = (mode != Device::AiWorkModeNone);
-        emit stateChanged(m_currentState);
+    if (!success) {
+        m_pendingAiIntent = previousIntent;
+        if (m_pendingAiIntent) {
+            // A superseding controller intent already invalidated the older
+            // token. Resume confirmation under the current generation so an
+            // older completion cannot become authoritative again.
+            m_pendingAiIntent->intentGeneration = m_trackingIntentGeneration;
+        }
+        m_currentState.aiMode = previousMode;
+        m_currentState.aiSubMode = previousSubMode;
+        m_currentState.autoFramingEnabled = previousTracking;
+        m_aiStateConfirmed = previousAiStateConfirmed;
+        if (previousIntent && confirmationWasActive) {
+            m_aiConfirmationTimer->start();
+        }
+        return false;
     }
 
-    return success;
+    // Publish the requested state immediately, but keep the pending intent
+    // until the SDK's lagging cameraStatus() cache confirms it.
+    m_currentState.aiMode = mode;
+    m_currentState.aiSubMode = subMode;
+    m_currentState.autoFramingEnabled = (mode != Device::AiWorkModeNone);
+    emit stateChanged(m_currentState);
+    beginSettling(3000);
+    return true;
+}
+
+CameraController::TrackingTransitionResult CameraController::setTrackingState(
+    bool enabled, int aiMode, int aiSubMode,
+    const TrackingModeProfile &profile)
+{
+    if (!m_connected || m_v4l2Only) {
+        return {false, false, false, m_trackingIntentGeneration};
+    }
+    if (!isValidTrackingModeProfile(profile)
+        || (!enabled
+            && (profile.focusPolicy != TrackingFocusPolicy::Manual
+                || profile.autoZoom))) {
+        emit commandFailed("Invalid tracking profile", -1);
+        return {false, false, false, m_trackingIntentGeneration};
+    }
+
+    const quint64 intentGeneration = ++m_trackingIntentGeneration;
+    m_pendingManualPosition.reset();
+    m_pendingTrackingProfile.reset();
+    m_manualMovementAuthorized = false;
+    emit trackingIntentStarted(intentGeneration);
+    const auto reportSynchronousFailure = [this, intentGeneration]() {
+        const bool observedTracking = isTiny2Family()
+            ? m_currentState.aiMode != Device::AiWorkModeNone
+            : m_currentState.autoFramingEnabled;
+        emit trackingStateConfirmationFailed(
+            observedTracking, intentGeneration);
+    };
+
+    if (isOriginalTinyFamily()) {
+        m_pendingAiIntent.reset();
+        const bool modeApplied = executeCommand(
+            enabled ? "Enable AI Tracking" : "Disable AI Tracking",
+            [this, enabled]() { return m_device->aiSetTargetSelectR(enabled); });
+        const bool profileApplied = modeApplied
+            && (enabled || applyTrackingProfile(profile, false));
+        if (modeApplied) {
+            m_currentState.autoFramingEnabled = enabled;
+            m_currentState.aiMode = enabled
+                ? Device::AiWorkModeHuman : Device::AiWorkModeNone;
+            emit stateChanged(m_currentState);
+        }
+        if (profileApplied) {
+            m_manualMovementAuthorized = !enabled;
+            emit trackingStateConfirmed(enabled, intentGeneration);
+        } else {
+            reportSynchronousFailure();
+        }
+        return {
+            modeApplied, profileApplied, false, intentGeneration
+        };
+    }
+
+    if (isMeetFamily()) {
+        m_pendingAiIntent.reset();
+        m_autoFramingIntentGeneration = intentGeneration;
+        const bool modeApplied = enableAutoFraming(enabled);
+        const bool profileApplied = modeApplied
+            && (enabled || applyTrackingProfile(profile, false));
+        const bool confirmationPending = enabled && modeApplied;
+        if (confirmationPending) {
+            emit trackingStateConfirmationPending(
+                enabled, intentGeneration);
+        } else if (profileApplied) {
+            m_manualMovementAuthorized = true;
+            emit trackingStateConfirmed(false, intentGeneration);
+        } else {
+            reportSynchronousFailure();
+        }
+        return {
+            modeApplied, profileApplied, confirmationPending,
+            intentGeneration
+        };
+    }
+
+    if (!isTiny2Family()) {
+        emit commandFailed("Tracking is unsupported for this camera", -1);
+        reportSynchronousFailure();
+        return {false, false, false, intentGeneration};
+    }
+
+    if (m_pendingAiIntent) {
+        m_pendingAiIntent->intentGeneration = intentGeneration;
+    }
+    m_pendingTrackingProfile = PendingTrackingProfile{
+        profile, intentGeneration};
+
+    int targetMode = enabled ? aiMode : Device::AiWorkModeNone;
+    if (enabled && targetMode == Device::AiWorkModeNone) {
+        targetMode = Device::AiWorkModeHuman;
+    }
+    const int targetSubMode = targetMode == Device::AiWorkModeHuman ? aiSubMode : 0;
+
+    // Auto zoom is the pre-mode part of the same profile transaction. Speed
+    // and focus wait for a fresh exact mode confirmation below.
+    const bool previousAutoZoom = m_currentState.autoZoomEnabled;
+    const bool targetAutoZoom = enabled && profile.autoZoom;
+    const bool autoZoomApplied = setAutoZoom(targetAutoZoom);
+    if (!autoZoomApplied) {
+        m_pendingTrackingProfile.reset();
+        const bool confirmationPending = m_pendingAiIntent.has_value();
+        if (!confirmationPending) {
+            reportSynchronousFailure();
+        }
+        return {false, false, confirmationPending, intentGeneration};
+    }
+
+    const bool modeApplied = setAiMode(targetMode, targetSubMode);
+    if (!modeApplied) {
+        m_pendingTrackingProfile.reset();
+        const bool rollbackApplied = setAutoZoom(previousAutoZoom);
+        const bool confirmationPending = m_pendingAiIntent.has_value();
+        if (!rollbackApplied) {
+            emit trackingStateConfirmationUncertain(intentGeneration);
+        }
+        if (!confirmationPending) {
+            reportSynchronousFailure();
+        }
+        return {
+            false, rollbackApplied, confirmationPending, intentGeneration
+        };
+    }
+
+    emit trackingStateConfirmationPending(enabled, intentGeneration);
+    return {true, true, true, intentGeneration};
 }
 
 bool CameraController::setAutoZoom(bool enabled)
@@ -360,6 +845,44 @@ bool CameraController::setTrackSpeed(int speedMode)
     return success;
 }
 
+bool CameraController::applyTrackingProfile(
+    const TrackingModeProfile &profile, bool trackingEnabled)
+{
+    if (!isValidTrackingModeProfile(profile)) {
+        emit commandFailed("Invalid tracking profile", -1);
+        return false;
+    }
+
+    bool speedApplied = true;
+    if (trackingEnabled) {
+        speedApplied = setTrackSpeed(profile.trackSpeed);
+    }
+
+    bool firstFocusCommand = false;
+    bool secondFocusCommand = false;
+    switch (profile.focusPolicy) {
+    case TrackingFocusPolicy::Face:
+        // General autofocus supplies the focus motor behavior; face focus then
+        // selects the face as the preferred target.
+        firstFocusCommand = setFocusAbsoluteUnchecked(
+            profile.manualFocusPosition, true);
+        secondFocusCommand = setFaceFocus(true);
+        break;
+    case TrackingFocusPolicy::Continuous:
+        firstFocusCommand = setFaceFocus(false);
+        secondFocusCommand = setFocusAbsoluteUnchecked(
+            profile.manualFocusPosition, true);
+        break;
+    case TrackingFocusPolicy::Manual:
+        firstFocusCommand = setFaceFocus(false);
+        secondFocusCommand = setFocusAbsoluteUnchecked(
+            profile.manualFocusPosition, false);
+        break;
+    }
+
+    return speedApplied && firstFocusCommand && secondFocusCommand;
+}
+
 bool CameraController::setAudioAutoGain(bool enabled)
 {
     if (!m_connected || m_v4l2Only) return false;
@@ -376,29 +899,30 @@ bool CameraController::setAudioAutoGain(bool enabled)
     return success;
 }
 
+bool CameraController::canApplyManualMovement() const
+{
+    return m_connected && !m_v4l2Only && m_device
+        && m_manualMovementAuthorized;
+}
+
 bool CameraController::setPanTilt(double pan, double tilt)
 {
-    if (!m_connected) return false;
+    // V4L2 cannot confirm that autonomous tracking released gimbal ownership.
+    // Enforce the fail-closed invariant at the transport boundary as well as
+    // in the widget so no future caller can bypass it.
+    if (!canApplyManualMovement()) return false;
 
     pan = qBound(-1.0, pan, 1.0);
     tilt = qBound(-1.0, tilt, 1.0);
 
-    bool success;
-    if (m_v4l2Only) {
-        auto panRange = m_v4l2.getPanRange();
-        auto tiltRange = m_v4l2.getTiltRange();
-        int panVal = static_cast<int>(pan * panRange.max);
-        int tiltVal = static_cast<int>(tilt * tiltRange.max);
-        success = m_v4l2.setPanAbsolute(panVal) && m_v4l2.setTiltAbsolute(tiltVal);
-    } else {
-        success = executeCommand("Set Pan/Tilt", [this, pan, tilt]() {
-            return m_device->cameraSetPanTiltAbsolute(pan, tilt);
-        });
-    }
+    const bool success = executeCommand("Set Pan/Tilt", [this, pan, tilt]() {
+        return m_device->cameraSetPanTiltAbsolute(pan, tilt);
+    });
 
     if (success) {
         m_currentState.pan = pan;
         m_currentState.tilt = tilt;
+        m_currentState.panTiltKnown = true;
         emit stateChanged(m_currentState);
     }
 
@@ -419,25 +943,21 @@ bool CameraController::adjustTilt(double delta)
 
 bool CameraController::setZoom(double zoom)
 {
-    if (!m_connected) return false;
+    if (!canApplyManualMovement()) return false;
 
     zoom = qBound(1.0, zoom, 2.0);
 
-    bool success;
-    if (m_v4l2Only) {
-        auto zoomRange = m_v4l2.getZoomRange();
-        int zoomMax = zoomRange.valid ? zoomRange.max : 100;
-        int v4l2Zoom = static_cast<int>((zoom - 1.0) * zoomMax);
-        success = m_v4l2.setZoomAbsolute(v4l2Zoom);
-    } else {
-        uint32_t zoomRatio = static_cast<uint32_t>(zoom * 100);
-        success = executeCommand("Set Zoom", [this, zoomRatio]() {
-            return m_device->cameraSetZoomWithSpeedAbsoluteR(zoomRatio, 255);
-        });
-    }
+    const float normalizedZoom = static_cast<float>(zoom);
+    const bool success = executeCommand("Set Zoom", [this, normalizedZoom]() {
+        // This SDK API accepts the same normalized 1.0-2.0 contract as Config
+        // and the UI. The speed API is device-specific and was observed to
+        // acknowledge Tiny 2 commands without changing zoom.
+        return m_device->cameraSetZoomAbsoluteR(normalizedZoom);
+    });
 
     if (success) {
         m_currentState.zoom = zoom;
+        m_currentState.zoomKnown = true;
         emit stateChanged(m_currentState);
     }
 
@@ -488,25 +1008,31 @@ bool CameraController::setFaceFocus(bool enabled)
 {
     if (!m_connected || m_v4l2Only) return false;
 
-    return executeCommand(enabled ? "Enable Face Focus" : "Disable Face Focus", [this, enabled]() {
-        return m_device->cameraSetFaceFocusR(enabled);
-    });
+    const bool success = executeCommand(
+        enabled ? "Enable Face Focus" : "Disable Face Focus",
+        [this, enabled]() { return m_device->cameraSetFaceFocusR(enabled); });
+    if (success) {
+        m_currentState.faceFocusEnabled = enabled;
+        emit stateChanged(m_currentState);
+    }
+    return success;
 }
 
 bool CameraController::setFocusAbsolute(int position, bool autoFocus)
 {
-    if (!m_connected) return false;
+    if (!canApplyManualMovement()) return false;
+    return setFocusAbsoluteUnchecked(position, autoFocus);
+}
+
+bool CameraController::setFocusAbsoluteUnchecked(
+    int position, bool autoFocus)
+{
+    if (!m_connected || m_v4l2Only || !m_device) return false;
     position = qBound(0, position, 100);
 
-    bool success;
-    if (m_v4l2Only) {
-        m_v4l2.setAutoFocus(autoFocus);
-        success = autoFocus || m_v4l2.setFocusAbsolute(position);
-    } else {
-        success = executeCommand("Set Focus", [this, position, autoFocus]() {
-            return m_device->cameraSetFocusAbsolute(position, autoFocus);
-        });
-    }
+    const bool success = executeCommand("Set Focus", [this, position, autoFocus]() {
+        return m_device->cameraSetFocusAbsolute(position, autoFocus);
+    });
     if (success) {
         m_currentState.autoFocusEnabled = autoFocus;
         m_currentState.manualFocusValue = position;
@@ -709,16 +1235,162 @@ void CameraController::updateState()
     }
 
     auto status = m_device->cameraStatus();
+    bool freshStatusRead = false;
+    if (isTiny2Family()) {
+        Device::CameraStatus freshStatus{};
+        if (m_device->cameraGetCameraStatusU(freshStatus) == 0) {
+            status = freshStatus;
+            freshStatusRead = true;
+        }
+    }
 
-    m_currentState.aiMode = status.tiny.ai_mode;
-    m_currentState.aiSubMode = status.tiny.ai_sub_mode;
+    const int reportedAiMode = status.tiny.ai_mode;
+    const int reportedAiSubMode = status.tiny.ai_sub_mode;
+    const bool reportedModeIsStable = reportedAiMode >= Device::AiWorkModeNone
+        && reportedAiMode <= Device::AiWorkModeDesk;
+    if (m_pendingAiIntent) {
+        const bool modeMatches = reportedAiMode == m_pendingAiIntent->mode;
+        const bool subModeMatches = m_pendingAiIntent->mode != Device::AiWorkModeHuman
+            || reportedAiSubMode == m_pendingAiIntent->subMode;
+        if (freshStatusRead && modeMatches && subModeMatches) {
+            const quint64 intentGeneration =
+                m_pendingAiIntent->intentGeneration;
+            const bool trackingEnabled =
+                reportedAiMode != Device::AiWorkModeNone;
+            const bool hasMatchingProfile = m_pendingTrackingProfile
+                && m_pendingTrackingProfile->intentGeneration
+                    == intentGeneration;
+            const TrackingModeProfile profile = hasMatchingProfile
+                ? m_pendingTrackingProfile->profile
+                : TrackingModeProfile{};
+
+            m_currentState.aiMode = reportedAiMode;
+            m_currentState.aiSubMode = reportedAiSubMode;
+            m_pendingAiIntent.reset();
+            m_pendingTrackingProfile.reset();
+            m_aiStateConfirmed = true;
+
+            // Focus and speed are allowed only after this fresh exact mode
+            // confirmation. The terminal tracking signal now means the whole
+            // profile transaction—not merely the AI mode—has completed.
+            const bool profileApplied = hasMatchingProfile
+                && applyTrackingProfile(profile, trackingEnabled);
+            if (profileApplied) {
+                // The off confirmation is not terminal until face focus is
+                // disabled and the retained manual snapshot has succeeded.
+                m_manualMovementAuthorized = !trackingEnabled;
+                emit trackingStateConfirmed(
+                    trackingEnabled, intentGeneration);
+                if (!trackingEnabled) {
+                    schedulePendingManualPosition();
+                }
+            } else {
+                m_manualMovementAuthorized = false;
+                m_pendingManualPosition.reset();
+                emit trackingStateConfirmationFailed(
+                    trackingEnabled, intentGeneration);
+                if (!hasMatchingProfile) {
+                    emit commandFailed("Apply Tracking Profile", -1);
+                }
+            }
+        } else {
+            PendingAiIntent &intent = *m_pendingAiIntent;
+            ++intent.confirmationAttempts;
+            if (freshStatusRead && reportedModeIsStable
+                && (intent.confirmationAttempts >= 3 || intent.failureReported)) {
+                const bool failureAlreadyReported = intent.failureReported;
+                const quint64 intentGeneration = intent.intentGeneration;
+                m_currentState.aiMode = reportedAiMode;
+                m_currentState.aiSubMode = reportedAiSubMode;
+                m_pendingAiIntent.reset();
+                m_aiStateConfirmed = true;
+                m_manualMovementAuthorized = false;
+                m_pendingManualPosition.reset();
+                m_pendingTrackingProfile.reset();
+                emit trackingStateConfirmationFailed(
+                    reportedAiMode != Device::AiWorkModeNone,
+                    intentGeneration);
+                if (!failureAlreadyReported) {
+                    emit commandFailed("Confirm AI Mode", -1);
+                }
+            } else if (intent.confirmationAttempts >= 3) {
+                // A failed fresh read or a transitional/sentinel mode is not
+                // evidence that AI released the gimbal. Keep retrying fresh
+                // reads, but fail closed until a stable mode is observed.
+                m_currentState.aiMode = intent.failSafeMode;
+                m_currentState.aiSubMode = intent.failSafeSubMode;
+                m_aiStateConfirmed = false;
+                m_manualMovementAuthorized = false;
+                if (!intent.failureReported) {
+                    intent.failureReported = true;
+                    emit trackingStateConfirmationUncertain(
+                        intent.intentGeneration);
+                    emit commandFailed("Confirm AI Mode", -1);
+                }
+            }
+        }
+        // Until a successful fresh read confirms or rejects the intent, retain
+        // explicit operator intent (or the conservative tracking-on fallback).
+    } else if (!isTiny2Family() || freshStatusRead) {
+        if (reportedModeIsStable) {
+            m_currentState.aiMode = reportedAiMode;
+            m_currentState.aiSubMode = reportedAiSubMode;
+            if (isTiny2Family()) {
+                // A fresh unsolicited observation may update displayed state,
+                // but it is not completion evidence for an already-resolved
+                // controller intent and therefore carries no generation token.
+                const bool trackingEnabled =
+                    reportedAiMode != Device::AiWorkModeNone;
+                m_aiStateConfirmed = true;
+                bool ownershipReady = trackingEnabled;
+                if (trackingEnabled) {
+                    m_manualMovementAuthorized = false;
+                } else if (m_manualMovementAuthorized) {
+                    ownershipReady = true;
+                } else {
+                    TrackingModeProfile manualProfile =
+                        m_config.getSettings().activeTrackingProfile;
+                    manualProfile.focusPolicy = TrackingFocusPolicy::Manual;
+                    manualProfile.autoZoom = false;
+                    ownershipReady = applyTrackingProfile(
+                        manualProfile, false);
+                    m_manualMovementAuthorized = ownershipReady;
+                }
+                if (ownershipReady) {
+                    emit trackingOwnershipObserved(trackingEnabled);
+                }
+            }
+        } else {
+            qDebug() << "CameraController: ignoring transitional AI mode"
+                     << reportedAiMode;
+        }
+    }
+    // A failed Tiny 2 fresh-status read never falls back to the SDK's lagging
+    // cameraStatus() cache for AI ownership.
     m_currentState.zoomRatio = status.tiny.zoom_ratio;
     // Derive zoom float from zoom_ratio (100 = 1.0x, 200 = 2.0x)
     if (status.tiny.zoom_ratio >= 100 && status.tiny.zoom_ratio <= 200) {
         m_currentState.zoom = status.tiny.zoom_ratio / 100.0;
+        m_currentState.zoomKnown = !isTiny2Family() || freshStatusRead;
     } else {
+        m_currentState.zoomKnown = false;
         qDebug() << "CameraController: unexpected zoom_ratio" << status.tiny.zoom_ratio
                  << "— keeping previous zoom" << m_currentState.zoom;
+    }
+
+    if (isTiny2Family()) {
+        Device::AiGimbalStateInfo gimbal{};
+        if (m_device->aiGetGimbalStateR(&gimbal) == 0
+            && std::isfinite(gimbal.yaw_motor)
+            && std::isfinite(gimbal.pitch_motor)) {
+            m_currentState.pan = qBound(
+                -1.0, static_cast<double>(gimbal.yaw_motor) / 180.0, 1.0);
+            m_currentState.tilt = qBound(
+                -1.0, static_cast<double>(gimbal.pitch_motor) / 90.0, 1.0);
+            m_currentState.panTiltKnown = true;
+        } else {
+            m_currentState.panTiltKnown = false;
+        }
     }
     m_currentState.hdrEnabled = status.tiny.hdr;
     m_currentState.faceAEEnabled = status.tiny.face_ae;
@@ -741,16 +1413,24 @@ void CameraController::updateState()
     Device::DevWhiteBalanceType wbType;
     int32_t wbParam;
 
-    if (m_device->cameraGetImageBrightnessR(brightness) == 0) {
+    const bool brightnessRead =
+        m_device->cameraGetImageBrightnessR(brightness) == 0;
+    const bool contrastRead =
+        m_device->cameraGetImageContrastR(contrast) == 0;
+    const bool saturationRead =
+        m_device->cameraGetImageSaturationR(saturation) == 0;
+    const bool whiteBalanceRead =
+        m_device->cameraGetWhiteBalanceR(wbType, wbParam) == 0;
+    if (brightnessRead) {
         m_currentState.brightness = clampToRange(brightness, m_brightnessRange, 0, 255);
     }
-    if (m_device->cameraGetImageContrastR(contrast) == 0) {
+    if (contrastRead) {
         m_currentState.contrast = clampToRange(contrast, m_contrastRange, 0, 255);
     }
-    if (m_device->cameraGetImageSaturationR(saturation) == 0) {
+    if (saturationRead) {
         m_currentState.saturation = clampToRange(saturation, m_saturationRange, 0, 255);
     }
-    if (m_device->cameraGetWhiteBalanceR(wbType, wbParam) == 0) {
+    if (whiteBalanceRead) {
         m_currentState.whiteBalance = static_cast<int>(wbType);
         if (wbType == Device::DevWhiteBalanceManual) {
             m_currentState.whiteBalanceKelvin = clampToRange(wbParam, m_whiteBalanceKelvinRange, 2000, 10000);
@@ -760,6 +1440,10 @@ void CameraController::updateState()
     }
 
     // Restore auto mode flags (not stored in camera)
+    m_currentState.imageSettingsKnown =
+        brightnessRead && contrastRead && saturationRead && whiteBalanceRead
+        && (!isTiny2Family() || freshStatusRead);
+
     m_currentState.brightnessAuto = preservedBrightnessAuto;
     m_currentState.contrastAuto = preservedContrastAuto;
     m_currentState.saturationAuto = preservedSaturationAuto;
@@ -771,6 +1455,41 @@ void CameraController::updateState()
     }
 
     emit stateChanged(m_currentState);
+}
+
+void CameraController::schedulePendingManualPosition()
+{
+    if (!m_pendingManualPosition || !m_connected || m_v4l2Only
+        || !m_aiStateConfirmed
+        || m_currentState.aiMode != Device::AiWorkModeNone) {
+        return;
+    }
+
+    const PendingManualPosition pending = *m_pendingManualPosition;
+    QTimer::singleShot(0, this, [this, pending]() {
+        if (!m_pendingManualPosition || !m_connected || m_v4l2Only
+            || pending.trackingIntentGeneration != m_trackingIntentGeneration
+            || pending.connectionGeneration != m_connectionGeneration
+            || !m_aiStateConfirmed
+            || m_currentState.aiMode != Device::AiWorkModeNone) {
+            return;
+        }
+        m_pendingManualPosition.reset();
+        if (pending.applyZoom && !setZoom(pending.zoom)) {
+            return;
+        }
+        if (pending.applyPanTilt
+            && !setPanTilt(pending.pan, pending.tilt)) {
+            return;
+        }
+        if (pending.focus) {
+            if (*pending.focus >= 0) {
+                setFocusAbsolute(*pending.focus, false);
+            } else {
+                setFocusAbsolute(0, true);
+            }
+        }
+    });
 }
 
 void CameraController::beginSettling(int durationMs)
@@ -787,8 +1506,8 @@ bool CameraController::loadConfig(std::vector<Config::ValidationError> &errors)
 
 bool CameraController::saveConfig()
 {
-    // Update config with current camera state before saving
-    saveCurrentStateToConfig();
+    // Config is the explicit persisted-intent model. Live SDK telemetry is
+    // deliberately never promoted here.
     return m_config.save();
 }
 
@@ -798,40 +1517,69 @@ void CameraController::applyConfigToCamera()
 
     auto settings = m_config.getSettings();
 
-    // Initialize auto mode flags from config
-    m_currentState.brightnessAuto = settings.brightnessAuto;
-    m_currentState.contrastAuto = settings.contrastAuto;
-    m_currentState.saturationAuto = settings.saturationAuto;
-
-    // Apply all settings to the camera
-    enableAutoFraming(settings.faceTracking);
-    setHDR(settings.hdr);
-    setFOV(settings.fov);
-    setFaceAE(settings.faceAE);
-    setFaceFocus(settings.faceFocus);
-    setZoom(settings.zoom);
-    setPanTilt(settings.pan, settings.tilt);
-    if (settings.focus >= 0) {
-        setFocusAbsolute(settings.focus, false);
-    } else {
-        setFocusAbsolute(0, true);
+    if (settings.imageIntentDefined) {
+        m_currentState.brightnessAuto = settings.brightnessAuto;
+        m_currentState.contrastAuto = settings.contrastAuto;
+        m_currentState.saturationAuto = settings.saturationAuto;
     }
 
-    if (isTiny2Family()) {
-        setAiMode(settings.aiMode, settings.aiSubMode);
-        setAutoZoom(settings.autoZoom);
-        setTrackSpeed(settings.trackSpeed);
+    // Apply all settings to the camera
+    const auto trackingResult = setTrackingState(
+        settings.faceTracking, settings.aiMode,
+        settings.aiSubMode, settings.activeTrackingProfile);
+    if (settings.imageIntentDefined) {
+        setHDR(settings.hdr);
+        setFOV(settings.fov);
+        setFaceAE(settings.faceAE);
+        if (!isTiny2Family()) {
+            setFaceFocus(settings.faceFocus);
+        }
+    }
+    if (!settings.faceTracking && trackingResult.trackingModeApplied) {
+        if (trackingResult.confirmationPending) {
+            m_pendingManualPosition = PendingManualPosition{
+                settings.pan,
+                settings.tilt,
+                settings.zoom,
+                settings.panTiltIntentDefined,
+                settings.zoomIntentDefined,
+                std::nullopt,
+                m_trackingIntentGeneration,
+                m_connectionGeneration
+            };
+        } else {
+            bool positionApplied = true;
+            if (settings.zoomIntentDefined) {
+                positionApplied = setZoom(settings.zoom);
+            }
+            if (positionApplied && settings.panTiltIntentDefined) {
+                positionApplied = setPanTilt(settings.pan, settings.tilt);
+            }
+            if (positionApplied) {
+                if (settings.focus >= 0) {
+                    setFocusAbsolute(settings.focus, false);
+                } else {
+                    setFocusAbsolute(0, true);
+                }
+            }
+        }
+    }
+
+    if (isTiny2Family() && settings.imageIntentDefined) {
+        // Tiny 2 speed and focus are applied only after exact AI-mode
+        // confirmation as part of activeTrackingProfile.
         setAudioAutoGain(settings.audioAutoGain);
     }
 
-    // Image controls
-    setBrightness(settings.brightness);
-    setContrast(settings.contrast);
-    setSaturation(settings.saturation);
-    if (settings.whiteBalance == static_cast<int>(Device::DevWhiteBalanceManual)) {
-        setWhiteBalanceManual(settings.whiteBalanceKelvin);
-    } else {
-        setWhiteBalance(settings.whiteBalance);
+    if (settings.imageIntentDefined) {
+        setBrightness(settings.brightness);
+        setContrast(settings.contrast);
+        setSaturation(settings.saturation);
+        if (settings.whiteBalance == static_cast<int>(Device::DevWhiteBalanceManual)) {
+            setWhiteBalanceManual(settings.whiteBalanceKelvin);
+        } else {
+            setWhiteBalance(settings.whiteBalance);
+        }
     }
 
     emit configLoaded();
@@ -852,20 +1600,46 @@ void CameraController::applyCurrentStateToCamera(const CameraState &uiState)
     // Begin settling period - block status updates for 2 seconds
     beginSettling(2000);
 
-    // Apply the current UI state to camera (respects user changes)
-    enableAutoFraming(uiState.autoFramingEnabled);
+    // Apply the current UI state to camera (respects user changes). A remembered
+    // nonzero AI mode must never override an explicit manual/off state.
+    TrackingModeProfile profile = legacyTrackingModeProfile(
+        uiState.faceFocusEnabled,
+        uiState.autoFocusEnabled ? -1 : uiState.manualFocusValue,
+        uiState.autoZoomEnabled,
+        uiState.trackSpeedMode);
+    if (!uiState.autoFramingEnabled) {
+        profile.focusPolicy = TrackingFocusPolicy::Manual;
+        profile.manualFocusPosition = uiState.manualFocusValue;
+        profile.autoZoom = false;
+    }
+    const auto trackingResult = setTrackingState(
+        uiState.autoFramingEnabled, uiState.aiMode,
+        uiState.aiSubMode, profile);
     if (isTiny2Family()) {
-        setAiMode(uiState.aiMode, uiState.aiSubMode);
-        setAutoZoom(uiState.autoZoomEnabled);
-        setTrackSpeed(uiState.trackSpeedMode);
         setAudioAutoGain(uiState.audioAutoGainEnabled);
     }
     setHDR(uiState.hdrEnabled);
     setFOV(uiState.fovMode);
     setFaceAE(uiState.faceAEEnabled);
-    setFaceFocus(uiState.faceFocusEnabled);
-    setZoom(uiState.zoom);
-    setPanTilt(uiState.pan, uiState.tilt);
+    if (!isTiny2Family()) {
+        setFaceFocus(uiState.faceFocusEnabled);
+    }
+    if (!uiState.autoFramingEnabled && trackingResult.trackingModeApplied) {
+        if (trackingResult.confirmationPending) {
+            m_pendingManualPosition = PendingManualPosition{
+                uiState.pan,
+                uiState.tilt,
+                uiState.zoom,
+                true,
+                true,
+                std::nullopt,
+                m_trackingIntentGeneration,
+                m_connectionGeneration
+            };
+        } else if (setZoom(uiState.zoom)) {
+            setPanTilt(uiState.pan, uiState.tilt);
+        }
+    }
 
     // Image controls
     setBrightness(uiState.brightness);
@@ -878,45 +1652,25 @@ void CameraController::applyCurrentStateToCamera(const CameraState &uiState)
     }
 }
 
-void CameraController::saveCurrentStateToConfig()
-{
-    // Get current settings to preserve app settings (like startMinimized)
-    Config::CameraSettings settings = m_config.getSettings();
-
-    // Update only camera-related settings from current state
-    settings.faceTracking = m_currentState.autoFramingEnabled;
-    settings.hdr = m_currentState.hdrEnabled;
-    settings.fov = m_currentState.fovMode;
-    settings.faceAE = m_currentState.faceAEEnabled;
-    settings.faceFocus = m_currentState.faceFocusEnabled;
-    settings.zoom = qBound(1.0, m_currentState.zoom, 2.0);
-    settings.pan = m_currentState.pan;
-    settings.tilt = m_currentState.tilt;
-    settings.aiMode = m_currentState.aiMode;
-    settings.aiSubMode = m_currentState.aiSubMode;
-    settings.autoZoom = m_currentState.autoZoomEnabled;
-    settings.trackSpeed = m_currentState.trackSpeedMode;
-    settings.audioAutoGain = m_currentState.audioAutoGainEnabled;
-
-    // Image controls
-    settings.brightnessAuto = m_currentState.brightnessAuto;
-    settings.brightness = m_currentState.brightness;
-    settings.contrastAuto = m_currentState.contrastAuto;
-    settings.contrast = m_currentState.contrast;
-    settings.saturationAuto = m_currentState.saturationAuto;
-    settings.saturation = m_currentState.saturation;
-    settings.whiteBalance = m_currentState.whiteBalance;
-    settings.whiteBalanceKelvin = m_currentState.whiteBalanceKelvin;
-    settings.focus = m_currentState.autoFocusEnabled ? -1 : m_currentState.manualFocusValue;
-
-    m_config.setSettings(settings);
-}
-
 bool CameraController::isTiny2Family() const
 {
     return m_cameraInfo.productType == ObsbotProdTiny2 ||
            m_cameraInfo.productType == ObsbotProdTiny2Lite ||
            m_cameraInfo.productType == ObsbotProdTinySE;
+}
+
+bool CameraController::isOriginalTinyFamily() const
+{
+    return m_cameraInfo.productType == ObsbotProdTiny
+        || m_cameraInfo.productType == ObsbotProdTiny4k;
+}
+
+bool CameraController::isMeetFamily() const
+{
+    return m_cameraInfo.productType == ObsbotProdMeet
+        || m_cameraInfo.productType == ObsbotProdMeet4k
+        || m_cameraInfo.productType == ObsbotProdMeet2
+        || m_cameraInfo.productType == ObsbotProdMeetSE;
 }
 
 void CameraController::refreshControlRanges()

--- a/src/gui/CameraController.cpp
+++ b/src/gui/CameraController.cpp
@@ -260,15 +260,28 @@ bool CameraController::hasTiny2Capabilities() const
     return isTiny2Family();
 }
 
+bool CameraController::enterAutoFramingMediaMode()
+{
+    if (!m_connected || m_v4l2Only) return false;
+
+    const bool success = executeCommand("Set MediaMode to AutoFrame", [this]() {
+        return m_device->cameraSetMediaModeU(Device::MediaModeAutoFrame);
+    });
+    if (success) {
+        setFocusAbsolute(0, true);
+        m_currentState.autoFramingEnabled = true;
+        emit stateChanged(m_currentState);
+    }
+    return success;
+}
+
 bool CameraController::enableAutoFraming(bool enabled)
 {
     if (!m_connected || m_v4l2Only) return false;
 
     if (enabled) {
         // Step 1: Set MediaMode to AutoFrame
-        if (!executeCommand("Set MediaMode to AutoFrame", [this]() {
-            return m_device->cameraSetMediaModeU(Device::MediaModeAutoFrame);
-        })) {
+        if (!enterAutoFramingMediaMode()) {
             return false;
         }
 
@@ -279,11 +292,6 @@ bool CameraController::enableAutoFraming(bool enabled)
             });
         });
 
-        // Restore auto focus when auto-framing is enabled
-        setFocusAbsolute(0, true);
-
-        m_currentState.autoFramingEnabled = true;
-        emit stateChanged(m_currentState);
         return true;  // First command succeeded, second is pending
     } else {
         bool success = executeCommand("Disable AutoFraming", [this]() {

--- a/src/gui/CameraController.h
+++ b/src/gui/CameraController.h
@@ -6,10 +6,13 @@
 #include <QMap>
 #include <memory>
 #include <functional>
+#include <optional>
 #include <vector>
 #include <dev/devs.hpp>
 #include "Config.h"
 #include "V4l2Backend.h"
+
+struct CameraControllerTestAccess;
 
 /**
  * @brief Handles all camera communication and state management
@@ -43,6 +46,9 @@ public:
         double pan;
         double tilt;
         double zoom;
+        bool panTiltKnown;
+        bool zoomKnown;
+        bool imageSettingsKnown;
 
         // Image settings
         bool hdrEnabled;
@@ -82,10 +88,16 @@ public:
     bool isConnected() const { return m_connected; }
     bool isV4l2Only() const { return m_v4l2Only; }
     CameraInfo getCameraInfo() const { return m_cameraInfo; }
+    void selectCameraTarget(
+        const QString &devicePath, const QString &serialNumber = QString());
     void connectToCamera();
-    void connectToCamera(const QString &devicePath);
+    void connectToCamera(
+        const QString &devicePath,
+        const QString &serialNumber = QString());
     void disconnectFromCamera();
     QString getVideoDevicePath() const;
+    QString selectedDevicePath() const { return m_selectedDevicePath; }
+    QString selectedDeviceSerial() const { return m_selectedDeviceSerial; }
     QMap<QString, QString> getSerialsByDevicePath() const;
 
     // State
@@ -93,9 +105,20 @@ public:
     bool hasTiny2Capabilities() const;
 
     // Tracking controls
+    struct TrackingTransitionResult {
+        bool trackingModeApplied = false;
+        bool autoZoomApplied = true;
+        bool confirmationPending = false;
+        quint64 intentGeneration = 0;
+        bool complete() const { return trackingModeApplied && autoZoomApplied; }
+    };
+
     bool enableAutoFraming(bool enabled);
     bool enterAutoFramingMediaMode();
     bool setAiMode(int mode, int subMode);
+    TrackingTransitionResult setTrackingState(
+        bool enabled, int aiMode, int aiSubMode,
+        const TrackingModeProfile &profile);
     bool setAutoZoom(bool enabled);
     bool setTrackSpeed(int speedMode);
     bool setAudioAutoGain(bool enabled);
@@ -147,21 +170,72 @@ signals:
     void cameraDisconnected();
     void stateChanged(const CameraState &state);
     void commandFailed(const QString &description, int errorCode);
+    void trackingIntentStarted(quint64 intentGeneration);
+    void trackingStateConfirmationPending(
+        bool trackingEnabled, quint64 intentGeneration);
+    void trackingStateConfirmationFailed(
+        bool trackingEnabled, quint64 intentGeneration);
+    void trackingStateConfirmationUncertain(quint64 intentGeneration);
+    void trackingStateConfirmed(
+        bool trackingEnabled, quint64 intentGeneration);
+    void trackingOwnershipObserved(bool trackingEnabled);
     void configLoaded();  // Emitted after config is successfully loaded
 
 private:
+    struct DeviceCallbackGate;
+    friend struct CameraControllerTestAccess;
+    std::shared_ptr<DeviceCallbackGate> m_deviceCallbackGate;
     std::shared_ptr<Device> m_device;
     bool m_connected;
+    bool m_deviceCallbackRegistered = false;
+    quint64 m_connectionGeneration = 0;
     QString m_selectedDevicePath;
+    QString m_selectedDeviceSerial;
     bool m_v4l2Only = false;
     V4l2Backend m_v4l2;
     QTimer *m_v4l2ScanTimer = nullptr;
+    quint64 m_v4l2FallbackGeneration = 0;
     QString m_v4l2DevicePath;
     CameraInfo m_cameraInfo;
     CameraState m_currentState;
     CameraState m_cachedState;  // Cache intended state during settling
     Config m_config;
     QTimer *m_settlingTimer;  // Timer for settling period after config apply
+    QTimer *m_aiConfirmationTimer;  // Fresh Tiny 2 status retries after settling
+    QTimer *m_autoFramingModeTimer;  // Owned Meet-series delayed enable step
+    bool m_autoFramingRequested = false;
+    quint64 m_autoFramingIntentGeneration = 0;
+    struct PendingAiIntent {
+        int mode;
+        int subMode;
+        int failSafeMode;
+        int failSafeSubMode;
+        quint64 intentGeneration;
+        int confirmationAttempts = 0;
+        bool failureReported = false;
+    };
+    std::optional<PendingAiIntent> m_pendingAiIntent;
+    struct PendingTrackingProfile {
+        TrackingModeProfile profile;
+        quint64 intentGeneration;
+    };
+    std::optional<PendingTrackingProfile> m_pendingTrackingProfile;
+    bool m_aiStateConfirmed = false;
+    // Granted only after this exact SDK connection has positively confirmed
+    // tracking off and restored the retained manual-focus state.
+    bool m_manualMovementAuthorized = false;
+    quint64 m_trackingIntentGeneration = 0;
+    struct PendingManualPosition {
+        double pan;
+        double tilt;
+        double zoom;
+        bool applyPanTilt;
+        bool applyZoom;
+        std::optional<int> focus;
+        quint64 trackingIntentGeneration;
+        quint64 connectionGeneration;
+    };
+    std::optional<PendingManualPosition> m_pendingManualPosition;
     ParamRange m_brightnessRange;
     ParamRange m_contrastRange;
     ParamRange m_saturationRange;
@@ -171,6 +245,11 @@ private:
     bool m_whiteBalanceFallbackActive;
     int m_fallbackWhiteBalanceMode;
     bool isTiny2Family() const;
+    bool isOriginalTinyFamily() const;
+    bool isMeetFamily() const;
+    std::shared_ptr<Device> selectedSdkDevice() const;
+    bool connectSdkDevice(const std::shared_ptr<Device> &device);
+    bool tryConnectSdkDevice();
     void tryV4l2Fallback();
     void connectV4l2(const std::string &devicePath);
     void refreshV4l2ControlRanges();
@@ -179,7 +258,11 @@ private:
     // Helper
     bool executeCommand(const QString &description, std::function<int32_t()> command);
     void updateState();
-    void saveCurrentStateToConfig();  // Update config with current camera state
+    bool applyTrackingProfile(
+        const TrackingModeProfile &profile, bool trackingEnabled);
+    bool canApplyManualMovement() const;
+    bool setFocusAbsoluteUnchecked(int position, bool autoFocus);
+    void schedulePendingManualPosition();
     void refreshControlRanges();
     void resetControlRanges();
     int clampToRange(int value, const ParamRange &range, int fallbackMin, int fallbackMax) const;

--- a/src/gui/CameraController.h
+++ b/src/gui/CameraController.h
@@ -94,6 +94,7 @@ public:
 
     // Tracking controls
     bool enableAutoFraming(bool enabled);
+    bool enterAutoFramingMediaMode();
     bool setAiMode(int mode, int subMode);
     bool setAutoZoom(bool enabled);
     bool setTrackSpeed(int speedMode);

--- a/src/gui/CameraPreviewWidget.cpp
+++ b/src/gui/CameraPreviewWidget.cpp
@@ -125,6 +125,8 @@ void CameraPreviewWidget::setupUI()
                     m_virtualCameraStreamer->onProcessedFrameReady(image);
                 }
             });
+    connect(m_filterPreviewWidget, &FilterPreviewWidget::paperDetectionChanged,
+            this, &CameraPreviewWidget::paperDetectionChanged);
 }
 
 bool CameraPreviewWidget::isPreviewEnabled() const
@@ -201,6 +203,13 @@ void CameraPreviewWidget::setVideoEffects(const FilterPreviewWidget::VideoEffect
     m_filterPreviewWidget->setVideoEffects(settings);
 }
 
+void CameraPreviewWidget::resetPaperDetection()
+{
+    if (m_filterPreviewWidget) {
+        m_filterPreviewWidget->resetPaperDetection();
+    }
+}
+
 FilterPreviewWidget::VideoEffectsSettings CameraPreviewWidget::videoEffects() const
 {
     if (!m_filterPreviewWidget) {
@@ -256,6 +265,9 @@ void CameraPreviewWidget::startPreview()
 void CameraPreviewWidget::stopPreview()
 {
     disconnect(m_snapshotConnection);
+    if (m_filterPreviewWidget) {
+        m_filterPreviewWidget->resetPaperDetection();
+    }
 
     if (m_videoSink) {
         disconnect(m_videoSink, nullptr, this, nullptr);

--- a/src/gui/CameraPreviewWidget.h
+++ b/src/gui/CameraPreviewWidget.h
@@ -40,6 +40,7 @@ public:
     void setControlsVisible(bool visible);
     void setVirtualCameraStreamer(VirtualCameraStreamer *streamer);
     void setVideoEffects(const FilterPreviewWidget::VideoEffectsSettings &settings);
+    void resetPaperDetection();
     FilterPreviewWidget::VideoEffectsSettings videoEffects() const;
     void captureSnapshot();
 
@@ -50,6 +51,7 @@ signals:
     void previewFailed(const QString &error);  // Emitted when preview fails to start
     void preferredFormatChanged(const QString &formatId);
     void snapshotCaptured(const QImage &image);
+    void paperDetectionChanged(bool detected);
 
 private slots:
     void onCameraError(QCamera::Error error);

--- a/src/gui/CameraSettingsWidget.cpp
+++ b/src/gui/CameraSettingsWidget.cpp
@@ -145,6 +145,7 @@ CameraSettingsWidget::CameraSettingsWidget(CameraController *controller, QWidget
 
 void CameraSettingsWidget::onHDRToggled(bool checked)
 {
+    emit hdrIntentEdited(checked);
     m_userInitiated = true;
     m_controller->setHDR(checked);
     m_commandTimer->start(1000);
@@ -152,6 +153,7 @@ void CameraSettingsWidget::onHDRToggled(bool checked)
 
 void CameraSettingsWidget::onFOVChanged(int index)
 {
+    emit fovIntentEdited(index);
     m_userInitiated = true;
     m_controller->setFOV(index);
     m_commandTimer->start(1000);
@@ -159,6 +161,7 @@ void CameraSettingsWidget::onFOVChanged(int index)
 
 void CameraSettingsWidget::onFaceAEToggled(bool checked)
 {
+    emit faceAEIntentEdited(checked);
     m_userInitiated = true;
     m_controller->setFaceAE(checked);
     m_commandTimer->start(1000);
@@ -166,6 +169,7 @@ void CameraSettingsWidget::onFaceAEToggled(bool checked)
 
 void CameraSettingsWidget::onFaceFocusToggled(bool checked)
 {
+    emit faceFocusIntentEdited(checked);
     m_userInitiated = true;
     m_controller->setFaceFocus(checked);
     m_commandTimer->start(1000);
@@ -189,11 +193,13 @@ void CameraSettingsWidget::onBrightnessAutoToggled(bool checked)
     }
     // Set auto flag AFTER sending the value
     m_controller->setBrightnessAuto(checked);
+    emit brightnessIntentEdited(checked, m_brightnessSlider->value());
     m_commandTimer->start(1000);
 }
 
 void CameraSettingsWidget::onBrightnessChanged(int value)
 {
+    emit brightnessIntentEdited(m_brightnessAutoCheckBox->isChecked(), value);
     m_userInitiated = true;
     m_controller->setBrightness(value);
     m_commandTimer->start(1000);
@@ -217,11 +223,13 @@ void CameraSettingsWidget::onContrastAutoToggled(bool checked)
     }
     // Set auto flag AFTER sending the value
     m_controller->setContrastAuto(checked);
+    emit contrastIntentEdited(checked, m_contrastSlider->value());
     m_commandTimer->start(1000);
 }
 
 void CameraSettingsWidget::onContrastChanged(int value)
 {
+    emit contrastIntentEdited(m_contrastAutoCheckBox->isChecked(), value);
     m_userInitiated = true;
     m_controller->setContrast(value);
     m_commandTimer->start(1000);
@@ -245,11 +253,13 @@ void CameraSettingsWidget::onSaturationAutoToggled(bool checked)
     }
     // Set auto flag AFTER sending the value
     m_controller->setSaturationAuto(checked);
+    emit saturationIntentEdited(checked, m_saturationSlider->value());
     m_commandTimer->start(1000);
 }
 
 void CameraSettingsWidget::onSaturationChanged(int value)
 {
+    emit saturationIntentEdited(m_saturationAutoCheckBox->isChecked(), value);
     m_userInitiated = true;
     m_controller->setSaturation(value);
     m_commandTimer->start(1000);
@@ -259,6 +269,7 @@ void CameraSettingsWidget::onWhiteBalanceChanged(int index)
 {
     Q_UNUSED(index);
     const int mode = m_whiteBalanceComboBox->currentData().toInt();
+    emit whiteBalanceIntentEdited(mode, m_whiteBalanceKelvinSlider->value());
     updateWhiteBalanceControls(mode);
 
     m_userInitiated = true;
@@ -276,6 +287,9 @@ void CameraSettingsWidget::onWhiteBalanceKelvinChanged(int value)
     if (m_whiteBalanceComboBox->currentData().toInt() != static_cast<int>(Device::DevWhiteBalanceManual)) {
         return;
     }
+
+    emit whiteBalanceIntentEdited(
+        static_cast<int>(Device::DevWhiteBalanceManual), value);
 
     m_userInitiated = true;
     m_controller->setWhiteBalanceManual(value);
@@ -424,6 +438,10 @@ void CameraSettingsWidget::updateWhiteBalanceControls(int mode)
 void CameraSettingsWidget::setV4l2Mode(bool v4l2Only)
 {
     m_advancedGroupBox->setVisible(!v4l2Only);
+    // Tiny 2 focus is owned by the selected tracking-mode profile. Hiding the
+    // legacy editor prevents it from racing the generation-bound profile.
+    m_faceFocusCheckBox->setVisible(
+        !v4l2Only && !m_controller->hasTiny2Capabilities());
 }
 
 void CameraSettingsWidget::updateWhiteBalanceKelvinLabel(int value)

--- a/src/gui/CameraSettingsWidget.h
+++ b/src/gui/CameraSettingsWidget.h
@@ -111,6 +111,16 @@ public:
         updateWhiteBalanceKelvinLabel(clamped);
     }
 
+signals:
+    void hdrIntentEdited(bool enabled);
+    void fovIntentEdited(int mode);
+    void faceAEIntentEdited(bool enabled);
+    void faceFocusIntentEdited(bool enabled);
+    void brightnessIntentEdited(bool automatic, int value);
+    void contrastIntentEdited(bool automatic, int value);
+    void saturationIntentEdited(bool automatic, int value);
+    void whiteBalanceIntentEdited(int mode, int kelvin);
+
 private slots:
     void onHDRToggled(bool checked);
     void onFOVChanged(int index);

--- a/src/gui/FilterPreviewWidget.cpp
+++ b/src/gui/FilterPreviewWidget.cpp
@@ -174,6 +174,7 @@ FilterPreviewWidget::FilterPreviewWidget(QWidget *parent)
     , m_textureDirty(false)
     , m_emitPending(false)
     , m_effectSettings(VideoEffectsSettings::defaults())
+    , m_lastPaperDetected(false)
     , m_vertexBuffer(QOpenGLBuffer::VertexBuffer)
     , m_geometryInitialized(false)
 {
@@ -195,7 +196,12 @@ void FilterPreviewWidget::setVideoEffects(const VideoEffectsSettings &settings)
     if (m_effectSettings == settings) {
         return;
     }
+    const bool cropModeChanged =
+        m_effectSettings.paperCrop.mode != settings.paperCrop.mode;
     m_effectSettings = settings;
+    if (cropModeChanged) {
+        resetPaperDetection();
+    }
     update();
 }
 
@@ -207,6 +213,15 @@ bool FilterPreviewWidget::automaticPaperCropAvailable()
 bool FilterPreviewWidget::paperDetected() const
 {
     return m_paperCropProcessor.paperDetected();
+}
+
+void FilterPreviewWidget::resetPaperDetection()
+{
+    m_paperCropProcessor.reset();
+    if (m_lastPaperDetected) {
+        m_lastPaperDetected = false;
+        emit paperDetectionChanged(false);
+    }
 }
 
 void FilterPreviewWidget::updateVideoFrame(const QVideoFrame &frame)
@@ -224,6 +239,14 @@ void FilterPreviewWidget::updateVideoFrame(const QVideoFrame &frame)
     image = m_paperCropProcessor.process(image, m_effectSettings.paperCrop);
     if (image.isNull()) {
         return;
+    }
+
+    const bool paperDetectedNow =
+        m_effectSettings.paperCrop.mode == PaperCropMode::Automatic
+        && m_paperCropProcessor.paperDetected();
+    if (paperDetectedNow != m_lastPaperDetected) {
+        m_lastPaperDetected = paperDetectedNow;
+        emit paperDetectionChanged(paperDetectedNow);
     }
 
     if (image.format() != QImage::Format_RGBA8888) {
@@ -287,7 +310,7 @@ void FilterPreviewWidget::paintGL()
 
     if (m_emitPending && m_framebuffer) {
         m_framebuffer->bind();
-        renderToCurrentTarget(frameSize);
+        renderToCurrentTarget(frameSize, false);
 
         QImage output(frameSize, QImage::Format_RGBA8888);
         glPixelStorei(GL_PACK_ALIGNMENT, 1);
@@ -299,7 +322,7 @@ void FilterPreviewWidget::paintGL()
         m_emitPending = false;
     }
 
-    renderToCurrentTarget(size());
+    renderToCurrentTarget(size(), true);
     m_program->release();
 }
 
@@ -418,13 +441,14 @@ void FilterPreviewWidget::uploadTextureIfNeeded()
     m_textureDirty = false;
 }
 
-void FilterPreviewWidget::renderToCurrentTarget(const QSize &targetSize)
+void FilterPreviewWidget::renderToCurrentTarget(
+    const QSize &targetSize, bool useDevicePixelRatio)
 {
     if (!m_program || !m_texture) {
         return;
     }
 
-    const qreal dpr = devicePixelRatioF();
+    const qreal dpr = useDevicePixelRatio ? devicePixelRatioF() : 1.0;
     const QSize physicalSize = (QSizeF(targetSize) * dpr).toSize();
 
     glViewport(0, 0, physicalSize.width(), physicalSize.height());

--- a/src/gui/FilterPreviewWidget.cpp
+++ b/src/gui/FilterPreviewWidget.cpp
@@ -199,6 +199,16 @@ void FilterPreviewWidget::setVideoEffects(const VideoEffectsSettings &settings)
     update();
 }
 
+bool FilterPreviewWidget::automaticPaperCropAvailable()
+{
+    return PaperCropProcessor::automaticDetectionAvailable();
+}
+
+bool FilterPreviewWidget::paperDetected() const
+{
+    return m_paperCropProcessor.paperDetected();
+}
+
 void FilterPreviewWidget::updateVideoFrame(const QVideoFrame &frame)
 {
     QVideoFrame copy(frame);
@@ -207,6 +217,11 @@ void FilterPreviewWidget::updateVideoFrame(const QVideoFrame &frame)
     }
 
     QImage image = copy.toImage();
+    if (image.isNull()) {
+        return;
+    }
+
+    image = m_paperCropProcessor.process(image, m_effectSettings.paperCrop);
     if (image.isNull()) {
         return;
     }

--- a/src/gui/FilterPreviewWidget.h
+++ b/src/gui/FilterPreviewWidget.h
@@ -85,9 +85,11 @@ public:
     void updateVideoFrame(const QVideoFrame &frame);
     static bool automaticPaperCropAvailable();
     bool paperDetected() const;
+    void resetPaperDetection();
 
 signals:
     void processedFrameReady(const QImage &frame);
+    void paperDetectionChanged(bool detected);
 
 protected:
     void initializeGL() override;
@@ -99,7 +101,7 @@ private:
     void ensureGeometry();
     void ensureFramebuffer(const QSize &size);
     void uploadTextureIfNeeded();
-    void renderToCurrentTarget(const QSize &targetSize);
+    void renderToCurrentTarget(const QSize &targetSize, bool useDevicePixelRatio);
     void applyEffectsUniforms();
     QVector3D srgbColorToLinearVec3(const QColor &color) const;
 
@@ -111,6 +113,7 @@ private:
     bool m_emitPending;
     VideoEffectsSettings m_effectSettings;
     PaperCropProcessor m_paperCropProcessor;
+    bool m_lastPaperDetected;
 
     std::unique_ptr<QOpenGLShaderProgram> m_program;
     std::unique_ptr<QOpenGLTexture> m_texture;

--- a/src/gui/FilterPreviewWidget.h
+++ b/src/gui/FilterPreviewWidget.h
@@ -1,6 +1,9 @@
 #ifndef FILTERPREVIEWWIDGET_H
 #define FILTERPREVIEWWIDGET_H
 
+#include "PaperCropProcessor.h"
+#include "PaperCropSettings.h"
+
 #include <QColor>
 #include <QImage>
 #include <QOpenGLBuffer>
@@ -40,6 +43,7 @@ public:
         QColor duoToneShadow = QColor(30, 30, 60);
         QColor duoToneHighlight = QColor(220, 180, 160);
         bool horizontalFlip = false;
+        PaperCropSettings paperCrop;
 
         bool operator==(const VideoEffectsSettings &other) const
         {
@@ -61,7 +65,8 @@ public:
                 && qFuzzyCompare(1.0f + duoToneIntensity, 1.0f + other.duoToneIntensity)
                 && duoToneShadow == other.duoToneShadow
                 && duoToneHighlight == other.duoToneHighlight
-                && horizontalFlip == other.horizontalFlip;
+                && horizontalFlip == other.horizontalFlip
+                && paperCrop == other.paperCrop;
         }
 
         bool operator!=(const VideoEffectsSettings &other) const
@@ -78,6 +83,8 @@ public:
     void setVideoEffects(const VideoEffectsSettings &settings);
     VideoEffectsSettings videoEffects() const { return m_effectSettings; }
     void updateVideoFrame(const QVideoFrame &frame);
+    static bool automaticPaperCropAvailable();
+    bool paperDetected() const;
 
 signals:
     void processedFrameReady(const QImage &frame);
@@ -103,6 +110,7 @@ private:
     bool m_textureDirty;
     bool m_emitPending;
     VideoEffectsSettings m_effectSettings;
+    PaperCropProcessor m_paperCropProcessor;
 
     std::unique_ptr<QOpenGLShaderProgram> m_program;
     std::unique_ptr<QOpenGLTexture> m_texture;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6,6 +6,7 @@
 #include <QWidget>
 #include <QIcon>
 #include <QEvent>
+#include <QEventLoop>
 #include <QWindowStateChangeEvent>
 #include <QApplication>
 #include <QCoreApplication>
@@ -33,6 +34,8 @@
 #include <QClipboard>
 #include <QDateTime>
 #include <QDir>
+#include <QDBusConnection>
+#include <QDBusError>
 #include <QFile>
 #include <QFileInfo>
 #include <QStandardPaths>
@@ -185,6 +188,17 @@ MainWindow::MainWindow(QWidget *parent)
     setupUI();
     setupTrayIcon();
 
+    QDBusConnection sessionBus = QDBusConnection::sessionBus();
+    if (sessionBus.registerService(QStringLiteral("com.obsbot.CameraControl"))) {
+        m_dbusRegistered = sessionBus.registerObject(
+            QStringLiteral("/CameraControl"),
+            this,
+            QDBusConnection::ExportScriptableSlots);
+        if (!m_dbusRegistered) {
+            sessionBus.unregisterService(QStringLiteral("com.obsbot.CameraControl"));
+        }
+    }
+
     // Load configuration
     loadConfiguration();
 
@@ -215,6 +229,12 @@ MainWindow::MainWindow(QWidget *parent)
 
 MainWindow::~MainWindow()
 {
+    if (m_dbusRegistered) {
+        QDBusConnection sessionBus = QDBusConnection::sessionBus();
+        sessionBus.unregisterObject(QStringLiteral("/CameraControl"));
+        sessionBus.unregisterService(QStringLiteral("com.obsbot.CameraControl"));
+    }
+
     // Save config on exit
     if (m_controller->isConnected()) {
         m_controller->saveConfig();
@@ -224,6 +244,42 @@ MainWindow::~MainWindow()
 bool MainWindow::isStartingMinimized() const
 {
     return m_controller->getConfig().getSettings().startMinimized;
+}
+
+bool MainWindow::recallPreset(int presetNumber)
+{
+    const int index = presetNumber - 1;
+    if (!m_ptzWidget || !m_ptzWidget->canRecallPreset(index)) {
+        return false;
+    }
+
+    if (m_controller->isConnected()) {
+        return m_ptzWidget->recallPreset(index);
+    }
+    if (m_pendingRemotePreset >= 0) {
+        return false;
+    }
+
+    m_pendingRemotePreset = index;
+    bool recalled = false;
+    QEventLoop waitForRecall;
+    QTimer timeout;
+    timeout.setSingleShot(true);
+    timeout.setInterval(5000);
+    connect(&timeout, &QTimer::timeout, &waitForRecall, &QEventLoop::quit);
+    connect(m_controller, &CameraController::cameraConnected, &waitForRecall,
+            [this, index, &waitForRecall, &recalled](const CameraController::CameraInfo &) {
+                QTimer::singleShot(150, &waitForRecall, [this, index, &waitForRecall, &recalled]() {
+                    recalled = m_ptzWidget->recallPreset(index);
+                    waitForRecall.quit();
+                });
+            });
+
+    m_controller->connectToCamera();
+    timeout.start();
+    waitForRecall.exec();
+    m_pendingRemotePreset = -1;
+    return recalled;
 }
 
 void MainWindow::setupUI()
@@ -407,6 +463,7 @@ void MainWindow::setupUI()
     m_ptzWidget = new PTZControlWidget(m_controller, this);
     m_settingsWidget = new CameraSettingsWidget(m_controller, this);
     m_ptzWidget->setCameraSettingsWidget(m_settingsWidget);
+    m_ptzWidget->setTrackingControlWidget(m_trackingWidget);
     connect(m_ptzWidget, &PTZControlWidget::presetUpdated,
             this, &MainWindow::onPresetUpdated);
 
@@ -417,6 +474,7 @@ void MainWindow::setupUI()
     m_tabWidget->addTab(m_ptzWidget, tr("Presets"));
     m_tabWidget->addTab(m_settingsWidget, tr("Camera Image"));
     m_effectsWidget = new VideoEffectsWidget(this);
+    m_ptzWidget->setVideoEffectsWidget(m_effectsWidget);
     connect(m_effectsWidget, &VideoEffectsWidget::effectsChanged,
             this, &MainWindow::onVideoEffectsChanged);
     // Mirror checkbox in tracking tab syncs with Creative FX horizontal flip
@@ -1057,7 +1115,10 @@ void MainWindow::onCameraConnected(const CameraController::CameraInfo &info)
     m_settingsWidget->setV4l2Mode(v4l2Mode);
 
     QTimer::singleShot(100, this, [this]() {
-        if (m_isCameraSwitch) {
+        if (m_pendingRemotePreset >= 0) {
+            // The synchronous D-Bus recall path owns this connection cycle.
+            return;
+        } else if (m_isCameraSwitch) {
             // Pull the new camera's actual state into the UI
             // without pushing the old camera's state back
             auto state = m_controller->getCurrentState();
@@ -1258,6 +1319,16 @@ void MainWindow::loadConfiguration()
     m_settingsWidget->setWhiteBalance(settings.whiteBalance);
     m_previewWidget->setPreferredFormatId(QString::fromStdString(settings.previewFormat));
 
+    auto effects = m_effectsWidget->settings();
+    effects.paperCrop = {
+        static_cast<PaperCropMode>(settings.paperCropMode),
+        static_cast<float>(settings.paperCropLeft),
+        static_cast<float>(settings.paperCropTop),
+        static_cast<float>(settings.paperCropRight),
+        static_cast<float>(settings.paperCropBottom)
+    };
+    m_effectsWidget->applySettings(effects);
+
     std::array<PTZControlWidget::PresetState, 3> presetStates{};
     for (int i = 0; i < 3; ++i) {
         const auto &preset = settings.presets[static_cast<size_t>(i)];
@@ -1265,7 +1336,19 @@ void MainWindow::loadConfiguration()
             preset.defined,
             preset.pan,
             preset.tilt,
-            preset.zoom
+            preset.zoom,
+            preset.sceneDefined,
+            preset.trackingEnabled,
+            preset.aiMode,
+            preset.aiSubMode,
+            preset.autoZoom,
+            {
+                static_cast<PaperCropMode>(preset.paperCropMode),
+                static_cast<float>(preset.paperCropLeft),
+                static_cast<float>(preset.paperCropTop),
+                static_cast<float>(preset.paperCropRight),
+                static_cast<float>(preset.paperCropBottom)
+            }
         };
     }
     m_ptzWidget->applyPresetStates(presetStates);
@@ -1523,18 +1606,30 @@ void MainWindow::onPreviewFormatChanged(const QString &formatId)
     updateVirtualCameraStreamerState();
 }
 
-void MainWindow::onPresetUpdated(int index, double pan, double tilt, double zoom, bool defined)
+void MainWindow::onPresetUpdated(int index)
 {
     auto settings = m_controller->getConfig().getSettings();
     if (index < 0 || index >= static_cast<int>(settings.presets.size())) {
         return;
     }
 
+    const auto uiPresets = m_ptzWidget->currentPresets();
+    const auto &ui = uiPresets[static_cast<size_t>(index)];
     auto &preset = settings.presets[static_cast<size_t>(index)];
-    preset.defined = defined;
-    preset.pan = pan;
-    preset.tilt = tilt;
-    preset.zoom = zoom;
+    preset.defined = ui.defined;
+    preset.pan = ui.pan;
+    preset.tilt = ui.tilt;
+    preset.zoom = ui.zoom;
+    preset.sceneDefined = ui.sceneDefined;
+    preset.trackingEnabled = ui.trackingEnabled;
+    preset.aiMode = ui.aiMode;
+    preset.aiSubMode = ui.aiSubMode;
+    preset.autoZoom = ui.autoZoom;
+    preset.paperCropMode = static_cast<int>(ui.paperCrop.mode);
+    preset.paperCropLeft = ui.paperCrop.left;
+    preset.paperCropTop = ui.paperCrop.top;
+    preset.paperCropRight = ui.paperCrop.right;
+    preset.paperCropBottom = ui.paperCrop.bottom;
 
     m_controller->getConfig().setSettings(settings);
     m_controller->saveConfig();
@@ -1911,6 +2006,25 @@ void MainWindow::onVideoEffectsChanged(const FilterPreviewWidget::VideoEffectsSe
     }
     m_previewWidget->setVideoEffects(settings);
     m_trackingWidget->setMirrored(settings.horizontalFlip);
+
+    const PaperCropSettings crop = settings.paperCrop.normalized();
+    auto configSettings = m_controller->getConfig().getSettings();
+    const PaperCropSettings savedCrop = {
+        static_cast<PaperCropMode>(configSettings.paperCropMode),
+        static_cast<float>(configSettings.paperCropLeft),
+        static_cast<float>(configSettings.paperCropTop),
+        static_cast<float>(configSettings.paperCropRight),
+        static_cast<float>(configSettings.paperCropBottom)
+    };
+    if (crop != savedCrop) {
+        configSettings.paperCropMode = static_cast<int>(crop.mode);
+        configSettings.paperCropLeft = crop.left;
+        configSettings.paperCropTop = crop.top;
+        configSettings.paperCropRight = crop.right;
+        configSettings.paperCropBottom = crop.bottom;
+        m_controller->getConfig().setSettings(configSettings);
+        m_controller->saveConfig();
+    }
 }
 
 void MainWindow::onSnapshotCaptured(const QImage &image)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -36,6 +36,7 @@
 #include <QDir>
 #include <QDBusConnection>
 #include <QDBusError>
+#include <QDebug>
 #include <QFile>
 #include <QFileInfo>
 #include <QStandardPaths>
@@ -178,8 +179,11 @@ MainWindow::MainWindow(QWidget *parent)
             this, &MainWindow::onCameraDisconnected);
     connect(m_controller, &CameraController::stateChanged,
             this, &MainWindow::onStateChanged);
+    // Defer modal error UI until the initiating control path has completed its
+    // safety rollback. A direct connection would open a nested event loop first.
     connect(m_controller, &CameraController::commandFailed,
-            this, &MainWindow::onCommandFailed);
+            this, &MainWindow::onCommandFailed,
+            Qt::QueuedConnection);
 
     m_virtualCameraStreamer = new VirtualCameraStreamer(this);
     connect(m_virtualCameraStreamer, &VirtualCameraStreamer::errorOccurred,
@@ -188,6 +192,146 @@ MainWindow::MainWindow(QWidget *parent)
     setupUI();
     setupTrayIcon();
 
+    // Config is the explicit persisted-intent model. These value-bearing
+    // signals update only the fields the operator actually edited; SDK status
+    // telemetry never flows into this model.
+    connect(m_trackingWidget, &TrackingControlWidget::trackingIntentEdited,
+            this, [this](const TrackingIntentState &tracking,
+                         bool updateModeProfile) {
+        updatePersistedIntent(
+            [this, tracking, updateModeProfile](
+                Config::CameraSettings &settings) {
+                storeTrackingIntent(
+                    settings, tracking, updateModeProfile);
+            });
+    });
+    connect(m_trackingWidget, &TrackingControlWidget::audioAutoGainIntentEdited,
+            this, [this](bool enabled) {
+        updatePersistedIntent([=](Config::CameraSettings &settings) {
+            settings.audioAutoGain = enabled;
+            settings.imageIntentDefined =
+                !m_controller->isV4l2Only();
+        });
+    });
+    connect(m_trackingWidget, &TrackingControlWidget::panTiltIntentEdited,
+            this, [this](double pan, double tilt) {
+        updatePersistedIntent([=](Config::CameraSettings &settings) {
+            settings.pan = pan;
+            settings.tilt = tilt;
+            settings.panTiltIntentDefined = true;
+        });
+    });
+    connect(m_trackingWidget, &TrackingControlWidget::zoomIntentEdited,
+            this, [this](double zoom) {
+        updatePersistedIntent([=](Config::CameraSettings &settings) {
+            settings.zoom = zoom;
+            settings.zoomIntentDefined = true;
+        });
+    });
+    connect(m_trackingWidget, &TrackingControlWidget::focusIntentEdited,
+            this, [this](int focus) {
+        updatePersistedIntent([=](Config::CameraSettings &settings) {
+            settings.focus = focus;
+        });
+    });
+
+    connect(m_settingsWidget, &CameraSettingsWidget::hdrIntentEdited,
+            this, [this](bool enabled) {
+        updatePersistedIntent([=](Config::CameraSettings &settings) {
+            settings.hdr = enabled;
+            settings.imageIntentDefined =
+                !m_controller->isV4l2Only();
+        });
+    });
+    connect(m_settingsWidget, &CameraSettingsWidget::fovIntentEdited,
+            this, [this](int mode) {
+        updatePersistedIntent([=](Config::CameraSettings &settings) {
+            settings.fov = mode;
+            settings.imageIntentDefined =
+                !m_controller->isV4l2Only();
+        });
+    });
+    connect(m_settingsWidget, &CameraSettingsWidget::faceAEIntentEdited,
+            this, [this](bool enabled) {
+        updatePersistedIntent([=](Config::CameraSettings &settings) {
+            settings.faceAE = enabled;
+            settings.imageIntentDefined =
+                !m_controller->isV4l2Only();
+        });
+    });
+    connect(m_settingsWidget, &CameraSettingsWidget::faceFocusIntentEdited,
+            this, [this](bool enabled) {
+        if (!m_controller->hasTiny2Capabilities()) {
+            updatePersistedIntent([=](Config::CameraSettings &settings) {
+                settings.faceFocus = enabled;
+                settings.imageIntentDefined =
+                    !m_controller->isV4l2Only();
+            });
+        }
+    });
+    connect(m_settingsWidget, &CameraSettingsWidget::brightnessIntentEdited,
+            this, [this](bool automatic, int value) {
+        updatePersistedIntent([=](Config::CameraSettings &settings) {
+            settings.brightnessAuto = automatic;
+            settings.brightness = value;
+            settings.imageIntentDefined =
+                !m_controller->isV4l2Only();
+        });
+    });
+    connect(m_settingsWidget, &CameraSettingsWidget::contrastIntentEdited,
+            this, [this](bool automatic, int value) {
+        updatePersistedIntent([=](Config::CameraSettings &settings) {
+            settings.contrastAuto = automatic;
+            settings.contrast = value;
+            settings.imageIntentDefined =
+                !m_controller->isV4l2Only();
+        });
+    });
+    connect(m_settingsWidget, &CameraSettingsWidget::saturationIntentEdited,
+            this, [this](bool automatic, int value) {
+        updatePersistedIntent([=](Config::CameraSettings &settings) {
+            settings.saturationAuto = automatic;
+            settings.saturation = value;
+            settings.imageIntentDefined =
+                !m_controller->isV4l2Only();
+        });
+    });
+    connect(m_settingsWidget, &CameraSettingsWidget::whiteBalanceIntentEdited,
+            this, [this](int mode, int kelvin) {
+        updatePersistedIntent([=](Config::CameraSettings &settings) {
+            settings.whiteBalance = mode;
+            settings.whiteBalanceKelvin = kelvin;
+            settings.imageIntentDefined =
+                !m_controller->isV4l2Only();
+        });
+    });
+
+    connect(m_ptzWidget, &PTZControlWidget::sceneIntentApplied,
+            this, [this](const TrackingIntentState &tracking,
+                         bool positionApplied,
+                         double pan, double tilt, double zoom,
+                         const PaperCropSettings &paperCrop) {
+        // Commit the complete successfully applied scene once. Programmatic
+        // crop rendering no longer writes a crop-only intermediate state.
+        auto settings = m_controller->getConfig().getSettings();
+        storeTrackingIntent(settings, tracking, false);
+        const PaperCropSettings crop = paperCrop.normalized();
+        settings.paperCropMode = static_cast<int>(crop.mode);
+        settings.paperCropLeft = crop.left;
+        settings.paperCropTop = crop.top;
+        settings.paperCropRight = crop.right;
+        settings.paperCropBottom = crop.bottom;
+        if (positionApplied) {
+            settings.pan = pan;
+            settings.tilt = tilt;
+            settings.zoom = zoom;
+            settings.panTiltIntentDefined = true;
+            settings.zoomIntentDefined = true;
+        }
+        m_controller->getConfig().setSettings(settings);
+        m_controller->saveConfig();
+    });
+
     QDBusConnection sessionBus = QDBusConnection::sessionBus();
     if (sessionBus.registerService(QStringLiteral("com.obsbot.CameraControl"))) {
         m_dbusRegistered = sessionBus.registerObject(
@@ -195,8 +339,13 @@ MainWindow::MainWindow(QWidget *parent)
             this,
             QDBusConnection::ExportScriptableSlots);
         if (!m_dbusRegistered) {
+            qWarning() << "Failed to register OBSBOT D-Bus object:"
+                       << sessionBus.lastError().message();
             sessionBus.unregisterService(QStringLiteral("com.obsbot.CameraControl"));
         }
+    } else {
+        qWarning() << "Failed to own OBSBOT D-Bus service:"
+                   << sessionBus.lastError().message();
     }
 
     // Load configuration
@@ -218,8 +367,18 @@ MainWindow::MainWindow(QWidget *parent)
     });
 #endif
 
-    // Start connecting to camera
-    m_controller->connectToCamera();
+    // Bind startup to the camera shown in the selector. Once the SDK resolves
+    // it, CameraController retains the stable serial across reconnects.
+    if (!m_detectedCameras.isEmpty()) {
+        const int selectedIndex = m_cameraSelectorCombo
+            ? qBound(0, m_cameraSelectorCombo->currentIndex(),
+                     m_detectedCameras.size() - 1)
+            : 0;
+        const auto &camera = m_detectedCameras[selectedIndex];
+        m_controller->connectToCamera(camera.devicePath, camera.serial);
+    } else {
+        m_controller->connectToCamera();
+    }
 
     // Update status periodically
     m_statusTimer = new QTimer(this);
@@ -235,10 +394,9 @@ MainWindow::~MainWindow()
         sessionBus.unregisterService(QStringLiteral("com.obsbot.CameraControl"));
     }
 
-    // Save config on exit
-    if (m_controller->isConnected()) {
-        m_controller->saveConfig();
-    }
+    // Config already contains explicit intent only, so it is safe to save even
+    // after the camera has disconnected.
+    m_controller->saveConfig();
 }
 
 bool MainWindow::isStartingMinimized() const
@@ -249,37 +407,184 @@ bool MainWindow::isStartingMinimized() const
 bool MainWindow::recallPreset(int presetNumber)
 {
     const int index = presetNumber - 1;
-    if (!m_ptzWidget || !m_ptzWidget->canRecallPreset(index)) {
+    if (!m_ptzWidget || !m_ptzWidget->canRecallPreset(index)
+        || m_remoteRecallInProgress || m_pendingRemotePreset >= 0) {
         return false;
     }
 
+    m_remoteRecallInProgress = true;
+    const quint64 operationGeneration = ++m_cameraSwitchGeneration;
+    QString targetSerial = m_controller->selectedDeviceSerial();
+    QString targetPath = m_controller->selectedDevicePath();
+
+    const auto bindConnectedTarget =
+        [this, &targetSerial, &targetPath](
+            const CameraController::CameraInfo &info) {
+        if (targetSerial.isEmpty() && targetPath.isEmpty()) {
+            targetSerial = info.serialNumber;
+            targetPath = m_controller->getVideoDevicePath();
+        }
+    };
+    const auto matchesTarget = [this, &targetSerial, &targetPath]() {
+        if (!m_controller->isConnected()) {
+            return false;
+        }
+        const auto info = m_controller->getCameraInfo();
+        if (!targetSerial.isEmpty()) {
+            return info.serialNumber == targetSerial;
+        }
+        if (!targetPath.isEmpty()) {
+            return m_controller->getVideoDevicePath() == targetPath;
+        }
+        return true;
+    };
+    const auto operationCurrent =
+        [this, operationGeneration, &matchesTarget]() {
+        return operationGeneration == m_cameraSwitchGeneration
+            && matchesTarget();
+    };
+
+    const auto awaitCompletion =
+        [this, &operationCurrent](bool accepted) {
+        if (!accepted || !m_ptzWidget->hasPendingRecall()) {
+            return accepted && operationCurrent();
+        }
+
+        bool completed = false;
+        bool succeeded = false;
+        bool superseded = false;
+        QEventLoop waitForCompletion;
+        QTimer timeout;
+        timeout.setSingleShot(true);
+        timeout.setInterval(10000);
+        QTimer supersessionPoll;
+        supersessionPoll.setInterval(25);
+        connect(&timeout, &QTimer::timeout,
+                &waitForCompletion, &QEventLoop::quit);
+        connect(&supersessionPoll, &QTimer::timeout,
+                &waitForCompletion,
+                [&operationCurrent, &superseded, &waitForCompletion]() {
+            if (!operationCurrent()) {
+                superseded = true;
+                waitForCompletion.quit();
+            }
+        });
+        connect(m_ptzWidget, &PTZControlWidget::presetRecallFinished,
+                &waitForCompletion,
+                [&operationCurrent, &completed, &succeeded, &superseded,
+                 &waitForCompletion](bool success) {
+            if (!operationCurrent()) {
+                superseded = true;
+            } else {
+                completed = true;
+                succeeded = success;
+            }
+            waitForCompletion.quit();
+        });
+        timeout.start();
+        supersessionPoll.start();
+        waitForCompletion.exec();
+        if (!completed || superseded) {
+            m_ptzWidget->cancelPendingRecall();
+            return false;
+        }
+        return succeeded && operationCurrent();
+    };
+
+    const auto finishRecall =
+        [this, &operationCurrent](bool success) {
+        const bool current = operationCurrent();
+        m_remoteRecallInProgress = false;
+        if (!current) {
+            return false;
+        }
+
+        m_isCameraSwitch = false;
+        if (success) {
+            m_initialCameraStateApplied = true;
+        } else if (!m_initialCameraStateApplied) {
+            // A failed first-connection recall suppressed normal startup apply;
+            // restore configured intent only on the same exact connection.
+            enforceAutomaticPaperCropTrackingPolicy();
+            m_controller->applyConfigToCamera();
+            m_initialCameraStateApplied = true;
+        }
+        return success;
+    };
+
     if (m_controller->isConnected()) {
-        return m_ptzWidget->recallPreset(index);
-    }
-    if (m_pendingRemotePreset >= 0) {
-        return false;
+        bindConnectedTarget(m_controller->getCameraInfo());
+        if (!operationCurrent()) {
+            return finishRecall(false);
+        }
+        return finishRecall(
+            awaitCompletion(m_ptzWidget->recallPreset(index)));
     }
 
     m_pendingRemotePreset = index;
     bool recalled = false;
+    bool superseded = false;
+    bool continuationScheduled = false;
     QEventLoop waitForRecall;
     QTimer timeout;
     timeout.setSingleShot(true);
-    timeout.setInterval(5000);
-    connect(&timeout, &QTimer::timeout, &waitForRecall, &QEventLoop::quit);
+    timeout.setInterval(10000);
+    QTimer supersessionPoll;
+    supersessionPoll.setInterval(25);
+    connect(&timeout, &QTimer::timeout,
+            &waitForRecall, &QEventLoop::quit);
+    connect(&supersessionPoll, &QTimer::timeout,
+            &waitForRecall,
+            [this, operationGeneration, &matchesTarget, &superseded,
+             &waitForRecall]() {
+        if (operationGeneration != m_cameraSwitchGeneration
+            || (m_controller->isConnected() && !matchesTarget())) {
+            superseded = true;
+            waitForRecall.quit();
+        }
+    });
     connect(m_controller, &CameraController::cameraConnected, &waitForRecall,
-            [this, index, &waitForRecall, &recalled](const CameraController::CameraInfo &) {
-                QTimer::singleShot(150, &waitForRecall, [this, index, &waitForRecall, &recalled]() {
-                    recalled = m_ptzWidget->recallPreset(index);
-                    waitForRecall.quit();
-                });
-            });
+            [this, index, operationGeneration, &bindConnectedTarget,
+             &matchesTarget, &waitForRecall, &recalled, &superseded,
+             &continuationScheduled](const CameraController::CameraInfo &info) {
+        if (operationGeneration != m_cameraSwitchGeneration) {
+            superseded = true;
+            waitForRecall.quit();
+            return;
+        }
+        bindConnectedTarget(info);
+        if (!matchesTarget()) {
+            superseded = true;
+            waitForRecall.quit();
+            return;
+        }
+        if (continuationScheduled) {
+            return;
+        }
+        continuationScheduled = true;
+        QTimer::singleShot(
+            150, &waitForRecall,
+            [this, index, operationGeneration, &matchesTarget,
+             &waitForRecall, &recalled, &superseded]() {
+            if (operationGeneration != m_cameraSwitchGeneration
+                || !matchesTarget()) {
+                superseded = true;
+            } else {
+                recalled = m_ptzWidget->recallPreset(index);
+            }
+            waitForRecall.quit();
+        });
+    });
 
     m_controller->connectToCamera();
     timeout.start();
+    supersessionPoll.start();
     waitForRecall.exec();
     m_pendingRemotePreset = -1;
-    return recalled;
+    if (superseded) {
+        m_ptzWidget->cancelPendingRecall();
+    }
+    return finishRecall(awaitCompletion(recalled && !superseded));
 }
 
 void MainWindow::setupUI()
@@ -452,6 +757,8 @@ void MainWindow::setupUI()
     m_reconnectButton = new QPushButton(tr("Reconnect"), actionRow);
     m_reconnectButton->setObjectName("secondaryAction");
     connect(m_reconnectButton, &QPushButton::clicked, this, [this]() {
+        ++m_cameraSwitchGeneration;
+        m_controller->saveConfig();
         m_controller->disconnectFromCamera();
         m_controller->connectToCamera();
     });
@@ -477,6 +784,12 @@ void MainWindow::setupUI()
     m_ptzWidget->setVideoEffectsWidget(m_effectsWidget);
     connect(m_effectsWidget, &VideoEffectsWidget::effectsChanged,
             this, &MainWindow::onVideoEffectsChanged);
+    connect(m_effectsWidget, &VideoEffectsWidget::paperCropIntentEdited,
+            this, &MainWindow::onPaperCropIntentEdited);
+    connect(m_effectsWidget, &VideoEffectsWidget::paperDetectionResetRequested,
+            m_previewWidget, &CameraPreviewWidget::resetPaperDetection);
+    connect(m_previewWidget, &CameraPreviewWidget::paperDetectionChanged,
+            m_effectsWidget, &VideoEffectsWidget::setPaperDetected);
     // Mirror checkbox in tracking tab syncs with Creative FX horizontal flip
     connect(m_trackingWidget, &TrackingControlWidget::mirrorToggled,
             this, [this](bool mirrored) {
@@ -1114,18 +1427,158 @@ void MainWindow::onCameraConnected(const CameraController::CameraInfo &info)
     m_trackingWidget->setV4l2Mode(v4l2Mode);
     m_settingsWidget->setV4l2Mode(v4l2Mode);
 
-    QTimer::singleShot(100, this, [this]() {
-        if (m_pendingRemotePreset >= 0) {
-            // The synchronous D-Bus recall path owns this connection cycle.
+    const bool initialApplicationWasPending =
+        !m_initialCameraStateApplied;
+    const quint64 switchGeneration = m_cameraSwitchGeneration;
+    const QString connectedSerial = info.serialNumber;
+    const QString connectedPath = m_controller->getVideoDevicePath();
+    QTimer::singleShot(100, this,
+                       [this, initialApplicationWasPending, switchGeneration,
+                        connectedSerial, connectedPath]() {
+        if (switchGeneration != m_cameraSwitchGeneration
+            || !m_controller->isConnected()) {
+            return;
+        }
+        const auto currentInfo = m_controller->getCameraInfo();
+        if ((!connectedSerial.isEmpty()
+             && currentInfo.serialNumber != connectedSerial)
+            || (connectedSerial.isEmpty()
+                && m_controller->getVideoDevicePath() != connectedPath)) {
+            return;
+        }
+
+        if (m_remoteRecallInProgress || m_pendingRemotePreset >= 0) {
+            // The synchronous D-Bus recall path owns this exact connection
+            // cycle and will establish preset intent or restore configuration.
+            m_isCameraSwitch = false;
             return;
         } else if (m_isCameraSwitch) {
-            // Pull the new camera's actual state into the UI
-            // without pushing the old camera's state back
+            // Pull the new camera's actual state into the UI without pushing
+            // unrelated settings from the old camera. If manual intent remains
+            // selected, reassert only tracking-off so movement is unlocked by
+            // an exact confirmation from the newly selected device.
             auto state = m_controller->getCurrentState();
             onStateChanged(state);
             m_isCameraSwitch = false;
+            if (!m_controller->isV4l2Only()) {
+                // Camera selection adopts only the new camera's observed AI
+                // ownership plus the global profile for that mode. It never
+                // pushes the prior camera's PTZ/image state, and the adopted
+                // intent is persisted so reconnect cannot reverse the switch.
+                auto settings = m_controller->getConfig().getSettings();
+                const bool tiny2 = m_controller->hasTiny2Capabilities();
+                const bool stableTiny2Mode = state.aiMode
+                        >= Device::AiWorkModeNone
+                    && state.aiMode <= Device::AiWorkModeDesk;
+                TrackingIntentState selectedTracking;
+                if (tiny2 && stableTiny2Mode
+                    && state.aiMode != Device::AiWorkModeNone) {
+                    selectedTracking.enabled = true;
+                    selectedTracking.aiMode = state.aiMode;
+                    selectedTracking.aiSubMode =
+                        state.aiMode == Device::AiWorkModeHuman
+                        ? state.aiSubMode : 0;
+                    const int profileIndex =
+                        tiny2TrackingModeProfileIndex(state.aiMode);
+                    selectedTracking.profile =
+                        settings.trackingModeProfiles[
+                            static_cast<std::size_t>(profileIndex)];
+                } else if (!tiny2 && state.autoFramingEnabled) {
+                    selectedTracking.enabled = true;
+                    selectedTracking.aiMode = Device::AiWorkModeHuman;
+                    selectedTracking.aiSubMode = Device::AiSubModeNormal;
+                    selectedTracking.profile =
+                        settings.activeTrackingProfile;
+                } else {
+                    selectedTracking.enabled = false;
+                    selectedTracking.aiMode = tiny2 && stableTiny2Mode
+                        ? state.aiMode : Device::AiWorkModeNone;
+                    selectedTracking.aiSubMode = 0;
+                    selectedTracking.profile = {
+                        TrackingFocusPolicy::Manual,
+                        qBound(0, state.manualFocusValue, 100),
+                        false,
+                        settings.activeTrackingProfile.trackSpeed
+                    };
+                }
+
+                selectedTracking =
+                    applyAutomaticPaperCropTrackingPolicy(
+                        settings.paperCropMode,
+                        tiny2,
+                        selectedTracking,
+                        settings.trackingModeProfiles);
+                storeTrackingIntent(
+                    settings, selectedTracking, false);
+
+                settings.panTiltIntentDefined = state.panTiltKnown;
+                if (state.panTiltKnown) {
+                    settings.pan = state.pan;
+                    settings.tilt = state.tilt;
+                }
+                settings.zoomIntentDefined = state.zoomKnown;
+                if (state.zoomKnown) {
+                    settings.zoom = state.zoom;
+                }
+                settings.imageIntentDefined = state.imageSettingsKnown;
+                if (state.imageSettingsKnown) {
+                    settings.hdr = state.hdrEnabled;
+                    settings.fov = state.fovMode;
+                    settings.faceAE = state.faceAEEnabled;
+                    settings.faceFocus = state.faceFocusEnabled;
+                    settings.brightness = state.brightness;
+                    settings.contrast = state.contrast;
+                    settings.saturation = state.saturation;
+                    settings.whiteBalance = state.whiteBalance;
+                    settings.whiteBalanceKelvin =
+                        state.whiteBalanceKelvin;
+                    settings.audioAutoGain =
+                        state.audioAutoGainEnabled;
+                }
+                m_controller->getConfig().setSettings(settings);
+                m_controller->saveConfig();
+                m_trackingWidget->applyTrackingState(selectedTracking);
+            } else {
+                // V4L2 cannot prove AI ownership or expose all camera state.
+                // Persist a safe off intent and invalidate every camera-bound
+                // category so a later SDK reconnect cannot apply the prior
+                // camera's movement or image values.
+                auto settings = m_controller->getConfig().getSettings();
+                const TrackingIntentState safeOff{
+                    false,
+                    Device::AiWorkModeNone,
+                    0,
+                    {
+                        TrackingFocusPolicy::Manual,
+                        settings.activeTrackingProfile.manualFocusPosition,
+                        false,
+                        settings.activeTrackingProfile.trackSpeed
+                    }
+                };
+                storeTrackingIntent(settings, safeOff, false);
+                settings.panTiltIntentDefined = false;
+                settings.zoomIntentDefined = false;
+                settings.imageIntentDefined = false;
+                m_controller->getConfig().setSettings(settings);
+                m_controller->saveConfig();
+                m_trackingWidget->setTrackingStatePresentation(safeOff);
+            }
+        } else if (initialApplicationWasPending) {
+            if (!m_initialCameraStateApplied) {
+                // The SDK emits an immediate pre-restore status snapshot when
+                // the device is discovered. Apply persisted intent directly on
+                // the first connection instead of feeding that snapshot back.
+                enforceAutomaticPaperCropTrackingPolicy();
+                m_controller->applyConfigToCamera();
+                m_initialCameraStateApplied = true;
+            }
+            // A first-connection preset recall may already have established
+            // intent; never overwrite it with the startup configuration.
         } else {
-            m_controller->applyCurrentStateToCamera(getUIState());
+            // Same-device reconnects reapply the explicit persisted-intent
+            // model, never telemetry-oriented widget/controller state.
+            enforceAutomaticPaperCropTrackingPolicy();
+            m_controller->applyConfigToCamera();
         }
     });
 
@@ -1164,6 +1617,13 @@ void MainWindow::onCameraDisconnected()
 
 void MainWindow::onStateChanged(const CameraController::CameraState &state)
 {
+    if (!m_initialCameraStateApplied) {
+        // Keep the loaded configuration authoritative until its first camera
+        // application. Otherwise discovery-time SDK defaults overwrite the UI
+        // before onCameraConnected() can restore persisted intent.
+        return;
+    }
+
     // Update all widgets with new state
     m_trackingWidget->updateFromState(state);
     m_settingsWidget->updateFromState(state);
@@ -1182,8 +1642,15 @@ void MainWindow::fitTabToCurrentPage()
 
 void MainWindow::onCommandFailed(const QString &description, int errorCode)
 {
-    QMessageBox::warning(this, "Command Failed",
-        QString("%1 failed with error code: %2").arg(description).arg(errorCode));
+    auto *dialog = new QMessageBox(
+        QMessageBox::Warning,
+        tr("Command Failed"),
+        tr("%1 failed with error code: %2").arg(description).arg(errorCode),
+        QMessageBox::Ok,
+        this);
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+    dialog->setModal(false);
+    dialog->show();
 }
 
 void MainWindow::updateStatus()
@@ -1288,6 +1755,104 @@ void MainWindow::updateVirtualCameraStreamerState()
     m_virtualCameraStreamer->setEnabled(enableOutput);
 }
 
+void MainWindow::updatePersistedIntent(
+    const std::function<void(Config::CameraSettings &)> &update)
+{
+    auto settings = m_controller->getConfig().getSettings();
+    update(settings);
+    m_controller->getConfig().setSettings(settings);
+}
+
+TrackingIntentState MainWindow::trackingIntentFromSettings(
+    const Config::CameraSettings &settings) const
+{
+    return {
+        settings.faceTracking,
+        settings.aiMode,
+        settings.aiMode == Device::AiWorkModeHuman
+            ? settings.aiSubMode : 0,
+        settings.activeTrackingProfile
+    };
+}
+
+void MainWindow::storeTrackingIntent(
+    Config::CameraSettings &settings,
+    const TrackingIntentState &tracking,
+    bool updateModeProfile) const
+{
+    TrackingIntentState normalized = tracking;
+    const TrackingModeProfile editedModeProfile = tracking.profile;
+    if (normalized.enabled
+        && normalized.aiMode == Device::AiWorkModeNone) {
+        normalized.aiMode = Device::AiWorkModeHuman;
+    }
+    if (normalized.aiMode != Device::AiWorkModeHuman) {
+        normalized.aiSubMode = 0;
+    }
+    if (!normalized.enabled) {
+        if (updateModeProfile) {
+            // Profile controls edit the retained AI mode while camera intent
+            // remains manual/off. Do not replace active manual focus with the
+            // profile editor's autofocus choice.
+            normalized.profile = settings.activeTrackingProfile;
+        }
+        normalized.profile.focusPolicy = TrackingFocusPolicy::Manual;
+        normalized.profile.autoZoom = false;
+    }
+
+    settings.faceTracking = normalized.enabled;
+    settings.aiMode = normalized.aiMode;
+    settings.aiSubMode = normalized.aiSubMode;
+    settings.activeTrackingProfile = normalized.profile;
+    settings.autoZoom = normalized.enabled && normalized.profile.autoZoom;
+    settings.trackSpeed = normalized.profile.trackSpeed;
+    settings.faceFocus =
+        normalized.profile.focusPolicy == TrackingFocusPolicy::Face;
+    settings.focus =
+        normalized.profile.focusPolicy == TrackingFocusPolicy::Continuous
+        ? -1 : normalized.profile.manualFocusPosition;
+
+    if (updateModeProfile) {
+        const int profileIndex =
+            tiny2TrackingModeProfileIndex(normalized.aiMode);
+        if (profileIndex >= 0) {
+            settings.trackingModeProfiles[
+                static_cast<std::size_t>(profileIndex)] =
+                editedModeProfile;
+        }
+    }
+}
+
+bool MainWindow::enforceAutomaticPaperCropTrackingPolicy()
+{
+    if (!m_controller->isConnected()
+        || !m_controller->hasTiny2Capabilities()) {
+        return false;
+    }
+
+    auto settings = m_controller->getConfig().getSettings();
+    if (settings.paperCropMode
+        != static_cast<int>(PaperCropMode::Automatic)) {
+        return false;
+    }
+
+    const TrackingIntentState current =
+        trackingIntentFromSettings(settings);
+    const TrackingIntentState effective =
+        applyAutomaticPaperCropTrackingPolicy(
+            settings.paperCropMode,
+            true,
+            current,
+            settings.trackingModeProfiles);
+    if (effective != current) {
+        storeTrackingIntent(settings, effective, false);
+        m_controller->getConfig().setSettings(settings);
+        m_controller->saveConfig();
+    }
+    m_trackingWidget->setTrackingStatePresentation(effective);
+    return true;
+}
+
 void MainWindow::loadConfiguration()
 {
     std::vector<Config::ValidationError> errors;
@@ -1298,11 +1863,11 @@ void MainWindow::loadConfiguration()
 
     // Initialize UI widgets from config
     auto settings = m_controller->getConfig().getSettings();
-    m_trackingWidget->setTrackingEnabled(settings.faceTracking);
-    m_trackingWidget->setAiMode(settings.aiMode);
-    m_trackingWidget->setHumanSubMode(settings.aiSubMode);
-    m_trackingWidget->setAutoZoomEnabled(settings.autoZoom);
-    m_trackingWidget->setTrackSpeed(settings.trackSpeed);
+    m_trackingWidget->setModeProfiles(settings.trackingModeProfiles);
+    m_trackingWidget->setTrackingStatePresentation(
+        trackingIntentFromSettings(settings));
+    m_trackingWidget->setManualFocusPosition(
+        settings.activeTrackingProfile.manualFocusPosition);
     m_trackingWidget->setAudioAutoGain(settings.audioAutoGain);
     m_settingsWidget->setHDREnabled(settings.hdr);
     m_settingsWidget->setFOVMode(settings.fov);
@@ -1342,6 +1907,9 @@ void MainWindow::loadConfiguration()
             preset.aiMode,
             preset.aiSubMode,
             preset.autoZoom,
+            preset.focusPolicy,
+            preset.manualFocusPosition,
+            preset.trackSpeed,
             {
                 static_cast<PaperCropMode>(preset.paperCropMode),
                 static_cast<float>(preset.paperCropLeft),
@@ -1505,13 +2073,18 @@ void MainWindow::changeEvent(QEvent *event)
                 m_previewToggleButton->setChecked(false);
             }
 
-            // Disconnect from camera to free resources
+            m_controller->saveConfig();
+
+            // Disconnect from camera to free resources and cancel any delayed
+            // selector connection without discarding its staged identity.
+            ++m_cameraSwitchGeneration;
             m_controller->disconnectFromCamera();
 
         } else if (stateEvent->oldState() & Qt::WindowMinimized) {
             // Window is being restored from minimized state
 
-            // ALWAYS reconnect to camera (regardless of preview state)
+            // ALWAYS reconnect to the staged exact target.
+            ++m_cameraSwitchGeneration;
             m_controller->connectToCamera();
 
             // ONLY restore preview if it was enabled before minimize
@@ -1625,6 +2198,9 @@ void MainWindow::onPresetUpdated(int index)
     preset.aiMode = ui.aiMode;
     preset.aiSubMode = ui.aiSubMode;
     preset.autoZoom = ui.autoZoom;
+    preset.focusPolicy = ui.focusPolicy;
+    preset.manualFocusPosition = ui.manualFocusPosition;
+    preset.trackSpeed = ui.trackSpeed;
     preset.paperCropMode = static_cast<int>(ui.paperCrop.mode);
     preset.paperCropLeft = ui.paperCrop.left;
     preset.paperCropTop = ui.paperCrop.top;
@@ -1665,6 +2241,38 @@ void MainWindow::populateCameraSelector()
 
     if (!m_cameraSelectorCombo) return;
 
+    const QString selectedSerial = m_controller->selectedDeviceSerial();
+    const QString selectedPath = m_controller->selectedDevicePath();
+    int preferredIndex = -1;
+    for (int index = 0; index < m_detectedCameras.size(); ++index) {
+        const auto &camera = m_detectedCameras[index];
+        if ((!selectedSerial.isEmpty() && camera.serial == selectedSerial)
+            || (selectedSerial.isEmpty() && !selectedPath.isEmpty()
+                && camera.devicePath == selectedPath)) {
+            preferredIndex = index;
+            break;
+        }
+    }
+
+    bool selectedUnavailable = false;
+    if (preferredIndex < 0
+        && (!selectedSerial.isEmpty() || !selectedPath.isEmpty())) {
+        DetectedCamera unavailable;
+        unavailable.devicePath = selectedPath;
+        unavailable.serial = selectedSerial;
+        unavailable.available = false;
+        unavailable.label = selectedSerial.isEmpty()
+            ? tr("Selected camera unavailable (%1)").arg(selectedPath)
+            : tr("Selected camera unavailable [%1]").arg(selectedSerial);
+        m_detectedCameras.prepend(unavailable);
+        preferredIndex = 0;
+        selectedUnavailable = true;
+    }
+
+    const int availableCount = static_cast<int>(std::count_if(
+        m_detectedCameras.cbegin(), m_detectedCameras.cend(),
+        [](const DetectedCamera &camera) { return camera.available; }));
+
     m_cameraSelectorCombo->blockSignals(true);
     m_cameraSelectorCombo->clear();
 
@@ -1674,14 +2282,16 @@ void MainWindow::populateCameraSelector()
     } else {
         for (const auto &cam : std::as_const(m_detectedCameras))
             m_cameraSelectorCombo->addItem(cam.label);
-        m_cameraSelectorCombo->setEnabled(true);
+        m_cameraSelectorCombo->setCurrentIndex(
+            preferredIndex >= 0 ? preferredIndex : 0);
+        m_cameraSelectorCombo->setEnabled(availableCount > 0);
     }
     m_cameraSelectorCombo->blockSignals(false);
 
-    const bool multiCam = m_detectedCameras.size() > 1;
-    m_cameraSelectorCombo->setVisible(multiCam);
+    const bool showSelector = selectedUnavailable || availableCount > 1;
+    m_cameraSelectorCombo->setVisible(showSelector);
     if (m_cameraSelectorLabel)
-        m_cameraSelectorLabel->setVisible(multiCam);
+        m_cameraSelectorLabel->setVisible(showSelector);
 }
 
 void MainWindow::onCameraSelectorChanged(int index)
@@ -1689,6 +2299,14 @@ void MainWindow::onCameraSelectorChanged(int index)
     if (index < 0 || index >= m_detectedCameras.size()) return;
 
     const DetectedCamera &cam = m_detectedCameras[index];
+    if (!cam.available) {
+        return;
+    }
+
+    // Stage the exact target synchronously. Any D-Bus recall, reconnect,
+    // minimize, or tray transition during the release delay will therefore
+    // reconnect to this selection rather than the previous camera.
+    m_controller->selectCameraTarget(cam.devicePath, cam.serial);
 
     if (m_previewToggleButton->isChecked()) {
         m_previewToggleButton->setChecked(false);
@@ -1701,10 +2319,42 @@ void MainWindow::onCameraSelectorChanged(int index)
     static constexpr int kCameraSwitchDelayMs = 300;
 
     const QString devicePath = cam.devicePath;
-    m_isCameraSwitch = true;
+    const QString serialNumber = cam.serial;
+    const quint64 switchGeneration = ++m_cameraSwitchGeneration;
+
+    // Invalidate prior-camera intent before any asynchronous release/connect
+    // window. If the switch is interrupted, every subsequent reconnect still
+    // sees a safe tracking-off state with no old movement/image categories.
+    auto settings = m_controller->getConfig().getSettings();
+    const TrackingIntentState safeSwitchIntent{
+        false,
+        Device::AiWorkModeNone,
+        0,
+        {
+            TrackingFocusPolicy::Manual,
+            50,
+            false,
+            settings.activeTrackingProfile.trackSpeed
+        }
+    };
+    storeTrackingIntent(settings, safeSwitchIntent, false);
+    settings.panTiltIntentDefined = false;
+    settings.zoomIntentDefined = false;
+    settings.imageIntentDefined = false;
+    m_controller->getConfig().setSettings(settings);
+    m_controller->saveConfig();
+
     m_controller->disconnectFromCamera();
-    QTimer::singleShot(kCameraSwitchDelayMs, this, [this, devicePath]() {
-        m_controller->connectToCamera(devicePath);
+    // disconnectFromCamera() emits cameraDisconnected synchronously; arm the
+    // switch marker afterward so that callback cannot clear it before the new
+    // device connects.
+    m_isCameraSwitch = true;
+    QTimer::singleShot(kCameraSwitchDelayMs, this,
+                       [this, devicePath, serialNumber, switchGeneration]() {
+        if (switchGeneration != m_cameraSwitchGeneration) {
+            return;
+        }
+        m_controller->connectToCamera(devicePath, serialNumber);
     });
 }
 
@@ -1812,12 +2462,17 @@ void MainWindow::onShowHideAction()
             m_previewToggleButton->setChecked(false);
         }
 
-        // Disconnect from camera to free resources
+        m_controller->saveConfig();
+
+        // Disconnect from camera to free resources and cancel any delayed
+        // selector connection without discarding its staged identity.
+        ++m_cameraSwitchGeneration;
         m_controller->disconnectFromCamera();
 
         hide();
     } else {
-        // ALWAYS reconnect to camera when restoring from tray
+        // ALWAYS reconnect to the staged exact target when restoring from tray.
+        ++m_cameraSwitchGeneration;
         m_controller->connectToCamera();
 
         // ONLY restore preview if it was enabled before hiding
@@ -1835,10 +2490,7 @@ void MainWindow::onShowHideAction()
 
 void MainWindow::onQuitAction()
 {
-    // Save config before quitting
-    if (m_controller->isConnected()) {
-        m_controller->saveConfig();
-    }
+    m_controller->saveConfig();
     QApplication::quit();
 }
 
@@ -1859,7 +2511,11 @@ void MainWindow::closeEvent(QCloseEvent *event)
             m_previewToggleButton->setChecked(false);
         }
 
-        // Disconnect from camera to free resources
+        m_controller->saveConfig();
+
+        // Disconnect from camera to free resources and cancel any delayed
+        // selector connection without discarding its staged identity.
+        ++m_cameraSwitchGeneration;
         m_controller->disconnectFromCamera();
 
         hide();
@@ -1878,11 +2534,8 @@ void MainWindow::closeEvent(QCloseEvent *event)
         }
     } else {
         std::cout << "[MainWindow] closeEvent: Quitting application" << std::endl;
-        // Actually quit the application
-        // Save config before quitting
-        if (m_controller->isConnected()) {
-            m_controller->saveConfig();
-        }
+        // Persist explicit intent even if the camera disconnected first.
+        m_controller->saveConfig();
         if (m_previewWidget->isPreviewEnabled()) {
             m_previewToggleButton->setChecked(false);
         }
@@ -1999,31 +2652,72 @@ void MainWindow::onVirtualCameraError(const QString &message)
     updateVirtualCameraStreamerState();
 }
 
-void MainWindow::onVideoEffectsChanged(const FilterPreviewWidget::VideoEffectsSettings &settings)
+void MainWindow::onVideoEffectsChanged(
+    const FilterPreviewWidget::VideoEffectsSettings &settings)
 {
     if (!m_previewWidget) {
         return;
     }
+    // Rendering updates are intentionally separate from persisted operator
+    // crop intent. Startup, mirror sync, and scene recall all use this path.
     m_previewWidget->setVideoEffects(settings);
     m_trackingWidget->setMirrored(settings.horizontalFlip);
+}
 
-    const PaperCropSettings crop = settings.paperCrop.normalized();
-    auto configSettings = m_controller->getConfig().getSettings();
-    const PaperCropSettings savedCrop = {
-        static_cast<PaperCropMode>(configSettings.paperCropMode),
-        static_cast<float>(configSettings.paperCropLeft),
-        static_cast<float>(configSettings.paperCropTop),
-        static_cast<float>(configSettings.paperCropRight),
-        static_cast<float>(configSettings.paperCropBottom)
+void MainWindow::onPaperCropIntentEdited(
+    const PaperCropSettings &requestedCrop)
+{
+    const PaperCropSettings crop = requestedCrop.normalized();
+    const auto previousSettings =
+        m_controller->getConfig().getSettings();
+    const PaperCropSettings previousCrop{
+        static_cast<PaperCropMode>(previousSettings.paperCropMode),
+        static_cast<float>(previousSettings.paperCropLeft),
+        static_cast<float>(previousSettings.paperCropTop),
+        static_cast<float>(previousSettings.paperCropRight),
+        static_cast<float>(previousSettings.paperCropBottom)
     };
-    if (crop != savedCrop) {
-        configSettings.paperCropMode = static_cast<int>(crop.mode);
-        configSettings.paperCropLeft = crop.left;
-        configSettings.paperCropTop = crop.top;
-        configSettings.paperCropRight = crop.right;
-        configSettings.paperCropBottom = crop.bottom;
-        m_controller->getConfig().setSettings(configSettings);
-        m_controller->saveConfig();
+    auto settings = previousSettings;
+    settings.paperCropMode = static_cast<int>(crop.mode);
+    settings.paperCropLeft = crop.left;
+    settings.paperCropTop = crop.top;
+    settings.paperCropRight = crop.right;
+    settings.paperCropBottom = crop.bottom;
+
+    const bool requiresDesk =
+        crop.mode == PaperCropMode::Automatic
+        && m_controller->isConnected()
+        && m_controller->hasTiny2Capabilities();
+    TrackingIntentState tracking = trackingIntentFromSettings(settings);
+    if (requiresDesk) {
+        tracking = applyAutomaticPaperCropTrackingPolicy(
+            static_cast<int>(crop.mode),
+            true,
+            tracking,
+            settings.trackingModeProfiles);
+        storeTrackingIntent(settings, tracking, false);
+    }
+
+    // Crop and any required Desk/profile transition are one persisted commit.
+    // If the atomic file replacement fails, restore both the in-memory intent
+    // and the already-rendered crop before issuing any camera command.
+    m_controller->getConfig().setSettings(settings);
+    if (!m_controller->saveConfig()) {
+        m_controller->getConfig().setSettings(previousSettings);
+        if (m_effectsWidget) {
+            m_effectsWidget->applyPaperCropForScene(previousCrop);
+        }
+        if (m_statusLabel) {
+            m_statusLabel->setText(tr(
+                "Could not save paper-crop scene; previous scene retained."));
+        }
+        qWarning() << "MainWindow: paper-crop scene persistence failed; "
+                      "Desk transition cancelled";
+        return;
+    }
+
+    if (requiresDesk) {
+        m_trackingWidget->applyTrackingState(tracking);
     }
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1465,7 +1465,9 @@ void MainWindow::onCameraConnected(const CameraController::CameraInfo &info)
                 // ownership plus the global profile for that mode. It never
                 // pushes the prior camera's PTZ/image state, and the adopted
                 // intent is persisted so reconnect cannot reverse the switch.
-                auto settings = m_controller->getConfig().getSettings();
+                const auto previousSettings =
+                    m_controller->getConfig().getSettings();
+                auto settings = previousSettings;
                 const bool tiny2 = m_controller->hasTiny2Capabilities();
                 const bool stableTiny2Mode = state.aiMode
                         >= Device::AiWorkModeNone
@@ -1536,14 +1538,25 @@ void MainWindow::onCameraConnected(const CameraController::CameraInfo &info)
                         state.audioAutoGainEnabled;
                 }
                 m_controller->getConfig().setSettings(settings);
-                m_controller->saveConfig();
+                if (!m_controller->saveConfig()) {
+                    m_controller->getConfig().setSettings(previousSettings);
+                    if (m_statusLabel) {
+                        m_statusLabel->setText(tr(
+                            "Selected camera retained its current state: adopted intent could not be saved."));
+                    }
+                    qWarning() << "MainWindow: selected-camera intent was not "
+                                  "applied because persistence failed";
+                    return;
+                }
                 m_trackingWidget->applyTrackingState(selectedTracking);
             } else {
                 // V4L2 cannot prove AI ownership or expose all camera state.
                 // Persist a safe off intent and invalidate every camera-bound
                 // category so a later SDK reconnect cannot apply the prior
                 // camera's movement or image values.
-                auto settings = m_controller->getConfig().getSettings();
+                const auto previousSettings =
+                    m_controller->getConfig().getSettings();
+                auto settings = previousSettings;
                 const TrackingIntentState safeOff{
                     false,
                     Device::AiWorkModeNone,
@@ -1560,7 +1573,16 @@ void MainWindow::onCameraConnected(const CameraController::CameraInfo &info)
                 settings.zoomIntentDefined = false;
                 settings.imageIntentDefined = false;
                 m_controller->getConfig().setSettings(settings);
-                m_controller->saveConfig();
+                if (!m_controller->saveConfig()) {
+                    m_controller->getConfig().setSettings(previousSettings);
+                    if (m_statusLabel) {
+                        m_statusLabel->setText(tr(
+                            "Selected V4L2 camera safe intent could not be saved."));
+                    }
+                    qWarning() << "MainWindow: selected V4L2 safe intent "
+                                  "persistence failed";
+                    return;
+                }
                 m_trackingWidget->setTrackingStatePresentation(safeOff);
             }
         } else if (initialApplicationWasPending) {
@@ -1845,9 +1867,20 @@ bool MainWindow::enforceAutomaticPaperCropTrackingPolicy()
             current,
             settings.trackingModeProfiles);
     if (effective != current) {
+        const auto previousSettings = settings;
         storeTrackingIntent(settings, effective, false);
         m_controller->getConfig().setSettings(settings);
-        m_controller->saveConfig();
+        if (!m_controller->saveConfig()) {
+            m_controller->getConfig().setSettings(previousSettings);
+            m_trackingWidget->setTrackingStatePresentation(current);
+            if (m_statusLabel) {
+                m_statusLabel->setText(tr(
+                    "Could not persist Automatic crop Desk mode; previous tracking retained."));
+            }
+            qWarning() << "MainWindow: Automatic crop Desk persistence "
+                          "failed; camera transition cancelled";
+            return false;
+        }
     }
     m_trackingWidget->setTrackingStatePresentation(effective);
     return true;
@@ -2303,15 +2336,61 @@ void MainWindow::onCameraSelectorChanged(int index)
         return;
     }
 
-    // Stage the exact target synchronously. Any D-Bus recall, reconnect,
-    // minimize, or tray transition during the release delay will therefore
-    // reconnect to this selection rather than the previous camera.
+    const QString previousDevicePath = m_controller->selectedDevicePath();
+    const QString previousSerial = m_controller->selectedDeviceSerial();
+    const auto previousSettings =
+        m_controller->getConfig().getSettings();
+    auto safeSettings = previousSettings;
+    const TrackingIntentState safeSwitchIntent{
+        false,
+        Device::AiWorkModeNone,
+        0,
+        {
+            TrackingFocusPolicy::Manual,
+            50,
+            false,
+            safeSettings.activeTrackingProfile.trackSpeed
+        }
+    };
+    storeTrackingIntent(safeSettings, safeSwitchIntent, false);
+    safeSettings.panTiltIntentDefined = false;
+    safeSettings.zoomIntentDefined = false;
+    safeSettings.imageIntentDefined = false;
+    m_controller->getConfig().setSettings(safeSettings);
+    if (!m_controller->saveConfig()) {
+        m_controller->getConfig().setSettings(previousSettings);
+        for (int previousIndex = 0;
+             previousIndex < m_detectedCameras.size(); ++previousIndex) {
+            const auto &candidate = m_detectedCameras[previousIndex];
+            const bool serialMatches = !previousSerial.isEmpty()
+                && candidate.serial == previousSerial;
+            const bool pathMatches = previousSerial.isEmpty()
+                && candidate.devicePath == previousDevicePath;
+            if (serialMatches || pathMatches) {
+                const bool wasBlocked =
+                    m_cameraSelectorCombo->blockSignals(true);
+                m_cameraSelectorCombo->setCurrentIndex(previousIndex);
+                m_cameraSelectorCombo->blockSignals(wasBlocked);
+                break;
+            }
+        }
+        if (m_statusLabel) {
+            m_statusLabel->setText(tr(
+                "Camera switch cancelled: safe intent could not be saved."));
+        }
+        qWarning() << "MainWindow: camera switch cancelled because safe "
+                      "intent persistence failed";
+        return;
+    }
+
+    // Stage the exact target only after the prior camera's movement/image
+    // intent has been durably invalidated. Any D-Bus recall, reconnect, or
+    // tray transition during the release delay is therefore fail-closed.
     m_controller->selectCameraTarget(cam.devicePath, cam.serial);
 
     if (m_previewToggleButton->isChecked()) {
         m_previewToggleButton->setChecked(false);
     }
-
     m_previewWidget->setCameraDeviceId(cam.devicePath);
 
     // Brief delay after disconnect so the SDK releases the previous device
@@ -2321,28 +2400,6 @@ void MainWindow::onCameraSelectorChanged(int index)
     const QString devicePath = cam.devicePath;
     const QString serialNumber = cam.serial;
     const quint64 switchGeneration = ++m_cameraSwitchGeneration;
-
-    // Invalidate prior-camera intent before any asynchronous release/connect
-    // window. If the switch is interrupted, every subsequent reconnect still
-    // sees a safe tracking-off state with no old movement/image categories.
-    auto settings = m_controller->getConfig().getSettings();
-    const TrackingIntentState safeSwitchIntent{
-        false,
-        Device::AiWorkModeNone,
-        0,
-        {
-            TrackingFocusPolicy::Manual,
-            50,
-            false,
-            settings.activeTrackingProfile.trackSpeed
-        }
-    };
-    storeTrackingIntent(settings, safeSwitchIntent, false);
-    settings.panTiltIntentDefined = false;
-    settings.zoomIntentDefined = false;
-    settings.imageIntentDefined = false;
-    m_controller->getConfig().setSettings(settings);
-    m_controller->saveConfig();
 
     m_controller->disconnectFromCamera();
     // disconnectFromCamera() emits cameraDisconnected synchronously; arm the

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -9,6 +9,7 @@
 #include <QVBoxLayout>
 #include <QSystemTrayIcon>
 #include <QMenu>
+#include <functional>
 #include "CameraController.h"
 #include "TrackingControlWidget.h"
 #include "PTZControlWidget.h"
@@ -69,6 +70,7 @@ private slots:
     void onVirtualCameraResolutionChanged(int index);
     void onVirtualCameraError(const QString &message);
     void onVideoEffectsChanged(const FilterPreviewWidget::VideoEffectsSettings &settings);
+    void onPaperCropIntentEdited(const PaperCropSettings &settings);
     void onSnapshotCaptured(const QImage &image);
     void onSnapshotDirectoryEdited();
 
@@ -89,6 +91,15 @@ private:
     void updateVirtualCameraAvailability(const QString &devicePath);
     void updateVirtualCameraStreamerState();
     void fitTabToCurrentPage();
+    void updatePersistedIntent(
+        const std::function<void(Config::CameraSettings &)> &update);
+    TrackingIntentState trackingIntentFromSettings(
+        const Config::CameraSettings &settings) const;
+    void storeTrackingIntent(
+        Config::CameraSettings &settings,
+        const TrackingIntentState &tracking,
+        bool updateModeProfile) const;
+    bool enforceAutomaticPaperCropTrackingPolicy();
 
     // Controller
     CameraController *m_controller;
@@ -96,10 +107,16 @@ private:
     // Camera selector (shown only when >1 OBSBOT camera is detected)
     QComboBox *m_cameraSelectorCombo {nullptr};
     QLabel *m_cameraSelectorLabel {nullptr};
-    struct DetectedCamera { QString label; QString devicePath; QString serial; };
+    struct DetectedCamera {
+        QString label;
+        QString devicePath;
+        QString serial;
+        bool available {true};
+    };
     QList<DetectedCamera> m_detectedCameras;
     void populateCameraSelector();
     bool m_isCameraSwitch {false};
+    quint64 m_cameraSwitchGeneration {0};
 
     // UI
     QPushButton *m_previewToggleButton;
@@ -156,6 +173,8 @@ private:
     bool m_isApplyingStyle;
     bool m_virtualCameraErrorNotified;
     bool m_virtualCameraAvailable;
+    bool m_initialCameraStateApplied {false};
+    bool m_remoteRecallInProgress {false};
     bool m_dbusRegistered {false};
     int m_pendingRemotePreset {-1};
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -34,12 +34,16 @@ class VirtualCameraStreamer;
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "com.obsbot.CameraControl")
 
 public:
     explicit MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
 
     bool isStartingMinimized() const;
+
+public slots:
+    Q_SCRIPTABLE bool recallPreset(int presetNumber);
 
 private slots:
     void onCameraSelectorChanged(int index);
@@ -54,7 +58,7 @@ private slots:
     void onPreviewStarted();
     void onPreviewFailed(const QString &error);
     void onPreviewFormatChanged(const QString &formatId);
-    void onPresetUpdated(int index, double pan, double tilt, double zoom, bool defined);
+    void onPresetUpdated(int index);
     void onTrayIconActivated(QSystemTrayIcon::ActivationReason reason);
     void onShowHideAction();
     void onQuitAction();
@@ -152,6 +156,8 @@ private:
     bool m_isApplyingStyle;
     bool m_virtualCameraErrorNotified;
     bool m_virtualCameraAvailable;
+    bool m_dbusRegistered {false};
+    int m_pendingRemotePreset {-1};
 
 protected:
     bool event(QEvent *event) override;

--- a/src/gui/PTZControlWidget.cpp
+++ b/src/gui/PTZControlWidget.cpp
@@ -2,15 +2,33 @@
 #include "CameraSettingsWidget.h"
 #include <QVBoxLayout>
 #include <QHBoxLayout>
+#include <QKeySequence>
+#include <QShortcut>
+#include <cmath>
 
 PTZControlWidget::PTZControlWidget(CameraController *controller, QWidget *parent)
     : QWidget(parent)
     , m_controller(controller)
     , m_settingsWidget(nullptr)
+    , m_cameraAvailable(controller->isConnected())
 {
     QVBoxLayout *layout = new QVBoxLayout(this);
     layout->setContentsMargins(8, 14, 8, 14);
     layout->setSpacing(14);
+
+    connect(m_controller, &CameraController::cameraConnected, this,
+            [this](const CameraController::CameraInfo &) {
+                m_cameraAvailable = true;
+                for (int i = 0; i < static_cast<int>(m_presets.size()); ++i) {
+                    updatePresetLabel(i);
+                }
+            });
+    connect(m_controller, &CameraController::cameraDisconnected, this, [this]() {
+        m_cameraAvailable = false;
+        for (int i = 0; i < static_cast<int>(m_presets.size()); ++i) {
+            updatePresetLabel(i);
+        }
+    });
 
     // Presets section
     QGroupBox *presetGroup = new QGroupBox("Camera Presets", this);
@@ -39,6 +57,14 @@ PTZControlWidget::PTZControlWidget(CameraController *controller, QWidget *parent
         presetUi.recallButton->setProperty("presetIndex", i);
         presetUi.recallButton->setEnabled(false);
         connect(presetUi.recallButton, &QPushButton::clicked, this, &PTZControlWidget::onRecallPreset);
+        const QKeySequence shortcutKey(QString("Ctrl+%1").arg(i + 1));
+        presetUi.recallButton->setToolTip(
+            QString("Recall this position (%1)").arg(shortcutKey.toString(QKeySequence::NativeText)));
+        auto *shortcut = new QShortcut(shortcutKey, this);
+        shortcut->setContext(Qt::ApplicationShortcut);
+        connect(shortcut, &QShortcut::activated, this, [this, i]() {
+            recallPreset(i);
+        });
         row->addWidget(presetUi.recallButton);
 
         presetUi.saveButton = new QPushButton("Save", this);
@@ -52,6 +78,9 @@ PTZControlWidget::PTZControlWidget(CameraController *controller, QWidget *parent
     }
 
     layout->addWidget(presetGroup);
+
+    QLabel *shortcutHint = new QLabel("Recall shortcuts: Ctrl+1, Ctrl+2, Ctrl+3", this);
+    presetLayout->addWidget(shortcutHint);
 
     // Image Quality Presets section
     QGroupBox *imagePresetGroup = new QGroupBox("Image Quality Presets", this);
@@ -115,28 +144,39 @@ std::array<PTZControlWidget::PresetState, 3> PTZControlWidget::currentPresets() 
     return out;
 }
 
+bool PTZControlWidget::recallPreset(int index)
+{
+    if (!m_cameraAvailable || index < 0 || index >= static_cast<int>(m_presets.size())) {
+        return false;
+    }
+
+    const auto &preset = m_presets[static_cast<size_t>(index)];
+    const bool valid = std::isfinite(preset.pan) && preset.pan >= -1.0 && preset.pan <= 1.0
+        && std::isfinite(preset.tilt) && preset.tilt >= -1.0 && preset.tilt <= 1.0
+        && std::isfinite(preset.zoom) && preset.zoom >= 1.0 && preset.zoom <= 2.0;
+    if (!preset.defined || !valid) {
+        return false;
+    }
+
+    const bool panTiltApplied = m_controller->setPanTilt(preset.pan, preset.tilt);
+    const bool zoomApplied = m_controller->setZoom(preset.zoom);
+    return panTiltApplied && zoomApplied;
+}
+
 void PTZControlWidget::onRecallPreset()
 {
     auto *button = qobject_cast<QPushButton*>(sender());
-    if (!button) {
-        return;
+    if (button) {
+        recallPreset(button->property("presetIndex").toInt());
     }
-    int index = button->property("presetIndex").toInt();
-    if (index < 0 || index >= static_cast<int>(m_presets.size())) {
-        return;
-    }
-
-    auto &preset = m_presets[static_cast<size_t>(index)];
-    if (!preset.defined) {
-        return;
-    }
-
-    m_controller->setPanTilt(preset.pan, preset.tilt);
-    m_controller->setZoom(preset.zoom);
 }
 
 void PTZControlWidget::onStorePreset()
 {
+    if (!m_cameraAvailable) {
+        return;
+    }
+
     auto *button = qobject_cast<QPushButton*>(sender());
     if (!button) {
         return;
@@ -178,7 +218,10 @@ void PTZControlWidget::updatePresetLabel(int index)
     }
 
     if (preset.recallButton) {
-        preset.recallButton->setEnabled(preset.defined);
+        preset.recallButton->setEnabled(m_cameraAvailable && preset.defined);
+    }
+    if (preset.saveButton) {
+        preset.saveButton->setEnabled(m_cameraAvailable);
     }
 }
 

--- a/src/gui/PTZControlWidget.cpp
+++ b/src/gui/PTZControlWidget.cpp
@@ -1,5 +1,7 @@
 #include "PTZControlWidget.h"
 #include "CameraSettingsWidget.h"
+#include "TrackingControlWidget.h"
+#include "VideoEffectsWidget.h"
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QKeySequence>
@@ -10,6 +12,8 @@ PTZControlWidget::PTZControlWidget(CameraController *controller, QWidget *parent
     : QWidget(parent)
     , m_controller(controller)
     , m_settingsWidget(nullptr)
+    , m_trackingWidget(nullptr)
+    , m_effectsWidget(nullptr)
     , m_cameraAvailable(controller->isConnected())
 {
     QVBoxLayout *layout = new QVBoxLayout(this);
@@ -42,6 +46,12 @@ PTZControlWidget::PTZControlWidget(CameraController *controller, QWidget *parent
         presetUi.pan = 0.0;
         presetUi.tilt = 0.0;
         presetUi.zoom = 1.0;
+        presetUi.sceneDefined = false;
+        presetUi.trackingEnabled = false;
+        presetUi.aiMode = 0;
+        presetUi.aiSubMode = 0;
+        presetUi.autoZoom = false;
+        presetUi.paperCrop = {};
 
         QHBoxLayout *row = new QHBoxLayout();
         row->setSpacing(8);
@@ -130,6 +140,12 @@ void PTZControlWidget::applyPresetStates(const std::array<PresetState, 3> &prese
         ui.pan = preset.pan;
         ui.tilt = preset.tilt;
         ui.zoom = preset.zoom;
+        ui.sceneDefined = preset.sceneDefined;
+        ui.trackingEnabled = preset.trackingEnabled;
+        ui.aiMode = preset.aiMode;
+        ui.aiSubMode = preset.aiSubMode;
+        ui.autoZoom = preset.autoZoom;
+        ui.paperCrop = preset.paperCrop;
         updatePresetLabel(i);
     }
 }
@@ -139,28 +155,71 @@ std::array<PTZControlWidget::PresetState, 3> PTZControlWidget::currentPresets() 
     std::array<PresetState, 3> out{};
     for (int i = 0; i < 3; ++i) {
         const auto &ui = m_presets[static_cast<size_t>(i)];
-        out[static_cast<size_t>(i)] = {ui.defined, ui.pan, ui.tilt, ui.zoom};
+        out[static_cast<size_t>(i)] = {
+            ui.defined,
+            ui.pan,
+            ui.tilt,
+            ui.zoom,
+            ui.sceneDefined,
+            ui.trackingEnabled,
+            ui.aiMode,
+            ui.aiSubMode,
+            ui.autoZoom,
+            ui.paperCrop
+        };
     }
     return out;
 }
 
-bool PTZControlWidget::recallPreset(int index)
+bool PTZControlWidget::canRecallPreset(int index) const
 {
-    if (!m_cameraAvailable || index < 0 || index >= static_cast<int>(m_presets.size())) {
+    if (index < 0 || index >= static_cast<int>(m_presets.size())) {
         return false;
     }
 
     const auto &preset = m_presets[static_cast<size_t>(index)];
-    const bool valid = std::isfinite(preset.pan) && preset.pan >= -1.0 && preset.pan <= 1.0
+    return preset.defined
+        && std::isfinite(preset.pan) && preset.pan >= -1.0 && preset.pan <= 1.0
         && std::isfinite(preset.tilt) && preset.tilt >= -1.0 && preset.tilt <= 1.0
-        && std::isfinite(preset.zoom) && preset.zoom >= 1.0 && preset.zoom <= 2.0;
-    if (!preset.defined || !valid) {
+        && std::isfinite(preset.zoom) && preset.zoom >= 1.0 && preset.zoom <= 2.0
+        && (!preset.sceneDefined || preset.paperCrop.isValid());
+}
+
+bool PTZControlWidget::recallPreset(int index)
+{
+    if (!m_cameraAvailable || !canRecallPreset(index)) {
         return false;
+    }
+
+    const auto &preset = m_presets[static_cast<size_t>(index)];
+
+    if (preset.sceneDefined && m_effectsWidget) {
+        auto effects = m_effectsWidget->settings();
+        effects.paperCrop = preset.paperCrop;
+        m_effectsWidget->applySettings(effects);
+    }
+
+    bool trackingApplied = true;
+    if (preset.sceneDefined && m_trackingWidget) {
+        trackingApplied = m_trackingWidget->applyTrackingState({
+            preset.trackingEnabled,
+            preset.aiMode,
+            preset.aiSubMode,
+            preset.autoZoom
+        });
+    } else if (!preset.sceneDefined && m_trackingWidget) {
+        auto tracking = m_trackingWidget->trackingState();
+        tracking.enabled = false;
+        trackingApplied = m_trackingWidget->applyTrackingState(tracking);
+    }
+
+    if (preset.sceneDefined && preset.trackingEnabled) {
+        return trackingApplied;
     }
 
     const bool panTiltApplied = m_controller->setPanTilt(preset.pan, preset.tilt);
     const bool zoomApplied = m_controller->setZoom(preset.zoom);
-    return panTiltApplied && zoomApplied;
+    return trackingApplied && panTiltApplied && zoomApplied;
 }
 
 void PTZControlWidget::onRecallPreset()
@@ -192,9 +251,20 @@ void PTZControlWidget::onStorePreset()
     preset.pan = state.pan;
     preset.tilt = state.tilt;
     preset.zoom = state.zoom;
+    if (m_trackingWidget) {
+        const auto tracking = m_trackingWidget->trackingState();
+        preset.sceneDefined = true;
+        preset.trackingEnabled = tracking.enabled;
+        preset.aiMode = tracking.aiMode;
+        preset.aiSubMode = tracking.aiSubMode;
+        preset.autoZoom = tracking.autoZoom;
+    }
+    if (m_effectsWidget) {
+        preset.paperCrop = m_effectsWidget->settings().paperCrop;
+    }
     updatePresetLabel(index);
 
-    emit presetUpdated(index, preset.pan, preset.tilt, preset.zoom, true);
+    emit presetUpdated(index);
 }
 
 void PTZControlWidget::updatePresetLabel(int index)
@@ -208,11 +278,35 @@ void PTZControlWidget::updatePresetLabel(int index)
     }
 
     if (preset.defined) {
-        preset.statusLabel->setText(
-            QString("Pan %1, Tilt %2, Zoom %3x")
-                .arg(preset.pan, 0, 'f', 2)
-                .arg(preset.tilt, 0, 'f', 2)
-                .arg(preset.zoom, 0, 'f', 1));
+        QString modeLabel = tr("Position");
+        if (preset.sceneDefined) {
+            if (!preset.trackingEnabled) {
+                modeLabel = tr("Manual");
+            } else if (preset.aiMode == 5) {
+                modeLabel = tr("Desk tracking");
+            } else {
+                modeLabel = tr("Tracking");
+            }
+        }
+
+        QString cropLabel;
+        if (preset.paperCrop.mode == PaperCropMode::Automatic) {
+            cropLabel = tr(" · Auto crop");
+        } else if (preset.paperCrop.mode == PaperCropMode::Manual) {
+            cropLabel = tr(" · Manual crop");
+        }
+
+        if (preset.sceneDefined && preset.trackingEnabled) {
+            preset.statusLabel->setText(modeLabel + cropLabel);
+        } else {
+            preset.statusLabel->setText(
+                QString("%1 · Pan %2, Tilt %3, Zoom %4x%5")
+                    .arg(modeLabel)
+                    .arg(preset.pan, 0, 'f', 2)
+                    .arg(preset.tilt, 0, 'f', 2)
+                    .arg(preset.zoom, 0, 'f', 1)
+                    .arg(cropLabel));
+        }
     } else {
         preset.statusLabel->setText("Empty");
     }

--- a/src/gui/PTZControlWidget.cpp
+++ b/src/gui/PTZControlWidget.cpp
@@ -6,7 +6,46 @@
 #include <QHBoxLayout>
 #include <QKeySequence>
 #include <QShortcut>
+#include <QTimer>
 #include <cmath>
+
+namespace {
+
+TrackingModeProfile trackingProfileFromPreset(
+    const PTZControlWidget::PresetState &preset)
+{
+    return {
+        preset.focusPolicy,
+        preset.manualFocusPosition,
+        preset.autoZoom,
+        preset.trackSpeed
+    };
+}
+
+TrackingIntentState trackingIntentFromPreset(
+    const PTZControlWidget::PresetState &preset)
+{
+    return {
+        preset.trackingEnabled,
+        preset.aiMode,
+        preset.aiSubMode,
+        trackingProfileFromPreset(preset)
+    };
+}
+
+void updatePresetTracking(PTZControlWidget::PresetState &preset,
+                          const TrackingIntentState &tracking)
+{
+    preset.trackingEnabled = tracking.enabled;
+    preset.aiMode = tracking.aiMode;
+    preset.aiSubMode = tracking.aiSubMode;
+    preset.autoZoom = tracking.profile.autoZoom;
+    preset.focusPolicy = tracking.profile.focusPolicy;
+    preset.manualFocusPosition = tracking.profile.manualFocusPosition;
+    preset.trackSpeed = tracking.profile.trackSpeed;
+}
+
+} // namespace
 
 PTZControlWidget::PTZControlWidget(CameraController *controller, QWidget *parent)
     : QWidget(parent)
@@ -29,10 +68,70 @@ PTZControlWidget::PTZControlWidget(CameraController *controller, QWidget *parent
             });
     connect(m_controller, &CameraController::cameraDisconnected, this, [this]() {
         m_cameraAvailable = false;
+        const bool recallWasPending = hasPendingRecall();
+        cancelPendingRecall();
+        if (recallWasPending) {
+            emit presetRecallFinished(false);
+        }
         for (int i = 0; i < static_cast<int>(m_presets.size()); ++i) {
             updatePresetLabel(i);
         }
     });
+    connect(m_controller, &CameraController::trackingIntentStarted,
+            this, [this](quint64 intentGeneration) {
+                if (m_pendingRecall
+                    && intentGeneration
+                        > m_pendingRecall->trackingIntentGeneration) {
+                    cancelPendingRecall();
+                    emit presetRecallFinished(false);
+                }
+            });
+    connect(m_controller, &CameraController::trackingStateConfirmed,
+            this, [this](bool trackingEnabled, quint64 intentGeneration) {
+                if (!m_pendingRecall || m_completionQueued
+                    || m_pendingRecall->trackingIntentGeneration
+                        != intentGeneration) {
+                    return;
+                }
+                if (m_pendingRecall->preset.trackingEnabled != trackingEnabled) {
+                    cancelPendingRecall();
+                    emit presetRecallFinished(false);
+                    return;
+                }
+
+                const PendingRecall pending = *m_pendingRecall;
+                m_completionQueued = true;
+                QTimer::singleShot(0, this, [this, pending]() {
+                    if (!m_pendingRecall
+                        || pending.generation != m_recallGeneration
+                        || pending.trackingIntentGeneration
+                            != m_pendingRecall->trackingIntentGeneration) {
+                        return;
+                    }
+                    const PresetState preset = m_pendingRecall->preset;
+                    m_pendingRecall.reset();
+                    m_completionQueued = false;
+                    emit presetRecallFinished(finishPresetRecall(preset));
+                });
+            });
+    connect(m_controller, &CameraController::trackingStateConfirmationFailed,
+            this, [this](bool, quint64 intentGeneration) {
+                if (m_pendingRecall
+                    && m_pendingRecall->trackingIntentGeneration
+                        == intentGeneration) {
+                    cancelPendingRecall();
+                    emit presetRecallFinished(false);
+                }
+            });
+    connect(m_controller, &CameraController::trackingStateConfirmationUncertain,
+            this, [this](quint64 intentGeneration) {
+                if (m_pendingRecall
+                    && m_pendingRecall->trackingIntentGeneration
+                        == intentGeneration) {
+                    cancelPendingRecall();
+                    emit presetRecallFinished(false);
+                }
+            });
 
     // Presets section
     QGroupBox *presetGroup = new QGroupBox("Camera Presets", this);
@@ -51,6 +150,9 @@ PTZControlWidget::PTZControlWidget(CameraController *controller, QWidget *parent
         presetUi.aiMode = 0;
         presetUi.aiSubMode = 0;
         presetUi.autoZoom = false;
+        presetUi.focusPolicy = TrackingFocusPolicy::Manual;
+        presetUi.manualFocusPosition = 50;
+        presetUi.trackSpeed = Device::AiTrackSpeedStandard;
         presetUi.paperCrop = {};
 
         QHBoxLayout *row = new QHBoxLayout();
@@ -145,6 +247,9 @@ void PTZControlWidget::applyPresetStates(const std::array<PresetState, 3> &prese
         ui.aiMode = preset.aiMode;
         ui.aiSubMode = preset.aiSubMode;
         ui.autoZoom = preset.autoZoom;
+        ui.focusPolicy = preset.focusPolicy;
+        ui.manualFocusPosition = preset.manualFocusPosition;
+        ui.trackSpeed = preset.trackSpeed;
         ui.paperCrop = preset.paperCrop;
         updatePresetLabel(i);
     }
@@ -165,6 +270,9 @@ std::array<PTZControlWidget::PresetState, 3> PTZControlWidget::currentPresets() 
             ui.aiMode,
             ui.aiSubMode,
             ui.autoZoom,
+            ui.focusPolicy,
+            ui.manualFocusPosition,
+            ui.trackSpeed,
             ui.paperCrop
         };
     }
@@ -178,11 +286,22 @@ bool PTZControlWidget::canRecallPreset(int index) const
     }
 
     const auto &preset = m_presets[static_cast<size_t>(index)];
+    const TrackingModeProfile profile{
+        preset.focusPolicy,
+        preset.manualFocusPosition,
+        preset.autoZoom,
+        preset.trackSpeed
+    };
     return preset.defined
         && std::isfinite(preset.pan) && preset.pan >= -1.0 && preset.pan <= 1.0
         && std::isfinite(preset.tilt) && preset.tilt >= -1.0 && preset.tilt <= 1.0
         && std::isfinite(preset.zoom) && preset.zoom >= 1.0 && preset.zoom <= 2.0
-        && (!preset.sceneDefined || preset.paperCrop.isValid());
+        && (!preset.sceneDefined
+            || (preset.paperCrop.isValid()
+                && isValidTrackingModeProfile(profile)
+                && (preset.trackingEnabled
+                    || (preset.focusPolicy == TrackingFocusPolicy::Manual
+                        && !preset.autoZoom))));
 }
 
 bool PTZControlWidget::recallPreset(int index)
@@ -191,35 +310,107 @@ bool PTZControlWidget::recallPreset(int index)
         return false;
     }
 
-    const auto &preset = m_presets[static_cast<size_t>(index)];
-
-    if (preset.sceneDefined && m_effectsWidget) {
-        auto effects = m_effectsWidget->settings();
-        effects.paperCrop = preset.paperCrop;
-        m_effectsWidget->applySettings(effects);
+    const auto &ui = m_presets[static_cast<size_t>(index)];
+    PresetState preset = {
+        ui.defined,
+        ui.pan,
+        ui.tilt,
+        ui.zoom,
+        ui.sceneDefined,
+        ui.trackingEnabled,
+        ui.aiMode,
+        ui.aiSubMode,
+        ui.autoZoom,
+        ui.focusPolicy,
+        ui.manualFocusPosition,
+        ui.trackSpeed,
+        ui.paperCrop
+    };
+    if (hasPendingRecall()) {
+        cancelPendingRecall();
+        emit presetRecallFinished(false);
     }
+    const quint64 recallGeneration = ++m_recallGeneration;
 
-    bool trackingApplied = true;
+    TrackingControlWidget::TrackingApplyResult trackingResult{true, false, 0};
     if (preset.sceneDefined && m_trackingWidget) {
-        trackingApplied = m_trackingWidget->applyTrackingState({
-            preset.trackingEnabled,
-            preset.aiMode,
-            preset.aiSubMode,
-            preset.autoZoom
-        });
+        TrackingIntentState tracking = trackingIntentFromPreset(preset);
+        tracking = applyAutomaticPaperCropTrackingPolicy(
+            static_cast<int>(preset.paperCrop.mode),
+            m_trackingWidget->hasTiny2Capabilities(),
+            tracking,
+            m_trackingWidget->modeProfiles());
+        updatePresetTracking(preset, tracking);
+        trackingResult = m_trackingWidget->applyTrackingState(tracking);
     } else if (!preset.sceneDefined && m_trackingWidget) {
         auto tracking = m_trackingWidget->trackingState();
         tracking.enabled = false;
-        trackingApplied = m_trackingWidget->applyTrackingState(tracking);
+        tracking.profile.focusPolicy = TrackingFocusPolicy::Manual;
+        tracking.profile.autoZoom = false;
+        updatePresetTracking(preset, tracking);
+        trackingResult = m_trackingWidget->applyTrackingState(tracking);
     }
 
-    if (preset.sceneDefined && preset.trackingEnabled) {
-        return trackingApplied;
+    if (!trackingResult.accepted) {
+        return false;
+    }
+    if (trackingResult.confirmationPending) {
+        // Never send PTZ/zoom while AI ownership is unconfirmed. Continue the
+        // accepted recall only after CameraController reports a fresh match.
+        m_pendingRecall = PendingRecall{
+            preset, recallGeneration, trackingResult.intentGeneration};
+        return true;
+    }
+    return finishPresetRecall(preset);
+}
+
+void PTZControlWidget::cancelPendingRecall()
+{
+    // Always invalidate a zero-delay continuation, even after confirmation has
+    // moved it out of the transport-pending phase.
+    ++m_recallGeneration;
+    m_pendingRecall.reset();
+    m_completionQueued = false;
+}
+
+bool PTZControlWidget::finishPresetRecall(const PresetState &preset)
+{
+    if (!m_cameraAvailable) {
+        return false;
     }
 
-    const bool panTiltApplied = m_controller->setPanTilt(preset.pan, preset.tilt);
-    const bool zoomApplied = m_controller->setZoom(preset.zoom);
-    return trackingApplied && panTiltApplied && zoomApplied;
+    if (m_trackingWidget) {
+        if (preset.sceneDefined) {
+            const TrackingControlWidget::TrackingState expected =
+                trackingIntentFromPreset(preset);
+            if (!m_trackingWidget->matchesTrackingState(expected)) {
+                return false;
+            }
+        } else if (!m_trackingWidget->isManualControlEnabled()) {
+            return false;
+        }
+    }
+
+    const bool positionApplied =
+        !(preset.sceneDefined && preset.trackingEnabled);
+    if (positionApplied) {
+        if (!m_controller->setPanTilt(preset.pan, preset.tilt)) {
+            return false;
+        }
+        if (!m_controller->setZoom(preset.zoom)) {
+            return false;
+        }
+    }
+
+    // Crop is local and infallible, so apply it last. A failed tracking/PTZ
+    // transition therefore cannot persist a partial crop-only scene recall.
+    if (preset.sceneDefined && m_effectsWidget) {
+        m_effectsWidget->applyPaperCropForScene(preset.paperCrop);
+    }
+    emit sceneIntentApplied(
+        trackingIntentFromPreset(preset), positionApplied,
+        preset.pan, preset.tilt, preset.zoom, preset.paperCrop);
+    return true;
 }
 
 void PTZControlWidget::onRecallPreset()
@@ -257,7 +448,10 @@ void PTZControlWidget::onStorePreset()
         preset.trackingEnabled = tracking.enabled;
         preset.aiMode = tracking.aiMode;
         preset.aiSubMode = tracking.aiSubMode;
-        preset.autoZoom = tracking.autoZoom;
+        preset.autoZoom = tracking.profile.autoZoom;
+        preset.focusPolicy = tracking.profile.focusPolicy;
+        preset.manualFocusPosition = tracking.profile.manualFocusPosition;
+        preset.trackSpeed = tracking.profile.trackSpeed;
     }
     if (m_effectsWidget) {
         preset.paperCrop = m_effectsWidget->settings().paperCrop;

--- a/src/gui/PTZControlWidget.h
+++ b/src/gui/PTZControlWidget.h
@@ -1,6 +1,8 @@
 #ifndef PTZCONTROLWIDGET_H
 #define PTZCONTROLWIDGET_H
 
+#include "PaperCropSettings.h"
+
 #include <QWidget>
 #include <QPushButton>
 #include <QSlider>
@@ -10,6 +12,8 @@
 #include "CameraController.h"
 
 class CameraSettingsWidget;
+class TrackingControlWidget;
+class VideoEffectsWidget;
 
 /**
  * @brief Widget for camera preset management
@@ -25,15 +29,28 @@ public:
     void setCameraSettingsWidget(CameraSettingsWidget *settingsWidget) {
         m_settingsWidget = settingsWidget;
     }
+    void setTrackingControlWidget(TrackingControlWidget *trackingWidget) {
+        m_trackingWidget = trackingWidget;
+    }
+    void setVideoEffectsWidget(VideoEffectsWidget *effectsWidget) {
+        m_effectsWidget = effectsWidget;
+    }
 
     struct PresetState {
         bool defined;
         double pan;
         double tilt;
         double zoom;
+        bool sceneDefined;
+        bool trackingEnabled;
+        int aiMode;
+        int aiSubMode;
+        bool autoZoom;
+        PaperCropSettings paperCrop;
     };
     void applyPresetStates(const std::array<PresetState, 3> &presets);
     std::array<PresetState, 3> currentPresets() const;
+    bool canRecallPreset(int index) const;
     bool recallPreset(int index);
 
     struct ImagePresetState {
@@ -55,7 +72,7 @@ public:
     std::array<ImagePresetState, 3> currentImagePresets() const;
 
 signals:
-    void presetUpdated(int index, double pan, double tilt, double zoom, bool defined);
+    void presetUpdated(int index);
     void imagePresetUpdated(int index);
 
 private slots:
@@ -67,6 +84,8 @@ private slots:
 private:
     CameraController *m_controller;
     CameraSettingsWidget *m_settingsWidget;
+    TrackingControlWidget *m_trackingWidget;
+    VideoEffectsWidget *m_effectsWidget;
     bool m_cameraAvailable;
 
     struct PresetUi {
@@ -77,6 +96,12 @@ private:
         double pan;
         double tilt;
         double zoom;
+        bool sceneDefined;
+        bool trackingEnabled;
+        int aiMode;
+        int aiSubMode;
+        bool autoZoom;
+        PaperCropSettings paperCrop;
     };
 
     struct ImagePresetUi {

--- a/src/gui/PTZControlWidget.h
+++ b/src/gui/PTZControlWidget.h
@@ -34,6 +34,7 @@ public:
     };
     void applyPresetStates(const std::array<PresetState, 3> &presets);
     std::array<PresetState, 3> currentPresets() const;
+    bool recallPreset(int index);
 
     struct ImagePresetState {
         bool defined;
@@ -66,6 +67,7 @@ private slots:
 private:
     CameraController *m_controller;
     CameraSettingsWidget *m_settingsWidget;
+    bool m_cameraAvailable;
 
     struct PresetUi {
         QPushButton *recallButton;

--- a/src/gui/PTZControlWidget.h
+++ b/src/gui/PTZControlWidget.h
@@ -9,11 +9,13 @@
 #include <QLabel>
 #include <QGroupBox>
 #include <array>
+#include <optional>
 #include "CameraController.h"
 
 class CameraSettingsWidget;
 class TrackingControlWidget;
 class VideoEffectsWidget;
+struct PTZControlWidgetTestAccess;
 
 /**
  * @brief Widget for camera preset management
@@ -46,12 +48,19 @@ public:
         int aiMode;
         int aiSubMode;
         bool autoZoom;
+        TrackingFocusPolicy focusPolicy;
+        int manualFocusPosition;
+        int trackSpeed;
         PaperCropSettings paperCrop;
     };
     void applyPresetStates(const std::array<PresetState, 3> &presets);
     std::array<PresetState, 3> currentPresets() const;
     bool canRecallPreset(int index) const;
     bool recallPreset(int index);
+    bool hasPendingRecall() const {
+        return m_pendingRecall.has_value() || m_completionQueued;
+    }
+    void cancelPendingRecall();
 
     struct ImagePresetState {
         bool defined;
@@ -74,6 +83,11 @@ public:
 signals:
     void presetUpdated(int index);
     void imagePresetUpdated(int index);
+    void presetRecallFinished(bool success);
+    void sceneIntentApplied(
+        const TrackingIntentState &tracking,
+        bool positionApplied, double pan, double tilt, double zoom,
+        const PaperCropSettings &paperCrop);
 
 private slots:
     void onRecallPreset();
@@ -83,6 +97,7 @@ private slots:
 
 private:
     CameraController *m_controller;
+    friend struct PTZControlWidgetTestAccess;
     CameraSettingsWidget *m_settingsWidget;
     TrackingControlWidget *m_trackingWidget;
     VideoEffectsWidget *m_effectsWidget;
@@ -101,6 +116,9 @@ private:
         int aiMode;
         int aiSubMode;
         bool autoZoom;
+        TrackingFocusPolicy focusPolicy;
+        int manualFocusPosition;
+        int trackSpeed;
         PaperCropSettings paperCrop;
     };
 
@@ -113,8 +131,17 @@ private:
 
     std::array<PresetUi, 3> m_presets;
     std::array<ImagePresetUi, 3> m_imagePresets;
+    struct PendingRecall {
+        PresetState preset;
+        quint64 generation;
+        quint64 trackingIntentGeneration;
+    };
+    std::optional<PendingRecall> m_pendingRecall;
+    quint64 m_recallGeneration = 0;
+    bool m_completionQueued = false;
 
     void updatePresetLabel(int index);
+    bool finishPresetRecall(const PresetState &preset);
     void updateImagePresetLabel(int index);
 };
 

--- a/src/gui/PaperCropProcessor.cpp
+++ b/src/gui/PaperCropProcessor.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <limits>
 #include <vector>
 
 #ifdef OBSBOT_HAS_OPENCV
@@ -58,33 +59,105 @@ float pointDistance(const cv::Point2f &a, const cv::Point2f &b)
 
 Quad orderQuad(const std::vector<cv::Point> &points)
 {
-    Quad ordered{};
-    auto minSum = points.front();
-    auto maxSum = points.front();
-    auto minDiff = points.front();
-    auto maxDiff = points.front();
-
+    std::vector<cv::Point2f> cyclic;
+    cyclic.reserve(points.size());
+    cv::Point2f center(0.0f, 0.0f);
     for (const cv::Point &point : points) {
-        if (point.x + point.y < minSum.x + minSum.y) minSum = point;
-        if (point.x + point.y > maxSum.x + maxSum.y) maxSum = point;
-        if (point.x - point.y < minDiff.x - minDiff.y) minDiff = point;
-        if (point.x - point.y > maxDiff.x - maxDiff.y) maxDiff = point;
+        cyclic.emplace_back(point);
+        center += cv::Point2f(point);
     }
+    center *= 1.0f / static_cast<float>(cyclic.size());
 
-    ordered[0] = cv::Point2f(minSum);  // top-left
-    ordered[1] = cv::Point2f(maxDiff); // top-right
-    ordered[2] = cv::Point2f(maxSum);  // bottom-right
-    ordered[3] = cv::Point2f(minDiff); // bottom-left
+    std::sort(cyclic.begin(), cyclic.end(), [center](const auto &a, const auto &b) {
+        return std::atan2(a.y - center.y, a.x - center.x)
+            < std::atan2(b.y - center.y, b.x - center.x);
+    });
+
+    // Start at the top-left-like corner while retaining cyclic order. Unlike
+    // sum/difference extrema, this never assigns one symmetric diamond corner
+    // to two output positions.
+    const auto first = std::min_element(cyclic.begin(), cyclic.end(), [](const auto &a, const auto &b) {
+        const float aSum = a.x + a.y;
+        const float bSum = b.x + b.y;
+        return aSum == bSum ? a.y < b.y : aSum < bSum;
+    });
+    std::rotate(cyclic.begin(), first, cyclic.end());
+
+    Quad ordered{};
+    std::copy_n(cyclic.begin(), ordered.size(), ordered.begin());
     return ordered;
+}
+
+float squaredDistance(const cv::Point2f &a, const cv::Point2f &b)
+{
+    const cv::Point2f delta = a - b;
+    return delta.x * delta.x + delta.y * delta.y;
+}
+
+Quad alignQuadToReference(const Quad &candidate, const Quad &reference)
+{
+    Quad aligned = candidate;
+    float bestScore = std::numeric_limits<float>::max();
+    for (int shift = 0; shift < 4; ++shift) {
+        float score = 0.0f;
+        for (int i = 0; i < 4; ++i) {
+            score += squaredDistance(reference[i], candidate[(i + shift) % 4]);
+        }
+        if (score < bestScore) {
+            bestScore = score;
+            for (int i = 0; i < 4; ++i) {
+                aligned[i] = candidate[(i + shift) % 4];
+            }
+        }
+    }
+    return aligned;
+}
+
+float maximumCornerDistance(const Quad &left, const Quad &right)
+{
+    float maximum = 0.0f;
+    for (int index = 0; index < 4; ++index) {
+        maximum = std::max(maximum,
+            std::sqrt(squaredDistance(left[index], right[index])));
+    }
+    return maximum;
 }
 
 bool isDocumentLike(const Quad &quad, const cv::Size &size)
 {
     const float minEdge = std::min(size.width, size.height) * 0.12f;
+    const float borderX = std::max(2.0f, size.width * 0.01f);
+    const float borderY = std::max(2.0f, size.height * 0.01f);
     for (int i = 0; i < 4; ++i) {
-        if (pointDistance(quad[i], quad[(i + 1) % 4]) < minEdge) {
+        const cv::Point2f &point = quad[i];
+        if (point.x <= borderX || point.x >= size.width - borderX
+            || point.y <= borderY || point.y >= size.height - borderY) {
+            // A four-corner homography is not trustworthy when the page exits
+            // the image. Keep searching and use the saved manual fallback.
             return false;
         }
+
+        const cv::Point2f previous = quad[(i + 3) % 4] - point;
+        const cv::Point2f next = quad[(i + 1) % 4] - point;
+        const float previousLength = pointDistance(quad[(i + 3) % 4], point);
+        const float nextLength = pointDistance(quad[(i + 1) % 4], point);
+        if (previousLength < minEdge || nextLength < minEdge) {
+            return false;
+        }
+        const float cosine = (previous.x * next.x + previous.y * next.y)
+            / (previousLength * nextLength);
+        if (std::abs(cosine) > 0.94f) {
+            return false;
+        }
+    }
+
+    const float width = std::max(
+        pointDistance(quad[0], quad[1]), pointDistance(quad[3], quad[2]));
+    const float height = std::max(
+        pointDistance(quad[0], quad[3]), pointDistance(quad[1], quad[2]));
+    const float aspectRatio = width / height;
+    if (aspectRatio < 0.35f || aspectRatio > 2.85f) {
+        return false;
     }
 
     std::vector<cv::Point2f> polygon(quad.begin(), quad.end());
@@ -93,8 +166,442 @@ bool isDocumentLike(const Quad &quad, const cv::Size &size)
     return area >= frameArea * 0.08 && area <= frameArea * 0.96;
 }
 
-bool detectPaperQuad(const QImage &image, Quad &normalizedQuad)
+bool approximateDocumentQuad(const std::vector<cv::Point> &contour, Quad &quad)
 {
+    // A hand overlapping an edge commonly makes the visible page contour
+    // concave. Its convex hull retains the outer page corners while removing
+    // bounded inward finger occlusions.
+    std::vector<cv::Point> hull;
+    cv::convexHull(contour, hull);
+    if (hull.size() < 4) {
+        return false;
+    }
+
+    const double hullArea = std::abs(cv::contourArea(hull));
+    const double contourArea = std::abs(cv::contourArea(contour));
+    constexpr double minimumSolidity = 0.78;
+    if (hullArea <= 0.0 || contourArea / hullArea < minimumSolidity) {
+        return false;
+    }
+
+    const double perimeter = cv::arcLength(hull, true);
+    constexpr std::array<double, 4> approximationRatios = {0.015, 0.02, 0.03, 0.04};
+    for (const double ratio : approximationRatios) {
+        std::vector<cv::Point> approximate;
+        cv::approxPolyDP(hull, approximate, perimeter * ratio, true);
+        if (approximate.size() == 4 && cv::isContourConvex(approximate)) {
+            quad = orderQuad(approximate);
+            return true;
+        }
+    }
+    return false;
+}
+
+struct BoundaryEvidence {
+    float topX = 0.0f;
+    float bottomX = 0.0f;
+    float firstSupportedFraction = 0.0f;
+    float lastSupportedFraction = 1.0f;
+    float contrast = 0.0f;
+    float support = 0.0f;
+    float score = 0.0f;
+};
+
+float median(std::vector<float> values)
+{
+    if (values.empty()) {
+        return 0.0f;
+    }
+    const auto middle = values.begin() + values.size() / 2;
+    std::nth_element(values.begin(), middle, values.end());
+    return *middle;
+}
+
+bool evaluateVerticalBoundary(const cv::Mat &gray,
+                              const cv::Mat &edges,
+                              float topX,
+                              float bottomX,
+                              bool interiorOnRight,
+                              BoundaryEvidence &evidence)
+{
+    const int shortDimension = std::min(gray.cols, gray.rows);
+    const int sampleOffset = std::max(5, qRound(shortDimension * 0.025));
+    const int edgeRadius = std::max(2, qRound(shortDimension * 0.01));
+    const int horizontalMargin = sampleOffset + edgeRadius + 1;
+    if (topX < horizontalMargin || topX >= gray.cols - horizontalMargin
+        || bottomX < horizontalMargin || bottomX >= gray.cols - horizontalMargin) {
+        return false;
+    }
+
+    int supportedRows = 0;
+    int sampledRows = 0;
+    int positiveRows = 0;
+    int topSupported = 0;
+    int topRows = 0;
+    int bottomSupported = 0;
+    int bottomRows = 0;
+    int firstSupportedY = gray.rows;
+    int lastSupportedY = -1;
+    int maximumUnsupportedRun = 0;
+    std::vector<float> differences;
+    differences.reserve(static_cast<size_t>(gray.rows));
+
+    const int topBandEnd = qRound(gray.rows * 0.12);
+    const int bottomBandStart = qRound(gray.rows * 0.88);
+    for (int y = 2; y < gray.rows - 2; ++y) {
+        const float t = y / static_cast<float>(gray.rows - 1);
+        const int x = qRound(topX + (bottomX - topX) * t);
+        if (x < horizontalMargin || x >= gray.cols - horizontalMargin) {
+            continue;
+        }
+
+        bool edgeSupported = false;
+        for (int offset = -edgeRadius; offset <= edgeRadius; ++offset) {
+            if (edges.at<uchar>(y, x + offset) != 0) {
+                edgeSupported = true;
+                break;
+            }
+        }
+        ++sampledRows;
+        if (edgeSupported) {
+            ++supportedRows;
+            if (lastSupportedY >= 0) {
+                maximumUnsupportedRun = std::max(
+                    maximumUnsupportedRun, y - lastSupportedY - 1);
+            }
+            firstSupportedY = std::min(firstSupportedY, y);
+            lastSupportedY = y;
+        }
+        if (y < topBandEnd) {
+            ++topRows;
+            if (edgeSupported) ++topSupported;
+        }
+        if (y >= bottomBandStart) {
+            ++bottomRows;
+            if (edgeSupported) ++bottomSupported;
+        }
+
+        const int insideX = x + (interiorOnRight ? sampleOffset : -sampleOffset);
+        const int outsideX = x + (interiorOnRight ? -sampleOffset : sampleOffset);
+        const float difference = static_cast<float>(gray.at<uchar>(y, insideX))
+            - static_cast<float>(gray.at<uchar>(y, outsideX));
+        differences.push_back(difference);
+        if (difference > 5.0f) {
+            ++positiveRows;
+        }
+    }
+
+    if (sampledRows == 0 || topRows == 0 || bottomRows == 0) {
+        return false;
+    }
+    const float support = supportedRows / static_cast<float>(sampledRows);
+    const float topSupport = topSupported / static_cast<float>(topRows);
+    const float bottomSupport = bottomSupported / static_cast<float>(bottomRows);
+    const float positiveFraction = positiveRows / static_cast<float>(sampledRows);
+    const float contrast = median(std::move(differences));
+    const float firstSupportedFraction =
+        firstSupportedY / static_cast<float>(gray.rows - 1);
+    const float lastSupportedFraction =
+        lastSupportedY / static_cast<float>(gray.rows - 1);
+    const float maximumGapFraction =
+        maximumUnsupportedRun / static_cast<float>(gray.rows);
+
+    // This fallback is intentionally conservative: both long sides must reach
+    // close to the opposite frame edges, stay substantially contiguous through
+    // bounded finger occlusion, and be brighter on the candidate's interior.
+    if (support < 0.40f || topSupport < 0.12f || bottomSupport < 0.12f
+        || firstSupportedFraction > 0.08f || lastSupportedFraction < 0.89f
+        || maximumGapFraction > 0.20f
+        || positiveFraction < 0.62f || contrast < 12.0f) {
+        return false;
+    }
+
+    evidence = {topX, bottomX,
+                firstSupportedFraction, lastSupportedFraction,
+                contrast, support, contrast + support * 20.0f};
+    return true;
+}
+
+void appendDistinctBoundary(std::vector<BoundaryEvidence> &boundaries,
+                            const BoundaryEvidence &candidate)
+{
+    for (BoundaryEvidence &existing : boundaries) {
+        if (std::abs(existing.topX - candidate.topX) < 7.0f
+            && std::abs(existing.bottomX - candidate.bottomX) < 7.0f) {
+            if (candidate.score > existing.score) {
+                existing = candidate;
+            }
+            return;
+        }
+    }
+    boundaries.push_back(candidate);
+}
+
+float parallelEdgeSupport(const cv::Mat &edges,
+                          const BoundaryEvidence &boundary,
+                          int horizontalOffset)
+{
+    int supportedRows = 0;
+    int sampledRows = 0;
+    const int radius = std::max(2, qRound(std::min(edges.cols, edges.rows) * 0.008));
+    for (int y = 2; y < edges.rows - 2; ++y) {
+        const float t = y / static_cast<float>(edges.rows - 1);
+        const int x = qRound(boundary.topX
+            + (boundary.bottomX - boundary.topX) * t) + horizontalOffset;
+        if (x < radius || x >= edges.cols - radius) {
+            continue;
+        }
+        ++sampledRows;
+        for (int delta = -radius; delta <= radius; ++delta) {
+            if (edges.at<uchar>(y, x + delta) != 0) {
+                ++supportedRows;
+                break;
+            }
+        }
+    }
+    return sampledRows > 0
+        ? supportedRows / static_cast<float>(sampledRows) : 0.0f;
+}
+
+float maximumOutsideParallelSupport(const cv::Mat &edges,
+                                    const BoundaryEvidence &boundary,
+                                    int outsideDirection)
+{
+    const int shortDimension = std::min(edges.cols, edges.rows);
+    const int firstOffset = std::max(10, qRound(shortDimension * 0.04));
+    const int lastOffset = std::max(firstOffset, qRound(shortDimension * 0.10));
+    const int step = std::max(3, qRound(shortDimension * 0.015));
+    float maximum = 0.0f;
+    for (int offset = firstOffset; offset <= lastOffset; offset += step) {
+        maximum = std::max(maximum, parallelEdgeSupport(
+            edges, boundary, outsideDirection * offset));
+    }
+    return maximum;
+}
+
+float outsideBandEdgeSupport(const cv::Mat &edges,
+                             const BoundaryEvidence &boundary,
+                             int outsideDirection)
+{
+    const int shortDimension = std::min(edges.cols, edges.rows);
+    const int firstOffset = std::max(10, qRound(shortDimension * 0.04));
+    const int lastOffset = std::max(firstOffset + 1,
+        qRound(shortDimension * 0.12));
+    const int radius = std::max(2, qRound(shortDimension * 0.008));
+    int sampledRows = 0;
+    int supportedRows = 0;
+    for (int y = 2; y < edges.rows - 2; ++y) {
+        const float t = y / static_cast<float>(edges.rows - 1);
+        const int boundaryX = qRound(boundary.topX
+            + (boundary.bottomX - boundary.topX) * t);
+        ++sampledRows;
+        bool supported = false;
+        for (int offset = firstOffset;
+             offset <= lastOffset && !supported;
+             ++offset) {
+            const int x = boundaryX + outsideDirection * offset;
+            if (x < radius || x >= edges.cols - radius) {
+                continue;
+            }
+            for (int delta = -radius; delta <= radius; ++delta) {
+                if (edges.at<uchar>(y, x + delta) != 0) {
+                    supported = true;
+                    break;
+                }
+            }
+        }
+        if (supported) ++supportedRows;
+    }
+    return sampledRows > 0
+        ? supportedRows / static_cast<float>(sampledRows) : 0.0f;
+}
+
+bool hasClippedDocumentAppearance(const cv::Mat &gray,
+                                  const cv::Mat &edges,
+                                  const Quad &quad)
+{
+    std::vector<cv::Point> polygon;
+    polygon.reserve(quad.size());
+    for (const cv::Point2f &point : quad) {
+        polygon.emplace_back(qRound(point.x), qRound(point.y));
+    }
+
+    cv::Mat mask(gray.size(), CV_8UC1, cv::Scalar(0));
+    cv::fillConvexPoly(mask, polygon, cv::Scalar(255));
+    const int inset = std::max(7, qRound(std::min(gray.cols, gray.rows) * 0.035));
+    const cv::Mat insetKernel = cv::getStructuringElement(
+        cv::MORPH_ELLIPSE, cv::Size(inset * 2 + 1, inset * 2 + 1));
+    cv::Mat interior;
+    cv::erode(mask, interior, insetKernel);
+
+    const cv::Mat ringKernel = cv::getStructuringElement(
+        cv::MORPH_ELLIPSE, cv::Size(inset * 2 + 1, inset * 2 + 1));
+    cv::Mat expanded;
+    cv::dilate(mask, expanded, ringKernel);
+    cv::Mat exteriorRing;
+    cv::subtract(expanded, mask, exteriorRing);
+
+    const int interiorPixels = cv::countNonZero(interior);
+    const int exteriorPixels = cv::countNonZero(exteriorRing);
+    if (interiorPixels <= 0 || exteriorPixels <= 0) {
+        return false;
+    }
+
+    cv::Scalar interiorMean;
+    cv::Scalar interiorStdDev;
+    cv::meanStdDev(gray, interiorMean, interiorStdDev, interior);
+    const double exteriorMean = cv::mean(gray, exteriorRing)[0];
+    cv::Mat interiorEdges;
+    cv::bitwise_and(edges, interior, interiorEdges);
+    const double edgeDensity =
+        cv::countNonZero(interiorEdges) / static_cast<double>(interiorPixels);
+
+    // A line-only recovery is ambiguous for a blank panel or monitor. Require
+    // light paper contrast plus bounded interior print/texture before inferring
+    // the two clipped edges. Fully visible blank paper still uses the contour
+    // detector above and is unaffected by this stricter fallback.
+    return interiorMean[0] >= exteriorMean + 10.0
+        && interiorStdDev[0] <= 75.0
+        && edgeDensity >= 0.015
+        && edgeDensity <= 0.35;
+}
+
+bool detectFrameClippedPaper(const cv::Mat &gray,
+                             const cv::Mat &edges,
+                             const cv::Mat &contextEdges,
+                             Quad &quad)
+{
+    std::vector<cv::Vec2f> houghLines;
+    const int voteThreshold = std::max(50, qRound(gray.rows * 0.28));
+    cv::HoughLines(edges, houghLines, 1.0, CV_PI / 720.0, voteThreshold);
+
+    std::vector<BoundaryEvidence> leftBoundaries;
+    std::vector<BoundaryEvidence> rightBoundaries;
+    int verticalLinesExamined = 0;
+    for (size_t index = 0;
+         index < houghLines.size() && verticalLinesExamined < 250;
+         ++index) {
+        const float rho = houghLines[index][0];
+        const float theta = houghLines[index][1];
+        float direction = theta + static_cast<float>(CV_PI / 2.0);
+        if (direction >= CV_PI) direction -= static_cast<float>(CV_PI);
+        if (std::abs(direction - static_cast<float>(CV_PI / 2.0))
+            > static_cast<float>(CV_PI / 9.0)) {
+            continue;
+        }
+        ++verticalLinesExamined;
+
+        const float cosine = std::cos(theta);
+        if (std::abs(cosine) < 0.1f) {
+            continue;
+        }
+        const float sine = std::sin(theta);
+        const float topX = rho / cosine;
+        const float bottomX =
+            (rho - (gray.rows - 1) * sine) / cosine;
+
+        BoundaryEvidence boundary;
+        if (evaluateVerticalBoundary(
+                gray, edges, topX, bottomX, true, boundary)) {
+            appendDistinctBoundary(leftBoundaries, boundary);
+        }
+        if (evaluateVerticalBoundary(
+                gray, edges, topX, bottomX, false, boundary)) {
+            appendDistinctBoundary(rightBoundaries, boundary);
+        }
+    }
+
+    const float frameArea = static_cast<float>(gray.cols * gray.rows);
+    const float verticalInset = std::max(1.0f, gray.rows * 0.005f);
+    const auto xAtY = [&gray](const BoundaryEvidence &boundary, float y) {
+        const float t = y / static_cast<float>(gray.rows - 1);
+        return boundary.topX + (boundary.bottomX - boundary.topX) * t;
+    };
+    float bestScore = -std::numeric_limits<float>::max();
+    Quad best{};
+    for (const BoundaryEvidence &left : leftBoundaries) {
+        for (const BoundaryEvidence &right : rightBoundaries) {
+            const float firstSupported = std::max(
+                left.firstSupportedFraction, right.firstSupportedFraction);
+            const float lastSupported = std::min(
+                left.lastSupportedFraction, right.lastSupportedFraction);
+            const float topY = std::max(verticalInset,
+                (firstSupported - 0.02f) * (gray.rows - 1));
+            const float bottomY = std::min(gray.rows - 1.0f - verticalInset,
+                (lastSupported + 0.02f) * (gray.rows - 1));
+            const float height = bottomY - topY;
+            if (height < gray.rows * 0.72f) {
+                continue;
+            }
+
+            const float leftTopX = xAtY(left, topY);
+            const float leftBottomX = xAtY(left, bottomY);
+            const float rightTopX = xAtY(right, topY);
+            const float rightBottomX = xAtY(right, bottomY);
+            const float topWidth = rightTopX - leftTopX;
+            const float bottomWidth = rightBottomX - leftBottomX;
+            if (topWidth <= height * 0.40f || bottomWidth <= height * 0.40f
+                || topWidth >= gray.cols * 0.90f
+                || bottomWidth >= gray.cols * 0.90f) {
+                continue;
+            }
+
+            const float aspectRatio = ((topWidth + bottomWidth) * 0.5f) / height;
+            if (aspectRatio < 0.48f || aspectRatio > 1.10f) {
+                continue;
+            }
+
+            // A bright display inside a dark bezel presents a second pair of
+            // long rails just outside the apparent content. Reject that
+            // ambiguous geometry rather than locking onto the display interior.
+            const float leftOuterSupport =
+                maximumOutsideParallelSupport(edges, left, -1);
+            const float rightOuterSupport =
+                maximumOutsideParallelSupport(edges, right, 1);
+            const float leftOutsideBand =
+                outsideBandEdgeSupport(contextEdges, left, -1);
+            const float rightOutsideBand =
+                outsideBandEdgeSupport(contextEdges, right, 1);
+            if ((leftOuterSupport > 0.55f && rightOuterSupport > 0.55f)
+                || (leftOutsideBand > 0.92f && rightOutsideBand > 0.92f)) {
+                continue;
+            }
+
+            const Quad candidate = {
+                cv::Point2f(leftTopX, topY),
+                cv::Point2f(rightTopX, topY),
+                cv::Point2f(rightBottomX, bottomY),
+                cv::Point2f(leftBottomX, bottomY)
+            };
+            std::vector<cv::Point2f> polygon(candidate.begin(), candidate.end());
+            const float area = static_cast<float>(std::abs(cv::contourArea(polygon)));
+            if (area < frameArea * 0.18f || area > frameArea * 0.85f
+                || !cv::isContourConvex(polygon)
+                || !hasClippedDocumentAppearance(gray, edges, candidate)) {
+                continue;
+            }
+
+            const float score = left.score + right.score
+                + area / frameArea * 10.0f
+                - std::abs(aspectRatio - 0.75f) * 8.0f;
+            if (score > bestScore) {
+                bestScore = score;
+                best = candidate;
+            }
+        }
+    }
+
+    if (bestScore == -std::numeric_limits<float>::max()) {
+        return false;
+    }
+    quad = best;
+    return true;
+}
+
+bool detectPaperQuad(const QImage &image, Quad &normalizedQuad,
+                     bool &frameClipped)
+{
+    frameClipped = false;
     const QImage rgba = image.convertToFormat(QImage::Format_RGBA8888);
     cv::Mat rgbaMat(rgba.height(), rgba.width(), CV_8UC4,
                     const_cast<uchar *>(rgba.constBits()), rgba.bytesPerLine());
@@ -115,26 +622,26 @@ bool detectPaperQuad(const QImage &image, Quad &normalizedQuad)
     cv::cvtColor(detectionImage, gray, cv::COLOR_BGR2GRAY);
     cv::GaussianBlur(gray, gray, cv::Size(5, 5), 0.0);
 
-    cv::Mat edges;
-    cv::Canny(gray, edges, 50.0, 150.0);
-    cv::dilate(edges, edges, cv::Mat(), cv::Point(-1, -1), 1);
+    cv::Mat lineEdges;
+    cv::Canny(gray, lineEdges, 50.0, 150.0);
+    cv::Mat contextEdges;
+    cv::Canny(gray, contextEdges, 15.0, 45.0);
+    cv::Mat contourEdges = lineEdges.clone();
+    const cv::Mat closeKernel = cv::getStructuringElement(
+        cv::MORPH_RECT, cv::Size(5, 5));
+    cv::morphologyEx(contourEdges, contourEdges, cv::MORPH_CLOSE, closeKernel);
+    cv::dilate(contourEdges, contourEdges, cv::Mat(), cv::Point(-1, -1), 1);
 
     std::vector<std::vector<cv::Point>> contours;
-    cv::findContours(edges, contours, cv::RETR_LIST, cv::CHAIN_APPROX_SIMPLE);
+    cv::findContours(contourEdges, contours, cv::RETR_LIST, cv::CHAIN_APPROX_SIMPLE);
     std::sort(contours.begin(), contours.end(), [](const auto &a, const auto &b) {
         return std::abs(cv::contourArea(a)) > std::abs(cv::contourArea(b));
     });
 
     for (const auto &contour : contours) {
-        const double perimeter = cv::arcLength(contour, true);
-        std::vector<cv::Point> approximate;
-        cv::approxPolyDP(contour, approximate, perimeter * 0.02, true);
-        if (approximate.size() != 4 || !cv::isContourConvex(approximate)) {
-            continue;
-        }
-
-        Quad ordered = orderQuad(approximate);
-        if (!isDocumentLike(ordered, detectionImage.size())) {
+        Quad ordered{};
+        if (!approximateDocumentQuad(contour, ordered)
+            || !isDocumentLike(ordered, detectionImage.size())) {
             continue;
         }
 
@@ -143,6 +650,18 @@ bool detectPaperQuad(const QImage &image, Quad &normalizedQuad)
             point.y /= detectionImage.rows;
         }
         normalizedQuad = ordered;
+        return true;
+    }
+
+    Quad clipped{};
+    if (detectFrameClippedPaper(
+            gray, lineEdges, contextEdges, clipped)) {
+        for (cv::Point2f &point : clipped) {
+            point.x /= detectionImage.cols;
+            point.y /= detectionImage.rows;
+        }
+        normalizedQuad = clipped;
+        frameClipped = true;
         return true;
     }
 
@@ -188,11 +707,14 @@ QImage warpPaper(const QImage &image, const Quad &normalizedQuad)
 } // namespace
 
 struct PaperCropProcessor::Impl {
-    int frameCounter = 0;
-    int missedDetections = 0;
+    quint64 frameCounter = 0;
+    int framesSinceSuccessfulDetection = 0;
     bool detected = false;
 #ifdef OBSBOT_HAS_OPENCV
     Quad normalizedQuad{};
+    Quad pendingClippedQuad{};
+    int consistentClippedDetections = 0;
+    bool pendingClippedQuadValid = false;
 #endif
 };
 
@@ -203,38 +725,111 @@ PaperCropProcessor::PaperCropProcessor()
 
 PaperCropProcessor::~PaperCropProcessor() = default;
 
+void PaperCropProcessor::reset()
+{
+    *m_impl = Impl{};
+}
+
 QImage PaperCropProcessor::process(const QImage &image, const PaperCropSettings &settings)
 {
     if (image.isNull() || settings.mode == PaperCropMode::Off) {
-        m_impl->detected = false;
+        reset();
         return image;
     }
 
     if (settings.mode == PaperCropMode::Manual) {
-        m_impl->detected = false;
+        reset();
         return applyManualCrop(image, settings);
     }
 
 #ifdef OBSBOT_HAS_OPENCV
-    constexpr int detectionInterval = 10;
+    constexpr quint64 detectionInterval = 10;
     constexpr int retainedDetectionFrames = 30;
-    if (m_impl->frameCounter++ % detectionInterval == 0 || !m_impl->detected) {
+    const bool shouldDetect = !m_impl->detected
+        || m_impl->frameCounter % detectionInterval == 0
+        || m_impl->framesSinceSuccessfulDetection >= retainedDetectionFrames;
+    ++m_impl->frameCounter;
+
+    bool detectedThisFrame = false;
+    if (shouldDetect) {
         Quad candidate{};
-        if (detectPaperQuad(image, candidate)) {
+        bool frameClipped = false;
+        const bool found = detectPaperQuad(image, candidate, frameClipped);
+        bool candidateAccepted = found;
+
+        if (found && frameClipped && !m_impl->detected) {
+            constexpr int requiredConsistentDetections = 3;
+            constexpr float acquisitionDistance = 0.06f;
+            if (m_impl->pendingClippedQuadValid) {
+                candidate = alignQuadToReference(
+                    candidate, m_impl->pendingClippedQuad);
+                if (maximumCornerDistance(
+                        candidate, m_impl->pendingClippedQuad)
+                    <= acquisitionDistance) {
+                    ++m_impl->consistentClippedDetections;
+                    constexpr float pendingSmoothing = 0.5f;
+                    for (int index = 0; index < 4; ++index) {
+                        m_impl->pendingClippedQuad[index] =
+                            m_impl->pendingClippedQuad[index]
+                                * (1.0f - pendingSmoothing)
+                            + candidate[index] * pendingSmoothing;
+                    }
+                } else {
+                    m_impl->pendingClippedQuad = candidate;
+                    m_impl->consistentClippedDetections = 1;
+                }
+            } else {
+                m_impl->pendingClippedQuad = candidate;
+                m_impl->pendingClippedQuadValid = true;
+                m_impl->consistentClippedDetections = 1;
+            }
+
+            candidateAccepted =
+                m_impl->consistentClippedDetections
+                >= requiredConsistentDetections;
+            if (candidateAccepted) {
+                candidate = m_impl->pendingClippedQuad;
+                m_impl->pendingClippedQuadValid = false;
+                m_impl->consistentClippedDetections = 0;
+            }
+        } else if (found) {
+            m_impl->pendingClippedQuadValid = false;
+            m_impl->consistentClippedDetections = 0;
+        } else if (!m_impl->detected) {
+            // Acquisition requires consecutive evidence, not intermittent hits.
+            m_impl->pendingClippedQuadValid = false;
+            m_impl->consistentClippedDetections = 0;
+        }
+
+        if (candidateAccepted) {
             if (m_impl->detected) {
-                constexpr float smoothing = 0.35f;
-                for (int i = 0; i < 4; ++i) {
-                    m_impl->normalizedQuad[i] =
-                        m_impl->normalizedQuad[i] * (1.0f - smoothing) + candidate[i] * smoothing;
+                candidate = alignQuadToReference(candidate, m_impl->normalizedQuad);
+                constexpr float maximumUpdateDistance = 0.15f;
+                if (maximumCornerDistance(candidate, m_impl->normalizedQuad)
+                    <= maximumUpdateDistance) {
+                    constexpr float smoothing = 0.35f;
+                    for (int index = 0; index < 4; ++index) {
+                        m_impl->normalizedQuad[index] =
+                            m_impl->normalizedQuad[index] * (1.0f - smoothing)
+                            + candidate[index] * smoothing;
+                    }
+                    detectedThisFrame = true;
                 }
             } else {
                 m_impl->normalizedQuad = candidate;
+                m_impl->detected = true;
+                detectedThisFrame = true;
             }
-            m_impl->detected = true;
-            m_impl->missedDetections = 0;
-        } else if (++m_impl->missedDetections > retainedDetectionFrames / detectionInterval) {
-            m_impl->detected = false;
+
+            if (detectedThisFrame) {
+                m_impl->framesSinceSuccessfulDetection = 0;
+            }
         }
+    }
+
+    if (m_impl->detected && !detectedThisFrame
+        && ++m_impl->framesSinceSuccessfulDetection > retainedDetectionFrames) {
+        m_impl->detected = false;
     }
 
     if (m_impl->detected) {

--- a/src/gui/PaperCropProcessor.cpp
+++ b/src/gui/PaperCropProcessor.cpp
@@ -1,0 +1,260 @@
+#include "PaperCropProcessor.h"
+
+#include <QPainter>
+#include <QRect>
+#include <QtGlobal>
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <vector>
+
+#ifdef OBSBOT_HAS_OPENCV
+#include <opencv2/core.hpp>
+#include <opencv2/imgproc.hpp>
+#endif
+
+namespace {
+
+QImage fitInsideFrame(const QImage &image, const QSize &frameSize)
+{
+    if (image.isNull() || !frameSize.isValid()) {
+        return image;
+    }
+
+    const QImage scaled = image.scaled(frameSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    QImage output(frameSize, QImage::Format_RGBA8888);
+    output.fill(Qt::black);
+
+    QPainter painter(&output);
+    painter.drawImage((frameSize.width() - scaled.width()) / 2,
+                      (frameSize.height() - scaled.height()) / 2,
+                      scaled);
+    return output;
+}
+
+QImage applyManualCrop(const QImage &image, const PaperCropSettings &settings)
+{
+    const PaperCropSettings crop = settings.normalized();
+    const int left = qRound(crop.left * image.width());
+    const int top = qRound(crop.top * image.height());
+    const int right = qRound(crop.right * image.width());
+    const int bottom = qRound(crop.bottom * image.height());
+    const QRect rect(left,
+                     top,
+                     std::max(1, image.width() - left - right),
+                     std::max(1, image.height() - top - bottom));
+    return fitInsideFrame(image.copy(rect.intersected(image.rect())), image.size());
+}
+
+#ifdef OBSBOT_HAS_OPENCV
+
+using Quad = std::array<cv::Point2f, 4>;
+
+float pointDistance(const cv::Point2f &a, const cv::Point2f &b)
+{
+    const cv::Point2f delta = a - b;
+    return std::sqrt(delta.x * delta.x + delta.y * delta.y);
+}
+
+Quad orderQuad(const std::vector<cv::Point> &points)
+{
+    Quad ordered{};
+    auto minSum = points.front();
+    auto maxSum = points.front();
+    auto minDiff = points.front();
+    auto maxDiff = points.front();
+
+    for (const cv::Point &point : points) {
+        if (point.x + point.y < minSum.x + minSum.y) minSum = point;
+        if (point.x + point.y > maxSum.x + maxSum.y) maxSum = point;
+        if (point.x - point.y < minDiff.x - minDiff.y) minDiff = point;
+        if (point.x - point.y > maxDiff.x - maxDiff.y) maxDiff = point;
+    }
+
+    ordered[0] = cv::Point2f(minSum);  // top-left
+    ordered[1] = cv::Point2f(maxDiff); // top-right
+    ordered[2] = cv::Point2f(maxSum);  // bottom-right
+    ordered[3] = cv::Point2f(minDiff); // bottom-left
+    return ordered;
+}
+
+bool isDocumentLike(const Quad &quad, const cv::Size &size)
+{
+    const float minEdge = std::min(size.width, size.height) * 0.12f;
+    for (int i = 0; i < 4; ++i) {
+        if (pointDistance(quad[i], quad[(i + 1) % 4]) < minEdge) {
+            return false;
+        }
+    }
+
+    std::vector<cv::Point2f> polygon(quad.begin(), quad.end());
+    const double area = std::abs(cv::contourArea(polygon));
+    const double frameArea = static_cast<double>(size.width) * size.height;
+    return area >= frameArea * 0.08 && area <= frameArea * 0.96;
+}
+
+bool detectPaperQuad(const QImage &image, Quad &normalizedQuad)
+{
+    const QImage rgba = image.convertToFormat(QImage::Format_RGBA8888);
+    cv::Mat rgbaMat(rgba.height(), rgba.width(), CV_8UC4,
+                    const_cast<uchar *>(rgba.constBits()), rgba.bytesPerLine());
+    cv::Mat bgr;
+    cv::cvtColor(rgbaMat, bgr, cv::COLOR_RGBA2BGR);
+
+    constexpr int maxDetectionDimension = 640;
+    const double scale = std::min(1.0, maxDetectionDimension /
+        static_cast<double>(std::max(bgr.cols, bgr.rows)));
+    cv::Mat detectionImage;
+    if (scale < 1.0) {
+        cv::resize(bgr, detectionImage, cv::Size(), scale, scale, cv::INTER_AREA);
+    } else {
+        detectionImage = bgr;
+    }
+
+    cv::Mat gray;
+    cv::cvtColor(detectionImage, gray, cv::COLOR_BGR2GRAY);
+    cv::GaussianBlur(gray, gray, cv::Size(5, 5), 0.0);
+
+    cv::Mat edges;
+    cv::Canny(gray, edges, 50.0, 150.0);
+    cv::dilate(edges, edges, cv::Mat(), cv::Point(-1, -1), 1);
+
+    std::vector<std::vector<cv::Point>> contours;
+    cv::findContours(edges, contours, cv::RETR_LIST, cv::CHAIN_APPROX_SIMPLE);
+    std::sort(contours.begin(), contours.end(), [](const auto &a, const auto &b) {
+        return std::abs(cv::contourArea(a)) > std::abs(cv::contourArea(b));
+    });
+
+    for (const auto &contour : contours) {
+        const double perimeter = cv::arcLength(contour, true);
+        std::vector<cv::Point> approximate;
+        cv::approxPolyDP(contour, approximate, perimeter * 0.02, true);
+        if (approximate.size() != 4 || !cv::isContourConvex(approximate)) {
+            continue;
+        }
+
+        Quad ordered = orderQuad(approximate);
+        if (!isDocumentLike(ordered, detectionImage.size())) {
+            continue;
+        }
+
+        for (cv::Point2f &point : ordered) {
+            point.x /= detectionImage.cols;
+            point.y /= detectionImage.rows;
+        }
+        normalizedQuad = ordered;
+        return true;
+    }
+
+    return false;
+}
+
+QImage warpPaper(const QImage &image, const Quad &normalizedQuad)
+{
+    const QImage rgba = image.convertToFormat(QImage::Format_RGBA8888);
+    cv::Mat rgbaMat(rgba.height(), rgba.width(), CV_8UC4,
+                    const_cast<uchar *>(rgba.constBits()), rgba.bytesPerLine());
+
+    Quad source = normalizedQuad;
+    for (cv::Point2f &point : source) {
+        point.x *= rgba.width();
+        point.y *= rgba.height();
+    }
+
+    const int targetWidth = std::max(32, qRound(std::max(
+        pointDistance(source[0], source[1]), pointDistance(source[3], source[2]))));
+    const int targetHeight = std::max(32, qRound(std::max(
+        pointDistance(source[0], source[3]), pointDistance(source[1], source[2]))));
+
+    const Quad destination = {
+        cv::Point2f(0.0f, 0.0f),
+        cv::Point2f(static_cast<float>(targetWidth - 1), 0.0f),
+        cv::Point2f(static_cast<float>(targetWidth - 1), static_cast<float>(targetHeight - 1)),
+        cv::Point2f(0.0f, static_cast<float>(targetHeight - 1))
+    };
+
+    const cv::Mat transform = cv::getPerspectiveTransform(source.data(), destination.data());
+    cv::Mat warped;
+    cv::warpPerspective(rgbaMat, warped, transform, cv::Size(targetWidth, targetHeight),
+                        cv::INTER_LINEAR, cv::BORDER_CONSTANT, cv::Scalar(0, 0, 0, 255));
+
+    QImage result(warped.data, warped.cols, warped.rows,
+                  static_cast<int>(warped.step), QImage::Format_RGBA8888);
+    return fitInsideFrame(result.copy(), image.size());
+}
+
+#endif
+
+} // namespace
+
+struct PaperCropProcessor::Impl {
+    int frameCounter = 0;
+    int missedDetections = 0;
+    bool detected = false;
+#ifdef OBSBOT_HAS_OPENCV
+    Quad normalizedQuad{};
+#endif
+};
+
+PaperCropProcessor::PaperCropProcessor()
+    : m_impl(std::make_unique<Impl>())
+{
+}
+
+PaperCropProcessor::~PaperCropProcessor() = default;
+
+QImage PaperCropProcessor::process(const QImage &image, const PaperCropSettings &settings)
+{
+    if (image.isNull() || settings.mode == PaperCropMode::Off) {
+        m_impl->detected = false;
+        return image;
+    }
+
+    if (settings.mode == PaperCropMode::Manual) {
+        m_impl->detected = false;
+        return applyManualCrop(image, settings);
+    }
+
+#ifdef OBSBOT_HAS_OPENCV
+    constexpr int detectionInterval = 10;
+    constexpr int retainedDetectionFrames = 30;
+    if (m_impl->frameCounter++ % detectionInterval == 0 || !m_impl->detected) {
+        Quad candidate{};
+        if (detectPaperQuad(image, candidate)) {
+            if (m_impl->detected) {
+                constexpr float smoothing = 0.35f;
+                for (int i = 0; i < 4; ++i) {
+                    m_impl->normalizedQuad[i] =
+                        m_impl->normalizedQuad[i] * (1.0f - smoothing) + candidate[i] * smoothing;
+                }
+            } else {
+                m_impl->normalizedQuad = candidate;
+            }
+            m_impl->detected = true;
+            m_impl->missedDetections = 0;
+        } else if (++m_impl->missedDetections > retainedDetectionFrames / detectionInterval) {
+            m_impl->detected = false;
+        }
+    }
+
+    if (m_impl->detected) {
+        return warpPaper(image, m_impl->normalizedQuad);
+    }
+#endif
+
+    return applyManualCrop(image, settings);
+}
+
+bool PaperCropProcessor::paperDetected() const
+{
+    return m_impl->detected;
+}
+
+bool PaperCropProcessor::automaticDetectionAvailable()
+{
+#ifdef OBSBOT_HAS_OPENCV
+    return true;
+#else
+    return false;
+#endif
+}

--- a/src/gui/PaperCropProcessor.h
+++ b/src/gui/PaperCropProcessor.h
@@ -1,0 +1,28 @@
+#ifndef PAPERCROPPROCESSOR_H
+#define PAPERCROPPROCESSOR_H
+
+#include "PaperCropSettings.h"
+
+#include <QImage>
+#include <memory>
+
+class PaperCropProcessor
+{
+public:
+    PaperCropProcessor();
+    ~PaperCropProcessor();
+
+    PaperCropProcessor(const PaperCropProcessor &) = delete;
+    PaperCropProcessor &operator=(const PaperCropProcessor &) = delete;
+
+    QImage process(const QImage &image, const PaperCropSettings &settings);
+    bool paperDetected() const;
+
+    static bool automaticDetectionAvailable();
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> m_impl;
+};
+
+#endif // PAPERCROPPROCESSOR_H

--- a/src/gui/PaperCropProcessor.h
+++ b/src/gui/PaperCropProcessor.h
@@ -17,6 +17,7 @@ public:
 
     QImage process(const QImage &image, const PaperCropSettings &settings);
     bool paperDetected() const;
+    void reset();
 
     static bool automaticDetectionAvailable();
 

--- a/src/gui/PaperCropSettings.h
+++ b/src/gui/PaperCropSettings.h
@@ -1,0 +1,60 @@
+#ifndef PAPERCROPSETTINGS_H
+#define PAPERCROPSETTINGS_H
+
+#include <algorithm>
+#include <cmath>
+
+enum class PaperCropMode {
+    Off = 0,
+    Manual = 1,
+    Automatic = 2
+};
+
+struct PaperCropSettings {
+    PaperCropMode mode = PaperCropMode::Off;
+    float left = 0.0f;
+    float top = 0.0f;
+    float right = 0.0f;
+    float bottom = 0.0f;
+
+    bool isValid() const
+    {
+        const auto validMargin = [](float value) {
+            return std::isfinite(value) && value >= 0.0f && value <= 0.45f;
+        };
+        return validMargin(left) && validMargin(top)
+            && validMargin(right) && validMargin(bottom)
+            && left + right <= 0.9f
+            && top + bottom <= 0.9f;
+    }
+
+    PaperCropSettings normalized() const
+    {
+        PaperCropSettings result = *this;
+        result.left = std::clamp(result.left, 0.0f, 0.45f);
+        result.top = std::clamp(result.top, 0.0f, 0.45f);
+        result.right = std::clamp(result.right, 0.0f, 0.45f);
+        result.bottom = std::clamp(result.bottom, 0.0f, 0.45f);
+        if (result.left + result.right > 0.9f) {
+            result.right = 0.9f - result.left;
+        }
+        if (result.top + result.bottom > 0.9f) {
+            result.bottom = 0.9f - result.top;
+        }
+        return result;
+    }
+
+    bool operator==(const PaperCropSettings &other) const
+    {
+        constexpr float epsilon = 0.0001f;
+        return mode == other.mode
+            && std::abs(left - other.left) < epsilon
+            && std::abs(top - other.top) < epsilon
+            && std::abs(right - other.right) < epsilon
+            && std::abs(bottom - other.bottom) < epsilon;
+    }
+
+    bool operator!=(const PaperCropSettings &other) const { return !(*this == other); }
+};
+
+#endif // PAPERCROPSETTINGS_H

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -2,14 +2,37 @@
 #include <QLabel>
 #include <dev/dev.hpp>
 
+namespace {
+constexpr int kCommandStateGuardMs = 3500;
+}
+
 TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidget *parent)
     : QWidget(parent)
     , m_controller(controller)
     , m_userInitiated(false)
+    , m_manualOverrideActive(true)
+    , m_manualControlAuthorized(false)
+    , m_manualConfirmationPending(false)
+    , m_trackingConfirmationPending(false)
+    , m_pendingTrackingIntentGeneration(0)
+    , m_highestTrackingIntentGeneration(0)
+    , m_trackingIntentResolved(false)
+    , m_v4l2Only(false)
 {
     // Create debounce timer for command completion
     m_commandTimer = new QTimer(this);
+    m_commandTimer->setObjectName(QStringLiteral("trackingCommandTimer"));
     m_commandTimer->setSingleShot(true);
+
+    m_profileFocusTimer = new QTimer(this);
+    m_profileFocusTimer->setSingleShot(true);
+    m_profileFocusTimer->setInterval(150);
+    connect(m_profileFocusTimer, &QTimer::timeout,
+            this, &TrackingControlWidget::submitCurrentTrackingProfile);
+
+    m_activeTrackingProfile = {
+        TrackingFocusPolicy::Manual, 50, false,
+        Device::AiTrackSpeedStandard};
 
     // Unified throttle for all manual controls (pan/tilt, zoom, focus)
     m_controlThrottle = new QTimer(this);
@@ -18,6 +41,18 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     connect(m_controlThrottle, &QTimer::timeout, this, &TrackingControlWidget::flushPendingCommands);
 
     m_tiny2Capabilities = m_controller->hasTiny2Capabilities();
+    connect(m_controller, &CameraController::trackingIntentStarted,
+            this, &TrackingControlWidget::onTrackingIntentStarted);
+    connect(m_controller, &CameraController::trackingStateConfirmationPending,
+            this, &TrackingControlWidget::onTrackingStateConfirmationPending);
+    connect(m_controller, &CameraController::trackingStateConfirmationFailed,
+            this, &TrackingControlWidget::onTrackingStateConfirmationFailed);
+    connect(m_controller, &CameraController::trackingStateConfirmationUncertain,
+            this, &TrackingControlWidget::onTrackingStateConfirmationUncertain);
+    connect(m_controller, &CameraController::trackingStateConfirmed,
+            this, &TrackingControlWidget::onTrackingStateConfirmed);
+    connect(m_controller, &CameraController::trackingOwnershipObserved,
+            this, &TrackingControlWidget::onTrackingOwnershipObserved);
 
     QVBoxLayout *layout = new QVBoxLayout(this);
     layout->setContentsMargins(8, 14, 8, 14);
@@ -30,6 +65,7 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     groupLayout->setSpacing(12);
 
     m_trackingCheckBox = new QCheckBox("Enable Auto-Framing", this);
+    m_trackingCheckBox->setObjectName(QStringLiteral("trackingCheckBox"));
     m_trackingCheckBox->setStyleSheet("font-weight: 600; font-size: 14px;");
     connect(m_trackingCheckBox, &QCheckBox::toggled, this, &TrackingControlWidget::onTrackingToggled);
     groupLayout->addWidget(m_trackingCheckBox);
@@ -80,9 +116,55 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     advancedLayout->addLayout(subModeLayout);
 
     m_autoZoomCheckBox = new QCheckBox("Enable AI Auto Zoom", this);
+    m_autoZoomCheckBox->setObjectName(
+        QStringLiteral("trackingAutoZoomCheckBox"));
     connect(m_autoZoomCheckBox, &QCheckBox::toggled, this, &TrackingControlWidget::onAutoZoomToggled);
     m_autoZoomCheckBox->setStyleSheet("font-size: 11px;");
     advancedLayout->addWidget(m_autoZoomCheckBox);
+
+    QHBoxLayout *focusPolicyLayout = new QHBoxLayout();
+    QLabel *focusPolicyLabel = new QLabel(tr("Focus Policy"), this);
+    focusPolicyLabel->setStyleSheet("font-size: 11px; font-weight: 600;");
+    m_profileFocusPolicyCombo = new QComboBox(this);
+    m_profileFocusPolicyCombo->setObjectName(
+        QStringLiteral("trackingFocusPolicyCombo"));
+    m_profileFocusPolicyCombo->addItem(
+        tr("Face autofocus"),
+        static_cast<int>(TrackingFocusPolicy::Face));
+    m_profileFocusPolicyCombo->addItem(
+        tr("Continuous scene autofocus"),
+        static_cast<int>(TrackingFocusPolicy::Continuous));
+    m_profileFocusPolicyCombo->addItem(
+        tr("Manual fixed position"),
+        static_cast<int>(TrackingFocusPolicy::Manual));
+    m_profileFocusPolicyCombo->setToolTip(tr(
+        "Saved independently for each tracking mode. Scene autofocus is used "
+        "for Hand, Whiteboard, and Desk by default."));
+    connect(m_profileFocusPolicyCombo,
+            QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, &TrackingControlWidget::onProfileFocusPolicyChanged);
+    focusPolicyLayout->addWidget(focusPolicyLabel);
+    focusPolicyLayout->addWidget(m_profileFocusPolicyCombo, 1);
+    advancedLayout->addLayout(focusPolicyLayout);
+
+    QHBoxLayout *profileFocusLayout = new QHBoxLayout();
+    QLabel *profileFocusTitle = new QLabel(tr("Saved Manual Focus"), this);
+    profileFocusTitle->setStyleSheet("font-size: 11px; font-weight: 600;");
+    m_profileFocusSlider = new QSlider(Qt::Horizontal, this);
+    m_profileFocusSlider->setObjectName(
+        QStringLiteral("trackingProfileFocusSlider"));
+    m_profileFocusSlider->setRange(0, 100);
+    m_profileFocusSlider->setValue(50);
+    m_profileFocusSlider->setToolTip(tr(
+        "Retained as this mode's manual fallback even while autofocus is active."));
+    connect(m_profileFocusSlider, &QSlider::valueChanged,
+            this, &TrackingControlWidget::onProfileFocusPositionChanged);
+    m_profileFocusLabel = new QLabel(QStringLiteral("50"), this);
+    m_profileFocusLabel->setMinimumWidth(28);
+    profileFocusLayout->addWidget(profileFocusTitle);
+    profileFocusLayout->addWidget(m_profileFocusSlider, 1);
+    profileFocusLayout->addWidget(m_profileFocusLabel);
+    advancedLayout->addLayout(profileFocusLayout);
 
     QHBoxLayout *speedLayout = new QHBoxLayout();
     QLabel *speedLabel = new QLabel("Tracking Speed", this);
@@ -118,12 +200,14 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     ptzContainerLayout->setSpacing(0);
 
     m_manualControlCheckBox = new QCheckBox(tr("Enable manual positioning (turns tracking off)"), m_ptzContainer);
+    m_manualControlCheckBox->setObjectName(QStringLiteral("manualControlCheckBox"));
     m_manualControlCheckBox->setChecked(true);
     connect(m_manualControlCheckBox, &QCheckBox::toggled,
             this, &TrackingControlWidget::onManualControlToggled);
     ptzContainerLayout->addWidget(m_manualControlCheckBox);
 
     m_ptzGroupBox = new QGroupBox("Manual Camera Control", this);
+    m_ptzGroupBox->setObjectName(QStringLiteral("manualControlGroup"));
     m_ptzGroupBox->setFlat(true);
     QVBoxLayout *ptzGroupLayout = new QVBoxLayout(m_ptzGroupBox);
     ptzGroupLayout->setContentsMargins(16, 16, 16, 16);
@@ -201,6 +285,9 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     ptzContainerLayout->addWidget(m_ptzGroupBox);
     layout->addWidget(m_ptzContainer);
 
+    setActiveTrackingProfile(m_activeTrackingProfile);
+    setManualFocusPosition(m_activeTrackingProfile.manualFocusPosition);
+
     // Update PTZ controls state based on auto-framing
     updatePTZControlsState();
 
@@ -209,50 +296,284 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
 
 bool TrackingControlWidget::isManualControlEnabled() const
 {
-    return m_manualControlCheckBox && m_manualControlCheckBox->isChecked();
+    return m_manualOverrideActive && m_manualControlAuthorized;
+}
+
+TrackingModeProfile TrackingControlWidget::activeTrackingProfile() const
+{
+    TrackingModeProfile profile = m_activeTrackingProfile;
+    if (m_profileFocusPolicyCombo) {
+        profile.focusPolicy = static_cast<TrackingFocusPolicy>(
+            m_profileFocusPolicyCombo->currentData().toInt());
+    }
+    if (m_profileFocusSlider) {
+        profile.manualFocusPosition = m_profileFocusSlider->value();
+    }
+    if (m_autoZoomCheckBox) {
+        profile.autoZoom = m_autoZoomCheckBox->isChecked();
+    }
+    if (m_speedCombo) {
+        profile.trackSpeed = m_speedCombo->currentData().toInt();
+    }
+    return profile;
 }
 
 TrackingControlWidget::TrackingState TrackingControlWidget::trackingState() const
 {
-    return {
+    TrackingState state{
         isTrackingEnabled(),
         currentAiMode(),
         currentHumanSubMode(),
-        isAutoZoomEnabled()
+        activeTrackingProfile()
     };
+    if (!state.enabled) {
+        state.profile.focusPolicy = TrackingFocusPolicy::Manual;
+        state.profile.manualFocusPosition = m_focusSlider->value();
+        state.profile.autoZoom = false;
+    }
+    if (state.aiMode != Device::AiWorkModeHuman) {
+        state.aiSubMode = 0;
+    }
+    return state;
+}
+
+bool TrackingControlWidget::matchesTrackingState(
+    const TrackingState &expected) const
+{
+    if (isTrackingEnabled() != expected.enabled) {
+        return false;
+    }
+    if (!expected.enabled) {
+        return isManualControlEnabled()
+            && trackingState().profile == expected.profile;
+    }
+
+    const int expectedMode = expected.aiMode == Device::AiWorkModeNone
+        ? Device::AiWorkModeHuman : expected.aiMode;
+    if (currentAiMode() != expectedMode) {
+        return false;
+    }
+    if (expectedMode == Device::AiWorkModeHuman
+        && currentHumanSubMode() != expected.aiSubMode) {
+        return false;
+    }
+    return activeTrackingProfile() == expected.profile;
+}
+
+void TrackingControlWidget::setModeProfiles(
+    const Tiny2TrackingModeProfiles &profiles)
+{
+    for (const auto &profile : profiles) {
+        if (!isValidTrackingModeProfile(profile)) {
+            return;
+        }
+    }
+    m_modeProfiles = profiles;
+}
+
+TrackingModeProfile TrackingControlWidget::modeProfile(int aiMode) const
+{
+    const int index = tiny2TrackingModeProfileIndex(aiMode);
+    return index >= 0
+        ? m_modeProfiles[static_cast<std::size_t>(index)]
+        : activeTrackingProfile();
+}
+
+TrackingControlWidget::TrackingState
+TrackingControlWidget::trackingStateForMode(int aiMode) const
+{
+    TrackingState state = trackingState();
+    state.enabled = aiMode != Device::AiWorkModeNone;
+    state.aiMode = aiMode;
+    state.aiSubMode = aiMode == Device::AiWorkModeHuman
+        ? currentHumanSubMode() : 0;
+    state.profile = modeProfile(aiMode);
+    if (!state.enabled) {
+        state.profile.focusPolicy = TrackingFocusPolicy::Manual;
+        state.profile.manualFocusPosition = m_focusSlider->value();
+        state.profile.autoZoom = false;
+    }
+    return state;
+}
+
+void TrackingControlWidget::setActiveTrackingProfile(
+    const TrackingModeProfile &profile)
+{
+    if (!isValidTrackingModeProfile(profile)) {
+        return;
+    }
+    m_activeTrackingProfile = profile;
+
+    const int policyIndex = m_profileFocusPolicyCombo->findData(
+        static_cast<int>(profile.focusPolicy));
+    if (policyIndex >= 0) {
+        QSignalBlocker blocker(m_profileFocusPolicyCombo);
+        m_profileFocusPolicyCombo->setCurrentIndex(policyIndex);
+    }
+    {
+        QSignalBlocker blocker(m_profileFocusSlider);
+        m_profileFocusSlider->setValue(profile.manualFocusPosition);
+    }
+    m_profileFocusLabel->setText(
+        QString::number(profile.manualFocusPosition));
+    setAutoZoomEnabled(profile.autoZoom);
+    setTrackSpeed(profile.trackSpeed);
+}
+
+void TrackingControlWidget::setManualFocusPosition(int position)
+{
+    position = qBound(0, position, 100);
+    QSignalBlocker blocker(m_focusSlider);
+    m_focusSlider->setValue(position);
+    m_focusLabel->setText(QString::number(position));
+    m_pendingFocus = position;
+}
+
+void TrackingControlWidget::setTrackingStatePresentation(
+    const TrackingState &state)
+{
+    TrackingState normalized = state;
+    if (normalized.enabled
+        && normalized.aiMode == Device::AiWorkModeNone) {
+        normalized.aiMode = Device::AiWorkModeHuman;
+    }
+    if (normalized.aiMode != Device::AiWorkModeHuman) {
+        normalized.aiSubMode = 0;
+    }
+    setAiMode(normalized.aiMode);
+    setHumanSubMode(normalized.aiSubMode);
+    if (normalized.enabled) {
+        setActiveTrackingProfile(normalized.profile);
+    } else {
+        normalized.profile.focusPolicy = TrackingFocusPolicy::Manual;
+        normalized.profile.autoZoom = false;
+        setManualFocusPosition(normalized.profile.manualFocusPosition);
+        const int profileIndex =
+            tiny2TrackingModeProfileIndex(normalized.aiMode);
+        if (profileIndex >= 0) {
+            setActiveTrackingProfile(
+                m_modeProfiles[static_cast<std::size_t>(profileIndex)]);
+        }
+        else {
+            setActiveTrackingProfile(normalized.profile);
+        }
+    }
+    setTrackingEnabled(normalized.enabled);
 }
 
 void TrackingControlWidget::setTrackingEnabled(bool enabled)
 {
+    m_manualOverrideActive = !enabled;
+    m_manualControlAuthorized = false;
+    m_manualConfirmationPending = false;
+    m_trackingConfirmationPending = false;
+    m_pendingTrackingIntentGeneration = 0;
+    m_trackingIntentResolved = false;
     QSignalBlocker trackingBlocker(m_trackingCheckBox);
+    QSignalBlocker manualBlocker(m_manualControlCheckBox);
     m_trackingCheckBox->setChecked(enabled);
+    m_manualControlCheckBox->setChecked(m_manualOverrideActive);
+    m_userInitiated = true;
+    m_commandTimer->start(kCommandStateGuardMs);
     updatePTZControlsState();
 }
 
-bool TrackingControlWidget::applyTrackingState(const TrackingState &state)
+TrackingControlWidget::TrackingApplyResult
+TrackingControlWidget::applyTrackingState(const TrackingState &state)
 {
-    setAiMode(state.aiMode);
-    setHumanSubMode(state.aiSubMode);
-    setAutoZoomEnabled(state.autoZoom);
-    setTrackingEnabled(state.enabled);
-
-    m_userInitiated = true;
-    bool applied = true;
-    if (m_tiny2Capabilities) {
-        const int mode = state.enabled ? state.aiMode : Device::AiWorkModeNone;
-        if (state.enabled) {
-            applied = m_controller->enterAutoFramingMediaMode();
-        }
-        applied = m_controller->setAiMode(mode, state.enabled ? state.aiSubMode : 0) && applied;
-        applied = m_controller->setAutoZoom(state.enabled && state.autoZoom) && applied;
-        if (!state.enabled) {
-            applied = m_controller->enableAutoFraming(false) && applied;
-        }
-    } else {
-        applied = m_controller->enableAutoFraming(state.enabled);
+    TrackingState requestedState = state;
+    if (requestedState.enabled
+        && requestedState.aiMode == Device::AiWorkModeNone) {
+        requestedState.aiMode = Device::AiWorkModeHuman;
     }
-    m_commandTimer->start(1000);
-    return applied;
+    if (requestedState.aiMode != Device::AiWorkModeHuman) {
+        requestedState.aiSubMode = 0;
+    }
+
+    const TrackingState previousState = trackingState();
+    const TrackingModeProfile previousEditorProfile =
+        activeTrackingProfile();
+    const bool previousManualAuthorized = m_manualControlAuthorized;
+    const bool previousConfirmationPending = m_manualConfirmationPending;
+    const bool previousTrackingConfirmationPending =
+        m_trackingConfirmationPending;
+    const quint64 previousTrackingIntentGeneration =
+        m_pendingTrackingIntentGeneration;
+    const bool previousTrackingIntentResolved = m_trackingIntentResolved;
+    if (!isValidTrackingModeProfile(requestedState.profile)) {
+        return {};
+    }
+    if (!requestedState.enabled) {
+        requestedState.profile.focusPolicy = TrackingFocusPolicy::Manual;
+        requestedState.profile.autoZoom = false;
+    }
+    setAiMode(requestedState.aiMode);
+    setHumanSubMode(requestedState.aiSubMode);
+    if (requestedState.enabled) {
+        setActiveTrackingProfile(requestedState.profile);
+    } else {
+        setManualFocusPosition(requestedState.profile.manualFocusPosition);
+    }
+    setTrackingEnabled(requestedState.enabled);
+
+    // Start the stale-state guard before the controller emits its optimistic
+    // stateChanged signal.
+    m_userInitiated = true;
+    m_commandTimer->start(kCommandStateGuardMs);
+    const auto result = m_controller->setTrackingState(
+        requestedState.enabled, requestedState.aiMode,
+        requestedState.aiSubMode, requestedState.profile);
+    if (!result.complete()) {
+        setAiMode(previousState.aiMode);
+        setHumanSubMode(previousState.aiSubMode);
+        setActiveTrackingProfile(previousEditorProfile);
+        if (!previousState.enabled) {
+            setManualFocusPosition(
+                previousState.profile.manualFocusPosition);
+        }
+        setTrackingEnabled(previousState.enabled);
+        if (result.confirmationPending) {
+            // Either the prior camera target is still being confirmed under
+            // this generation or rollback itself is uncertain. Restore the
+            // visible intent, but keep all manual movement fail-closed.
+            m_manualControlAuthorized = false;
+            m_manualConfirmationPending = !previousState.enabled;
+            m_trackingConfirmationPending = true;
+            m_pendingTrackingIntentGeneration = result.intentGeneration;
+            m_trackingIntentResolved = false;
+        } else {
+            m_manualControlAuthorized = previousManualAuthorized;
+            m_manualConfirmationPending = previousConfirmationPending;
+            if (m_highestTrackingIntentGeneration
+                > previousTrackingIntentGeneration) {
+                m_trackingConfirmationPending = false;
+                m_pendingTrackingIntentGeneration =
+                    m_highestTrackingIntentGeneration;
+                m_trackingIntentResolved = true;
+            } else {
+                m_trackingConfirmationPending =
+                    previousTrackingConfirmationPending;
+                m_pendingTrackingIntentGeneration =
+                    previousTrackingIntentGeneration;
+                m_trackingIntentResolved = previousTrackingIntentResolved;
+            }
+        }
+        m_userInitiated = false;
+        m_commandTimer->stop();
+    } else {
+        m_manualConfirmationPending =
+            !requestedState.enabled && result.confirmationPending;
+        m_trackingConfirmationPending = result.confirmationPending;
+        m_pendingTrackingIntentGeneration = result.intentGeneration;
+        m_trackingIntentResolved = !result.confirmationPending;
+        m_manualControlAuthorized =
+            !requestedState.enabled && !result.confirmationPending;
+    }
+    updatePTZControlsState();
+    return {
+        result.complete(), result.confirmationPending,
+        result.intentGeneration
+    };
 }
 
 void TrackingControlWidget::setAiMode(int mode)
@@ -261,6 +582,7 @@ void TrackingControlWidget::setAiMode(int mode)
     if (idx >= 0) {
         QSignalBlocker blocker(m_modeCombo);
         m_modeCombo->setCurrentIndex(idx);
+        m_lastAcceptedAiMode = mode;
     }
     updateTiny2Visibility();
 }
@@ -271,6 +593,7 @@ void TrackingControlWidget::setHumanSubMode(int subMode)
     if (idx >= 0) {
         QSignalBlocker blocker(m_humanSubModeCombo);
         m_humanSubModeCombo->setCurrentIndex(idx);
+        m_lastAcceptedHumanSubMode = subMode;
     }
 }
 
@@ -278,6 +601,7 @@ void TrackingControlWidget::setAutoZoomEnabled(bool enabled)
 {
     QSignalBlocker blocker(m_autoZoomCheckBox);
     m_autoZoomCheckBox->setChecked(enabled);
+    m_activeTrackingProfile.autoZoom = enabled;
 }
 
 void TrackingControlWidget::setTrackSpeed(int speedMode)
@@ -286,6 +610,7 @@ void TrackingControlWidget::setTrackSpeed(int speedMode)
     if (idx >= 0) {
         QSignalBlocker blocker(m_speedCombo);
         m_speedCombo->setCurrentIndex(idx);
+        m_activeTrackingProfile.trackSpeed = speedMode;
     }
 }
 
@@ -297,34 +622,129 @@ void TrackingControlWidget::setAudioAutoGain(bool enabled)
 
 void TrackingControlWidget::onTrackingToggled(bool checked)
 {
-    m_userInitiated = true;
+    const TrackingModeProfile previousEditorProfile =
+        activeTrackingProfile();
+    TrackingState previousState{
+        !checked,
+        m_modeCombo->currentData().toInt(),
+        m_humanSubModeCombo->currentData().toInt(),
+        activeTrackingProfile()
+    };
+    if (!previousState.enabled) {
+        previousState.profile.focusPolicy = TrackingFocusPolicy::Manual;
+        previousState.profile.manualFocusPosition = m_focusSlider->value();
+        previousState.profile.autoZoom = false;
+    }
+    const bool previousManualOverride = m_manualOverrideActive;
+    const bool previousManualAuthorized = m_manualControlAuthorized;
+    const bool previousConfirmationPending = m_manualConfirmationPending;
+    const bool previousTrackingConfirmationPending =
+        m_trackingConfirmationPending;
+    const quint64 previousTrackingIntentGeneration =
+        m_pendingTrackingIntentGeneration;
+    const bool previousTrackingIntentResolved = m_trackingIntentResolved;
+    m_manualOverrideActive = !checked;
+    m_manualControlAuthorized = false;
+    m_manualConfirmationPending = !checked;
+    m_trackingConfirmationPending = false;
+    m_trackingIntentResolved = false;
 
-    if (m_tiny2Capabilities) {
-        int modeValue = m_modeCombo->currentData().toInt();
-        if (checked && modeValue == Device::AiWorkModeNone) {
-            int humanIndex = m_modeCombo->findData(Device::AiWorkModeHuman);
-            if (humanIndex >= 0) {
-                m_modeCombo->blockSignals(true);
-                m_modeCombo->setCurrentIndex(humanIndex);
-                m_modeCombo->blockSignals(false);
-                modeValue = Device::AiWorkModeHuman;
-            }
+    int modeValue = m_modeCombo->currentData().toInt();
+    if (checked && modeValue == Device::AiWorkModeNone) {
+        const int humanIndex = m_modeCombo->findData(Device::AiWorkModeHuman);
+        if (humanIndex >= 0) {
+            QSignalBlocker blocker(m_modeCombo);
+            m_modeCombo->setCurrentIndex(humanIndex);
+            modeValue = Device::AiWorkModeHuman;
         }
-
-        int subMode = m_humanSubModeCombo->currentData().toInt();
-        if (modeValue != Device::AiWorkModeHuman) {
-            subMode = 0;
-        }
-
-        m_controller->setAiMode(checked ? modeValue : Device::AiWorkModeNone, subMode);
     }
 
-    m_controller->enableAutoFraming(checked);
+    if (checked) {
+        // Tracking-off uses a temporary manual active profile; re-enabling
+        // always restores the selected mode's independent saved profile.
+        setActiveTrackingProfile(modeProfile(modeValue));
+    }
 
-    // Update PTZ controls state (disable when auto-framing is on)
+    int subMode = m_humanSubModeCombo->currentData().toInt();
+    if (modeValue != Device::AiWorkModeHuman) {
+        subMode = 0;
+    }
+
+    if (checked) {
+        m_controlThrottle->stop();
+        m_dirtyPanTilt = false;
+        m_dirtyZoom = false;
+        m_dirtyFocus = false;
+    }
+
+    // Guard before the controller's synchronous stateChanged emissions.
+    m_userInitiated = true;
+    m_commandTimer->start(kCommandStateGuardMs);
     updatePTZControlsState();
-
-    m_commandTimer->start(1000);
+    TrackingState requestedState{
+        checked,
+        modeValue,
+        subMode,
+        activeTrackingProfile()
+    };
+    if (!checked) {
+        requestedState.profile.focusPolicy = TrackingFocusPolicy::Manual;
+        requestedState.profile.manualFocusPosition = m_focusSlider->value();
+        requestedState.profile.autoZoom = false;
+    }
+    const auto result = m_controller->setTrackingState(
+        requestedState.enabled, requestedState.aiMode,
+        requestedState.aiSubMode, requestedState.profile);
+    emit trackingIntentEdited(requestedState, false);
+    if (!result.complete()) {
+        setAiMode(previousState.aiMode);
+        setHumanSubMode(previousState.aiSubMode);
+        setActiveTrackingProfile(previousEditorProfile);
+        {
+            QSignalBlocker blocker(m_trackingCheckBox);
+            m_trackingCheckBox->setChecked(previousState.enabled);
+        }
+        m_manualOverrideActive = previousManualOverride;
+        if (result.confirmationPending) {
+            m_manualControlAuthorized = false;
+            m_manualConfirmationPending = !previousState.enabled;
+            m_trackingConfirmationPending = true;
+            m_pendingTrackingIntentGeneration = result.intentGeneration;
+            m_trackingIntentResolved = false;
+        } else {
+            m_manualControlAuthorized = previousManualAuthorized;
+            m_manualConfirmationPending = previousConfirmationPending;
+            if (m_highestTrackingIntentGeneration
+                > previousTrackingIntentGeneration) {
+                m_trackingConfirmationPending = false;
+                m_pendingTrackingIntentGeneration =
+                    m_highestTrackingIntentGeneration;
+                m_trackingIntentResolved = true;
+            } else {
+                m_trackingConfirmationPending =
+                    previousTrackingConfirmationPending;
+                m_pendingTrackingIntentGeneration =
+                    previousTrackingIntentGeneration;
+                m_trackingIntentResolved = previousTrackingIntentResolved;
+            }
+        }
+        m_userInitiated = false;
+        m_commandTimer->stop();
+    } else {
+        // The command was accepted even when its fresh camera confirmation is
+        // still pending; use that accepted selection as the rollback baseline
+        // for any immediately following mode edit.
+        m_lastAcceptedAiMode = modeValue;
+        if (modeValue == Device::AiWorkModeHuman) {
+            m_lastAcceptedHumanSubMode = subMode;
+        }
+        m_manualConfirmationPending = !checked && result.confirmationPending;
+        m_trackingConfirmationPending = result.confirmationPending;
+        m_pendingTrackingIntentGeneration = result.intentGeneration;
+        m_trackingIntentResolved = !result.confirmationPending;
+        m_manualControlAuthorized = !checked && !result.confirmationPending;
+    }
+    updatePTZControlsState();
 }
 
 void TrackingControlWidget::updateFromState(const CameraController::CameraState &state)
@@ -336,19 +756,31 @@ void TrackingControlWidget::updateFromState(const CameraController::CameraState 
     // 4. Camera is not settling
     // For Tiny2: aiMode determines tracking state
     // For non-Tiny2 (original Tiny): use autoFramingEnabled flag
-    bool shouldBeChecked = m_tiny2Capabilities
+    const bool cameraReportsTracking = m_tiny2Capabilities
         ? (state.aiMode != Device::AiWorkModeNone)
         : state.autoFramingEnabled;
-    bool commandInFlight = m_commandTimer->isActive();
-    bool isSettling = m_controller->isSettling();
-
-    if (m_trackingCheckBox->isChecked() != shouldBeChecked && !m_userInitiated && !commandInFlight && !isSettling) {
-        m_trackingCheckBox->blockSignals(true);
-        m_trackingCheckBox->setChecked(shouldBeChecked);
-        m_trackingCheckBox->blockSignals(false);
-    }
+    const bool commandInFlight = m_commandTimer->isActive();
+    const bool isSettling = m_controller->isSettling();
+    const bool hasCurrentExplicitIntent =
+        m_pendingTrackingIntentGeneration != 0
+        && m_pendingTrackingIntentGeneration
+            == m_highestTrackingIntentGeneration;
 
     if (!m_userInitiated && !commandInFlight && !isSettling) {
+        // Generic cameraStatus() telemetry may lag. It can orient an
+        // uninitialized widget, but it cannot replace a resolved explicit
+        // tracking intent, create a manual latch, or authorize movement.
+        const bool hasResolvedExplicitIntent =
+            hasCurrentExplicitIntent && m_trackingIntentResolved;
+        const bool shouldBeChecked = m_manualOverrideActive
+            ? false
+            : (hasResolvedExplicitIntent
+                   ? m_trackingCheckBox->isChecked()
+                   : cameraReportsTracking);
+        if (m_trackingCheckBox->isChecked() != shouldBeChecked) {
+            QSignalBlocker blocker(m_trackingCheckBox);
+            m_trackingCheckBox->setChecked(shouldBeChecked);
+        }
         updatePTZControlsState();
     }
 
@@ -358,53 +790,47 @@ void TrackingControlWidget::updateFromState(const CameraController::CameraState 
         updateTiny2Visibility();
     }
 
-    if (m_tiny2Capabilities && !m_userInitiated && !commandInFlight && !isSettling) {
-        int modeIdx = m_modeCombo->findData(state.aiMode);
-        if (modeIdx >= 0 && m_modeCombo->currentIndex() != modeIdx) {
-            m_modeCombo->blockSignals(true);
-            m_modeCombo->setCurrentIndex(modeIdx);
-            m_modeCombo->blockSignals(false);
-        }
-
-        updateTiny2Visibility();
-
-        if (state.aiMode == Device::AiWorkModeHuman) {
-            int subIdx = m_humanSubModeCombo->findData(state.aiSubMode);
-            if (subIdx >= 0 && m_humanSubModeCombo->currentIndex() != subIdx) {
-                m_humanSubModeCombo->blockSignals(true);
-                m_humanSubModeCombo->setCurrentIndex(subIdx);
-                m_humanSubModeCombo->blockSignals(false);
+    if (m_tiny2Capabilities && !m_manualOverrideActive
+        && !m_userInitiated && !commandInFlight && !isSettling) {
+        // AI mode, sub-mode, and auto-zoom are one exact operator intent.
+        // Ungenerated SDK telemetry may initialize them, but cannot rewrite an
+        // explicit pending or resolved selection (or its rollback baseline).
+        if (!hasCurrentExplicitIntent) {
+            int modeIdx = m_modeCombo->findData(state.aiMode);
+            if (modeIdx >= 0) {
+                if (m_modeCombo->currentIndex() != modeIdx) {
+                    m_modeCombo->blockSignals(true);
+                    m_modeCombo->setCurrentIndex(modeIdx);
+                    m_modeCombo->blockSignals(false);
+                }
+                m_lastAcceptedAiMode = state.aiMode;
             }
-        }
 
-        if (m_autoZoomCheckBox->isChecked() != state.autoZoomEnabled) {
-            m_autoZoomCheckBox->blockSignals(true);
-            m_autoZoomCheckBox->setChecked(state.autoZoomEnabled);
-            m_autoZoomCheckBox->blockSignals(false);
-        }
+            updateTiny2Visibility();
 
-        int speedIdx = m_speedCombo->findData(state.trackSpeedMode);
-        if (speedIdx >= 0 && m_speedCombo->currentIndex() != speedIdx) {
-            m_speedCombo->blockSignals(true);
-            m_speedCombo->setCurrentIndex(speedIdx);
-            m_speedCombo->blockSignals(false);
+            if (state.aiMode == Device::AiWorkModeHuman) {
+                int subIdx = m_humanSubModeCombo->findData(state.aiSubMode);
+                if (subIdx >= 0) {
+                    if (m_humanSubModeCombo->currentIndex() != subIdx) {
+                        m_humanSubModeCombo->blockSignals(true);
+                        m_humanSubModeCombo->setCurrentIndex(subIdx);
+                        m_humanSubModeCombo->blockSignals(false);
+                    }
+                    m_lastAcceptedHumanSubMode = state.aiSubMode;
+                }
+            }
+
+            if (m_autoZoomCheckBox->isChecked() != state.autoZoomEnabled) {
+                m_autoZoomCheckBox->blockSignals(true);
+                m_autoZoomCheckBox->setChecked(state.autoZoomEnabled);
+                m_autoZoomCheckBox->blockSignals(false);
+            }
         }
 
         if (m_audioGainCheckBox->isChecked() != state.audioAutoGainEnabled) {
             m_audioGainCheckBox->blockSignals(true);
             m_audioGainCheckBox->setChecked(state.audioAutoGainEnabled);
             m_audioGainCheckBox->blockSignals(false);
-        }
-    }
-
-    // Sync zoom slider from camera state (only when user isn't dragging)
-    if (!m_zoomSlider->isSliderDown() && !commandInFlight && !isSettling) {
-        int zoomSliderVal = static_cast<int>(state.zoom * 10.0 + 0.5);
-        if (m_zoomSlider->value() != zoomSliderVal) {
-            m_zoomSlider->blockSignals(true);
-            m_zoomSlider->setValue(zoomSliderVal);
-            m_zoomSlider->blockSignals(false);
-            m_zoomLabel->setText(QString("%1x").arg(zoomSliderVal / 10.0, 0, 'f', 1));
         }
     }
 
@@ -455,76 +881,456 @@ void TrackingControlWidget::onModeChanged(int index)
     Q_UNUSED(index);
     if (!m_tiny2Capabilities) return;
 
-    int modeValue = m_modeCombo->currentData().toInt();
+    const int modeValue = m_modeCombo->currentData().toInt();
+    const int previousModeValue = m_lastAcceptedAiMode;
+    const int previousSubMode = m_lastAcceptedHumanSubMode;
+    const TrackingModeProfile previousProfile = activeTrackingProfile();
+    const bool previousTracking = m_trackingCheckBox->isChecked();
+    const bool previousManualOverride = m_manualOverrideActive;
+    const bool previousManualAuthorized = m_manualControlAuthorized;
+    const bool previousConfirmationPending = m_manualConfirmationPending;
+    const bool previousTrackingConfirmationPending =
+        m_trackingConfirmationPending;
+    const quint64 previousTrackingIntentGeneration =
+        m_pendingTrackingIntentGeneration;
+    const bool previousTrackingIntentResolved = m_trackingIntentResolved;
     m_humanSubModeCombo->setEnabled(modeValue == Device::AiWorkModeHuman);
 
-    m_userInitiated = true;
     int subMode = m_humanSubModeCombo->currentData().toInt();
     if (modeValue != Device::AiWorkModeHuman) {
         subMode = 0;
     }
 
-    m_controller->setAiMode(modeValue, subMode);
+    const bool shouldCheck = modeValue != Device::AiWorkModeNone;
+    TrackingModeProfile requestedProfile = shouldCheck
+        ? modeProfile(modeValue) : previousProfile;
+    if (!shouldCheck) {
+        requestedProfile.focusPolicy = TrackingFocusPolicy::Manual;
+        requestedProfile.manualFocusPosition = m_focusSlider->value();
+        requestedProfile.autoZoom = false;
+    }
+    setActiveTrackingProfile(requestedProfile);
 
-    bool shouldCheck = modeValue != Device::AiWorkModeNone;
+    m_manualOverrideActive = !shouldCheck;
+    m_manualControlAuthorized = false;
+    m_manualConfirmationPending = !shouldCheck;
+    m_trackingConfirmationPending = false;
+    m_trackingIntentResolved = false;
     if (m_trackingCheckBox->isChecked() != shouldCheck) {
-        m_trackingCheckBox->blockSignals(true);
+        QSignalBlocker blocker(m_trackingCheckBox);
         m_trackingCheckBox->setChecked(shouldCheck);
-        m_trackingCheckBox->blockSignals(false);
     }
     updatePTZControlsState();
     updateTiny2Visibility();
 
-    m_commandTimer->start(1000);
+    const TrackingState requestedState{
+        shouldCheck, modeValue, subMode, requestedProfile};
+    m_userInitiated = true;
+    m_commandTimer->start(kCommandStateGuardMs);
+    const auto result = m_controller->setTrackingState(
+        requestedState.enabled, requestedState.aiMode,
+        requestedState.aiSubMode, requestedState.profile);
+    emit trackingIntentEdited(requestedState, false);
+    if (!result.complete()) {
+        setAiMode(previousModeValue);
+        setHumanSubMode(previousSubMode);
+        setActiveTrackingProfile(previousProfile);
+        QSignalBlocker blocker(m_trackingCheckBox);
+        m_trackingCheckBox->setChecked(previousTracking);
+        m_manualOverrideActive = previousManualOverride;
+        if (result.confirmationPending) {
+            m_manualControlAuthorized = false;
+            m_manualConfirmationPending = previousManualOverride;
+            m_trackingConfirmationPending = true;
+            m_pendingTrackingIntentGeneration = result.intentGeneration;
+            m_trackingIntentResolved = false;
+        } else {
+            m_manualControlAuthorized = previousManualAuthorized;
+            m_manualConfirmationPending = previousConfirmationPending;
+            if (m_highestTrackingIntentGeneration
+                > previousTrackingIntentGeneration) {
+                m_trackingConfirmationPending = false;
+                m_pendingTrackingIntentGeneration =
+                    m_highestTrackingIntentGeneration;
+                m_trackingIntentResolved = true;
+            } else {
+                m_trackingConfirmationPending =
+                    previousTrackingConfirmationPending;
+                m_pendingTrackingIntentGeneration =
+                    previousTrackingIntentGeneration;
+                m_trackingIntentResolved = previousTrackingIntentResolved;
+            }
+        }
+        m_userInitiated = false;
+        m_commandTimer->stop();
+    } else {
+        m_lastAcceptedAiMode = modeValue;
+        if (modeValue == Device::AiWorkModeHuman) {
+            m_lastAcceptedHumanSubMode = subMode;
+        }
+        m_manualConfirmationPending = !shouldCheck && result.confirmationPending;
+        m_trackingConfirmationPending = result.confirmationPending;
+        m_pendingTrackingIntentGeneration = result.intentGeneration;
+        m_trackingIntentResolved = !result.confirmationPending;
+        m_manualControlAuthorized = !shouldCheck && !result.confirmationPending;
+    }
+    updatePTZControlsState();
 }
 
 void TrackingControlWidget::onHumanSubModeChanged(int index)
 {
     Q_UNUSED(index);
     if (!m_tiny2Capabilities) return;
+    if (currentAiMode() != Device::AiWorkModeHuman) return;
 
-    if (m_modeCombo->currentData().toInt() != Device::AiWorkModeHuman) {
+    TrackingState requestedState = trackingState();
+    if (m_manualOverrideActive) {
+        requestedState.aiSubMode = currentHumanSubMode();
+        m_lastAcceptedHumanSubMode = requestedState.aiSubMode;
+        emit trackingIntentEdited(requestedState, false);
         return;
     }
+    requestedState.enabled = true;
+    requestedState.aiMode = Device::AiWorkModeHuman;
+    requestedState.aiSubMode = currentHumanSubMode();
+    emit trackingIntentEdited(requestedState, false);
 
+    const quint64 previousGeneration = m_pendingTrackingIntentGeneration;
+    const bool previousPending = m_trackingConfirmationPending;
+    const bool previousResolved = m_trackingIntentResolved;
+    const int previousSubMode = m_lastAcceptedHumanSubMode;
     m_userInitiated = true;
-    m_controller->setAiMode(Device::AiWorkModeHuman, m_humanSubModeCombo->currentData().toInt());
-    m_commandTimer->start(1000);
+    m_commandTimer->start(kCommandStateGuardMs);
+    const auto result = m_controller->setTrackingState(
+        requestedState.enabled, requestedState.aiMode,
+        requestedState.aiSubMode, requestedState.profile);
+    if (result.complete()) {
+        m_lastAcceptedHumanSubMode = requestedState.aiSubMode;
+        m_trackingConfirmationPending = result.confirmationPending;
+        m_pendingTrackingIntentGeneration = result.intentGeneration;
+        m_trackingIntentResolved = !result.confirmationPending;
+    } else {
+        setHumanSubMode(previousSubMode);
+        if (result.confirmationPending) {
+            m_trackingConfirmationPending = true;
+            m_pendingTrackingIntentGeneration = result.intentGeneration;
+            m_trackingIntentResolved = false;
+            return;
+        }
+        if (m_highestTrackingIntentGeneration > previousGeneration) {
+            m_trackingConfirmationPending = false;
+            m_pendingTrackingIntentGeneration =
+                m_highestTrackingIntentGeneration;
+            m_trackingIntentResolved = true;
+        } else {
+            m_trackingConfirmationPending = previousPending;
+            m_pendingTrackingIntentGeneration = previousGeneration;
+            m_trackingIntentResolved = previousResolved;
+        }
+        m_userInitiated = false;
+        m_commandTimer->stop();
+    }
 }
 
 void TrackingControlWidget::onAutoZoomToggled(bool checked)
 {
     if (!m_tiny2Capabilities) return;
-    m_userInitiated = true;
-    m_controller->setAutoZoom(checked);
-    m_commandTimer->start(1000);
+    if (tiny2TrackingModeProfileIndex(currentAiMode()) < 0) {
+        setAutoZoomEnabled(m_activeTrackingProfile.autoZoom);
+        return;
+    }
+    m_activeTrackingProfile.autoZoom = checked;
+    storeActiveProfileForCurrentMode();
+    persistActiveTrackingIntent(true);
+    submitCurrentTrackingProfile();
 }
 
 void TrackingControlWidget::onSpeedChanged(int index)
 {
     Q_UNUSED(index);
     if (!m_tiny2Capabilities) return;
+    if (tiny2TrackingModeProfileIndex(currentAiMode()) < 0) {
+        setTrackSpeed(m_activeTrackingProfile.trackSpeed);
+        return;
+    }
+    m_activeTrackingProfile.trackSpeed = currentTrackSpeed();
+    storeActiveProfileForCurrentMode();
+    persistActiveTrackingIntent(true);
+    submitCurrentTrackingProfile();
+}
+
+void TrackingControlWidget::onProfileFocusPolicyChanged(int index)
+{
+    Q_UNUSED(index);
+    if (!m_tiny2Capabilities) return;
+    if (tiny2TrackingModeProfileIndex(currentAiMode()) < 0) {
+        setActiveTrackingProfile(m_activeTrackingProfile);
+        return;
+    }
+    m_activeTrackingProfile.focusPolicy = static_cast<TrackingFocusPolicy>(
+        m_profileFocusPolicyCombo->currentData().toInt());
+    storeActiveProfileForCurrentMode();
+    persistActiveTrackingIntent(true);
+    submitCurrentTrackingProfile();
+}
+
+void TrackingControlWidget::onProfileFocusPositionChanged(int value)
+{
+    if (!m_tiny2Capabilities) return;
+    if (tiny2TrackingModeProfileIndex(currentAiMode()) < 0) {
+        setActiveTrackingProfile(m_activeTrackingProfile);
+        return;
+    }
+    m_profileFocusLabel->setText(QString::number(value));
+    m_activeTrackingProfile.manualFocusPosition = value;
+    storeActiveProfileForCurrentMode();
+    persistActiveTrackingIntent(true);
+    if (isTrackingEnabled()
+        && m_activeTrackingProfile.focusPolicy
+            == TrackingFocusPolicy::Manual) {
+        m_profileFocusTimer->start();
+    }
+}
+
+void TrackingControlWidget::storeActiveProfileForCurrentMode()
+{
+    m_activeTrackingProfile = activeTrackingProfile();
+    const int profileIndex = tiny2TrackingModeProfileIndex(currentAiMode());
+    if (profileIndex >= 0) {
+        m_modeProfiles[static_cast<std::size_t>(profileIndex)] =
+            m_activeTrackingProfile;
+    }
+}
+
+void TrackingControlWidget::persistActiveTrackingIntent(
+    bool updateModeProfile)
+{
+    TrackingState intent = trackingState();
+    if (updateModeProfile && !intent.enabled) {
+        // The profile editor remains bound to the retained AI mode while the
+        // active camera intent is temporary manual/off.
+        intent.profile = activeTrackingProfile();
+    }
+    emit trackingIntentEdited(intent, updateModeProfile);
+}
+
+void TrackingControlWidget::submitCurrentTrackingProfile()
+{
+    if (!m_tiny2Capabilities || !isTrackingEnabled()) {
+        return;
+    }
+
+    const TrackingState requestedState = trackingState();
     m_userInitiated = true;
-    m_controller->setTrackSpeed(m_speedCombo->currentData().toInt());
-    m_commandTimer->start(1000);
+    m_commandTimer->start(kCommandStateGuardMs);
+    const auto result = m_controller->setTrackingState(
+        requestedState.enabled, requestedState.aiMode,
+        requestedState.aiSubMode, requestedState.profile);
+    if (result.complete()) {
+        m_trackingConfirmationPending = result.confirmationPending;
+        m_pendingTrackingIntentGeneration = result.intentGeneration;
+        m_trackingIntentResolved = !result.confirmationPending;
+    } else if (result.confirmationPending) {
+        m_trackingConfirmationPending = true;
+        m_pendingTrackingIntentGeneration = result.intentGeneration;
+        m_trackingIntentResolved = false;
+    } else {
+        m_trackingConfirmationPending = false;
+        m_pendingTrackingIntentGeneration =
+            m_highestTrackingIntentGeneration;
+        m_trackingIntentResolved = true;
+        m_userInitiated = false;
+        m_commandTimer->stop();
+    }
 }
 
 void TrackingControlWidget::onAudioGainToggled(bool checked)
 {
     if (!m_tiny2Capabilities) return;
+    emit audioAutoGainIntentEdited(checked);
     m_userInitiated = true;
+    m_commandTimer->start(kCommandStateGuardMs);
     m_controller->setAudioAutoGain(checked);
-    m_commandTimer->start(1000);
 }
 
 void TrackingControlWidget::onManualControlToggled(bool checked)
 {
     const bool trackingShouldBeEnabled = !checked;
     if (m_trackingCheckBox->isChecked() != trackingShouldBeEnabled) {
+        // The tracking handler owns the product-specific camera transition and
+        // rolls the checkbox back if the essential camera command fails.
         m_trackingCheckBox->setChecked(trackingShouldBeEnabled);
+    } else if (checked
+               && (!m_manualOverrideActive || !m_manualControlAuthorized)) {
+        // Generic status may already display tracking as off, but it is never
+        // sufficient movement authorization. Explicitly submit tracking-off so
+        // this manual request receives a generation-bound confirmation.
+        onTrackingToggled(false);
     } else {
+        m_manualOverrideActive = checked;
+        if (!checked) {
+            m_manualControlAuthorized = false;
+        }
         updatePTZControlsState();
     }
+}
+
+void TrackingControlWidget::onTrackingIntentStarted(quint64 intentGeneration)
+{
+    if (intentGeneration == 0
+        || intentGeneration <= m_highestTrackingIntentGeneration) {
+        return;
+    }
+    m_highestTrackingIntentGeneration = intentGeneration;
+    m_pendingTrackingIntentGeneration = intentGeneration;
+    m_trackingIntentResolved = false;
+    m_trackingConfirmationPending = false;
+    // Any new ownership intent immediately revokes movement authorization.
+    m_manualControlAuthorized = false;
+    m_controlThrottle->stop();
+    m_dirtyPanTilt = false;
+    m_dirtyZoom = false;
+    m_dirtyFocus = false;
+    updatePTZControlsState();
+}
+
+void TrackingControlWidget::onTrackingStateConfirmationPending(
+    bool trackingEnabled, quint64 intentGeneration)
+{
+    if (intentGeneration != m_pendingTrackingIntentGeneration
+        || intentGeneration != m_highestTrackingIntentGeneration
+        || m_trackingIntentResolved) {
+        return;
+    }
+    m_userInitiated = true;
+    m_commandTimer->start(kCommandStateGuardMs);
+    m_trackingConfirmationPending = true;
+    m_manualOverrideActive = !trackingEnabled;
+    m_manualControlAuthorized = false;
+    m_manualConfirmationPending = !trackingEnabled;
+    {
+        QSignalBlocker blocker(m_trackingCheckBox);
+        m_trackingCheckBox->setChecked(trackingEnabled);
+    }
+    m_controlThrottle->stop();
+    m_dirtyPanTilt = false;
+    m_dirtyZoom = false;
+    m_dirtyFocus = false;
+    updatePTZControlsState();
+}
+
+void TrackingControlWidget::onTrackingStateConfirmationFailed(
+    bool trackingEnabled, quint64 intentGeneration)
+{
+    if (intentGeneration != m_pendingTrackingIntentGeneration
+        || intentGeneration != m_highestTrackingIntentGeneration
+        || m_trackingIntentResolved) {
+        return;
+    }
+    Q_UNUSED(trackingEnabled);
+    m_userInitiated = false;
+    m_commandTimer->stop();
+    // A terminal mismatch reports camera reality but does not replace the
+    // operator's requested mode. In particular, failed tracking-off keeps the
+    // manual latch visible while movement remains fail-closed.
+    m_manualControlAuthorized = false;
+    m_manualConfirmationPending = m_manualOverrideActive;
+    m_trackingConfirmationPending = false;
+    m_trackingIntentResolved = true;
+    {
+        QSignalBlocker blocker(m_trackingCheckBox);
+        m_trackingCheckBox->setChecked(!m_manualOverrideActive);
+    }
+    m_controlThrottle->stop();
+    m_dirtyPanTilt = false;
+    m_dirtyZoom = false;
+    m_dirtyFocus = false;
+    updatePTZControlsState();
+}
+
+void TrackingControlWidget::onTrackingStateConfirmationUncertain(
+    quint64 intentGeneration)
+{
+    if (intentGeneration != m_pendingTrackingIntentGeneration
+        || intentGeneration != m_highestTrackingIntentGeneration
+        || m_trackingIntentResolved) {
+        return;
+    }
+    m_userInitiated = false;
+    m_commandTimer->stop();
+    m_trackingConfirmationPending = true;
+    m_manualControlAuthorized = false;
+    m_manualConfirmationPending = m_manualOverrideActive;
+    if (!m_manualOverrideActive) {
+        QSignalBlocker blocker(m_trackingCheckBox);
+        m_trackingCheckBox->setChecked(true);
+    }
+    m_controlThrottle->stop();
+    m_dirtyPanTilt = false;
+    m_dirtyZoom = false;
+    m_dirtyFocus = false;
+    updatePTZControlsState();
+}
+
+void TrackingControlWidget::onTrackingStateConfirmed(
+    bool trackingEnabled, quint64 intentGeneration)
+{
+    if (intentGeneration != m_pendingTrackingIntentGeneration
+        || intentGeneration != m_highestTrackingIntentGeneration
+        || m_trackingIntentResolved) {
+        return;
+    }
+
+    m_userInitiated = false;
+    m_commandTimer->stop();
+    m_manualOverrideActive = !trackingEnabled;
+    m_manualControlAuthorized = !trackingEnabled;
+    m_manualConfirmationPending = false;
+    m_trackingConfirmationPending = false;
+    m_trackingIntentResolved = true;
+    {
+        QSignalBlocker blocker(m_trackingCheckBox);
+        m_trackingCheckBox->setChecked(trackingEnabled);
+    }
+    if (trackingEnabled) {
+        m_controlThrottle->stop();
+        m_dirtyPanTilt = false;
+        m_dirtyZoom = false;
+        m_dirtyFocus = false;
+    }
+    updatePTZControlsState();
+}
+
+void TrackingControlWidget::onTrackingOwnershipObserved(bool trackingEnabled)
+{
+    const bool currentIntentUnresolved =
+        !m_trackingIntentResolved
+        && m_pendingTrackingIntentGeneration != 0
+        && m_pendingTrackingIntentGeneration
+            == m_highestTrackingIntentGeneration;
+    if (!m_manualOverrideActive || currentIntentUnresolved) {
+        // AI-off alone cannot resolve an uncertain auto-zoom rollback. Only a
+        // generation-bound terminal result (or a new explicit intent) may clear
+        // that fail-closed ownership state.
+        return;
+    }
+
+    // This signal is emitted only from a successful fresh Tiny 2 status read.
+    // It can revoke or restore movement authority without changing the
+    // operator's explicit manual-mode latch.
+    m_manualControlAuthorized = !trackingEnabled;
+    m_manualConfirmationPending = trackingEnabled;
+    {
+        QSignalBlocker blocker(m_trackingCheckBox);
+        m_trackingCheckBox->setChecked(false);
+    }
+    if (trackingEnabled) {
+        m_controlThrottle->stop();
+        m_dirtyPanTilt = false;
+        m_dirtyZoom = false;
+        m_dirtyFocus = false;
+    }
+    updatePTZControlsState();
 }
 
 void TrackingControlWidget::onDeskModeToggled(bool checked)
@@ -543,7 +1349,16 @@ void TrackingControlWidget::updateTiny2Visibility()
     }
 
     m_advancedContainer->setVisible(m_tiny2Capabilities);
-    m_humanSubModeCombo->setEnabled(m_tiny2Capabilities && m_modeCombo->currentData().toInt() == Device::AiWorkModeHuman);
+    const int selectedMode = m_modeCombo->currentData().toInt();
+    const bool profileModeSelected = m_tiny2Capabilities
+        && tiny2TrackingModeProfileIndex(selectedMode) >= 0;
+    m_humanSubModeCombo->setEnabled(
+        m_tiny2Capabilities && selectedMode == Device::AiWorkModeHuman);
+    m_autoZoomCheckBox->setEnabled(profileModeSelected);
+    m_speedCombo->setEnabled(profileModeSelected);
+    m_profileFocusPolicyCombo->setEnabled(profileModeSelected);
+    m_profileFocusSlider->setEnabled(profileModeSelected);
+    m_profileFocusLabel->setEnabled(profileModeSelected);
     if (m_deskModeCheckBox) {
         QSignalBlocker blocker(m_deskModeCheckBox);
         m_deskModeCheckBox->setChecked(
@@ -553,18 +1368,36 @@ void TrackingControlWidget::updateTiny2Visibility()
 
 void TrackingControlWidget::updatePTZControlsState()
 {
-    const bool manualEnabled = !m_trackingCheckBox->isChecked();
     if (m_manualControlCheckBox) {
         QSignalBlocker blocker(m_manualControlCheckBox);
-        m_manualControlCheckBox->setChecked(manualEnabled);
+        m_manualControlCheckBox->setChecked(m_manualOverrideActive);
+        m_manualControlCheckBox->setEnabled(!m_v4l2Only);
     }
     if (m_ptzGroupBox) {
-        m_ptzGroupBox->setEnabled(manualEnabled);
+        if (m_v4l2Only) {
+            m_ptzGroupBox->setTitle(
+                tr("Manual Camera Control (SDK tracking confirmation unavailable)"));
+        } else if (m_manualOverrideActive && !m_manualControlAuthorized) {
+            m_ptzGroupBox->setTitle(
+                tr("Manual Camera Control (waiting for tracking to stop)"));
+        } else {
+            m_ptzGroupBox->setTitle(tr("Manual Camera Control"));
+        }
+        m_ptzGroupBox->setEnabled(
+            !m_v4l2Only
+            && m_manualOverrideActive
+            && m_manualControlAuthorized);
     }
 }
 
 void TrackingControlWidget::flushPendingCommands()
 {
+    if (!isManualControlEnabled()) {
+        m_dirtyPanTilt = false;
+        m_dirtyZoom = false;
+        m_dirtyFocus = false;
+        return;
+    }
     if (m_dirtyPanTilt) {
         m_controller->setPanTilt(m_pendingPan, m_pendingTilt);
         m_dirtyPanTilt = false;
@@ -581,6 +1414,9 @@ void TrackingControlWidget::flushPendingCommands()
 
 void TrackingControlWidget::scheduleFlush()
 {
+    if (!isManualControlEnabled()) {
+        return;
+    }
     // First change fires immediately, subsequent ones coalesce at 100ms
     if (!m_controlThrottle->isActive()) {
         flushPendingCommands();
@@ -590,10 +1426,14 @@ void TrackingControlWidget::scheduleFlush()
 
 void TrackingControlWidget::onXYPadChanged(float x, float y)
 {
+    if (!isManualControlEnabled()) {
+        return;
+    }
     if (m_invertControlsCheckBox->isChecked()) {
         x = -x;
         y = -y;
     }
+    emit panTiltIntentEdited(x, y);
 
     m_pendingPan = x;
     m_pendingTilt = y;
@@ -608,6 +1448,10 @@ void TrackingControlWidget::onXYPadChanged(float x, float y)
 
 void TrackingControlWidget::onZoomChanged(int value)
 {
+    if (!isManualControlEnabled()) {
+        return;
+    }
+    emit zoomIntentEdited(value / 100.0);
     m_pendingZoom = value;
     m_dirtyZoom = true;
     m_zoomLabel->setText(QString("%1x").arg(value / 100.0, 0, 'f', 2));
@@ -616,6 +1460,14 @@ void TrackingControlWidget::onZoomChanged(int value)
 
 void TrackingControlWidget::onFocusChanged(int value)
 {
+    if (!isManualControlEnabled()) {
+        return;
+    }
+    emit focusIntentEdited(value);
+    m_activeTrackingProfile.focusPolicy = TrackingFocusPolicy::Manual;
+    m_activeTrackingProfile.manualFocusPosition = value;
+    m_activeTrackingProfile.autoZoom = false;
+    emit trackingIntentEdited(trackingState(), false);
     m_pendingFocus = value;
     m_dirtyFocus = true;
     m_focusLabel->setText(QString::number(value));
@@ -624,7 +1476,26 @@ void TrackingControlWidget::onFocusChanged(int value)
 
 void TrackingControlWidget::setV4l2Mode(bool v4l2Only)
 {
+    m_v4l2Only = v4l2Only;
     m_trackingGroupBox->setVisible(!v4l2Only);
+    if (v4l2Only) {
+        m_manualOverrideActive = true;
+        // V4L2 exposes camera controls but cannot positively confirm that an
+        // SDK tracking mode released gimbal ownership. Keep every movement
+        // control fail-closed rather than treating backend choice as proof.
+        m_manualControlAuthorized = false;
+        m_manualConfirmationPending = false;
+        m_trackingConfirmationPending = false;
+        m_pendingTrackingIntentGeneration = 0;
+        m_trackingIntentResolved = false;
+        QSignalBlocker trackingBlocker(m_trackingCheckBox);
+        m_trackingCheckBox->setChecked(false);
+    } else {
+        // SDK cameras must re-establish AI ownership before manual movement.
+        m_manualControlAuthorized = false;
+        m_trackingIntentResolved = false;
+    }
+    updatePTZControlsState();
 }
 
 void TrackingControlWidget::setMirrored(bool mirrored)

--- a/src/gui/TrackingControlWidget.cpp
+++ b/src/gui/TrackingControlWidget.cpp
@@ -57,6 +57,12 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     modeLayout->addWidget(m_modeCombo, 1);
     advancedLayout->addLayout(modeLayout);
 
+    m_deskModeCheckBox = new QCheckBox(tr("Use camera Desk mode for automatic paper framing (direct feed)"), this);
+    m_deskModeCheckBox->setStyleSheet("font-size: 11px;");
+    connect(m_deskModeCheckBox, &QCheckBox::toggled,
+            this, &TrackingControlWidget::onDeskModeToggled);
+    advancedLayout->addWidget(m_deskModeCheckBox);
+
     QHBoxLayout *subModeLayout = new QHBoxLayout();
     QLabel *subModeLabel = new QLabel("Human Sub-Mode", this);
     subModeLabel->setStyleSheet("font-size: 11px; font-weight: 600;");
@@ -111,9 +117,15 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     ptzContainerLayout->setContentsMargins(0, 0, 0, 0);
     ptzContainerLayout->setSpacing(0);
 
-    QGroupBox *ptzGroupBox = new QGroupBox("Manual Camera Control", this);
-    ptzGroupBox->setFlat(true);
-    QVBoxLayout *ptzGroupLayout = new QVBoxLayout(ptzGroupBox);
+    m_manualControlCheckBox = new QCheckBox(tr("Enable manual positioning (turns tracking off)"), m_ptzContainer);
+    m_manualControlCheckBox->setChecked(true);
+    connect(m_manualControlCheckBox, &QCheckBox::toggled,
+            this, &TrackingControlWidget::onManualControlToggled);
+    ptzContainerLayout->addWidget(m_manualControlCheckBox);
+
+    m_ptzGroupBox = new QGroupBox("Manual Camera Control", this);
+    m_ptzGroupBox->setFlat(true);
+    QVBoxLayout *ptzGroupLayout = new QVBoxLayout(m_ptzGroupBox);
     ptzGroupLayout->setContentsMargins(16, 16, 16, 16);
     ptzGroupLayout->setSpacing(12);
 
@@ -186,13 +198,61 @@ TrackingControlWidget::TrackingControlWidget(CameraController *controller, QWidg
     m_positionLabel->setStyleSheet("color: palette(mid); font-size: 11px;");
     ptzGroupLayout->addWidget(m_positionLabel);
 
-    ptzContainerLayout->addWidget(ptzGroupBox);
+    ptzContainerLayout->addWidget(m_ptzGroupBox);
     layout->addWidget(m_ptzContainer);
 
     // Update PTZ controls state based on auto-framing
     updatePTZControlsState();
 
     layout->addStretch();
+}
+
+bool TrackingControlWidget::isManualControlEnabled() const
+{
+    return m_manualControlCheckBox && m_manualControlCheckBox->isChecked();
+}
+
+TrackingControlWidget::TrackingState TrackingControlWidget::trackingState() const
+{
+    return {
+        isTrackingEnabled(),
+        currentAiMode(),
+        currentHumanSubMode(),
+        isAutoZoomEnabled()
+    };
+}
+
+void TrackingControlWidget::setTrackingEnabled(bool enabled)
+{
+    QSignalBlocker trackingBlocker(m_trackingCheckBox);
+    m_trackingCheckBox->setChecked(enabled);
+    updatePTZControlsState();
+}
+
+bool TrackingControlWidget::applyTrackingState(const TrackingState &state)
+{
+    setAiMode(state.aiMode);
+    setHumanSubMode(state.aiSubMode);
+    setAutoZoomEnabled(state.autoZoom);
+    setTrackingEnabled(state.enabled);
+
+    m_userInitiated = true;
+    bool applied = true;
+    if (m_tiny2Capabilities) {
+        const int mode = state.enabled ? state.aiMode : Device::AiWorkModeNone;
+        if (state.enabled) {
+            applied = m_controller->enterAutoFramingMediaMode();
+        }
+        applied = m_controller->setAiMode(mode, state.enabled ? state.aiSubMode : 0) && applied;
+        applied = m_controller->setAutoZoom(state.enabled && state.autoZoom) && applied;
+        if (!state.enabled) {
+            applied = m_controller->enableAutoFraming(false) && applied;
+        }
+    } else {
+        applied = m_controller->enableAutoFraming(state.enabled);
+    }
+    m_commandTimer->start(1000);
+    return applied;
 }
 
 void TrackingControlWidget::setAiMode(int mode)
@@ -412,6 +472,8 @@ void TrackingControlWidget::onModeChanged(int index)
         m_trackingCheckBox->setChecked(shouldCheck);
         m_trackingCheckBox->blockSignals(false);
     }
+    updatePTZControlsState();
+    updateTiny2Visibility();
 
     m_commandTimer->start(1000);
 }
@@ -455,6 +517,25 @@ void TrackingControlWidget::onAudioGainToggled(bool checked)
     m_commandTimer->start(1000);
 }
 
+void TrackingControlWidget::onManualControlToggled(bool checked)
+{
+    const bool trackingShouldBeEnabled = !checked;
+    if (m_trackingCheckBox->isChecked() != trackingShouldBeEnabled) {
+        m_trackingCheckBox->setChecked(trackingShouldBeEnabled);
+    } else {
+        updatePTZControlsState();
+    }
+}
+
+void TrackingControlWidget::onDeskModeToggled(bool checked)
+{
+    const int targetMode = checked ? Device::AiWorkModeDesk : Device::AiWorkModeHuman;
+    const int index = m_modeCombo->findData(targetMode);
+    if (index >= 0 && m_modeCombo->currentIndex() != index) {
+        m_modeCombo->setCurrentIndex(index);
+    }
+}
+
 void TrackingControlWidget::updateTiny2Visibility()
 {
     if (!m_advancedContainer) {
@@ -463,13 +544,23 @@ void TrackingControlWidget::updateTiny2Visibility()
 
     m_advancedContainer->setVisible(m_tiny2Capabilities);
     m_humanSubModeCombo->setEnabled(m_tiny2Capabilities && m_modeCombo->currentData().toInt() == Device::AiWorkModeHuman);
+    if (m_deskModeCheckBox) {
+        QSignalBlocker blocker(m_deskModeCheckBox);
+        m_deskModeCheckBox->setChecked(
+            m_tiny2Capabilities && m_modeCombo->currentData().toInt() == Device::AiWorkModeDesk);
+    }
 }
 
 void TrackingControlWidget::updatePTZControlsState()
 {
-    // Disable PTZ controls when auto-framing is enabled
-    bool enabled = !m_trackingCheckBox->isChecked();
-    m_ptzContainer->setEnabled(enabled);
+    const bool manualEnabled = !m_trackingCheckBox->isChecked();
+    if (m_manualControlCheckBox) {
+        QSignalBlocker blocker(m_manualControlCheckBox);
+        m_manualControlCheckBox->setChecked(manualEnabled);
+    }
+    if (m_ptzGroupBox) {
+        m_ptzGroupBox->setEnabled(manualEnabled);
+    }
 }
 
 void TrackingControlWidget::flushPendingCommands()

--- a/src/gui/TrackingControlWidget.h
+++ b/src/gui/TrackingControlWidget.h
@@ -27,12 +27,18 @@ public:
 
     void updateFromState(const CameraController::CameraState &state);
     void setV4l2Mode(bool v4l2Only);
+    struct TrackingState {
+        bool enabled = false;
+        int aiMode = 0;
+        int aiSubMode = 0;
+        bool autoZoom = false;
+    };
+
     bool isTrackingEnabled() const { return m_trackingCheckBox->isChecked(); }
-    void setTrackingEnabled(bool enabled) {
-        m_trackingCheckBox->blockSignals(true);
-        m_trackingCheckBox->setChecked(enabled);
-        m_trackingCheckBox->blockSignals(false);
-    }
+    bool isManualControlEnabled() const;
+    TrackingState trackingState() const;
+    void setTrackingEnabled(bool enabled);
+    bool applyTrackingState(const TrackingState &state);
     void setAiMode(int mode);
     void setHumanSubMode(int subMode);
     void setAutoZoomEnabled(bool enabled);
@@ -56,6 +62,8 @@ private slots:
     void onAutoZoomToggled(bool checked);
     void onSpeedChanged(int index);
     void onAudioGainToggled(bool checked);
+    void onManualControlToggled(bool checked);
+    void onDeskModeToggled(bool checked);
 
     // Manual PTZ control slots
     void onXYPadChanged(float x, float y);
@@ -68,6 +76,7 @@ private:
     QComboBox *m_modeCombo;
     QComboBox *m_humanSubModeCombo;
     QCheckBox *m_autoZoomCheckBox;
+    QCheckBox *m_deskModeCheckBox;
     QComboBox *m_speedCombo;
     QCheckBox *m_audioGainCheckBox;
     QWidget *m_advancedContainer;
@@ -79,6 +88,8 @@ private:
     XYPad *m_xyPad;
     QCheckBox *m_invertControlsCheckBox;
     QCheckBox *m_mirrorCheckBox;
+    QCheckBox *m_manualControlCheckBox;
+    QGroupBox *m_ptzGroupBox;
     QSlider *m_zoomSlider;
     QLabel *m_zoomLabel;
     QSlider *m_focusSlider;

--- a/src/gui/TrackingControlWidget.h
+++ b/src/gui/TrackingControlWidget.h
@@ -14,6 +14,8 @@
 #include "CameraController.h"
 #include "XYPad.h"
 
+struct TrackingControlWidgetTestAccess;
+
 /**
  * @brief Widget for camera tracking control (automatic or manual PTZ)
  * Contains auto-framing toggle and manual PTZ controls (mutually exclusive)
@@ -27,18 +29,30 @@ public:
 
     void updateFromState(const CameraController::CameraState &state);
     void setV4l2Mode(bool v4l2Only);
-    struct TrackingState {
-        bool enabled = false;
-        int aiMode = 0;
-        int aiSubMode = 0;
-        bool autoZoom = false;
+    using TrackingState = TrackingIntentState;
+    struct TrackingApplyResult {
+        bool accepted = false;
+        bool confirmationPending = false;
+        quint64 intentGeneration = 0;
     };
 
     bool isTrackingEnabled() const { return m_trackingCheckBox->isChecked(); }
     bool isManualControlEnabled() const;
     TrackingState trackingState() const;
+    bool matchesTrackingState(const TrackingState &expected) const;
     void setTrackingEnabled(bool enabled);
-    bool applyTrackingState(const TrackingState &state);
+    TrackingApplyResult applyTrackingState(const TrackingState &state);
+    void setTrackingStatePresentation(const TrackingState &state);
+    void setModeProfiles(const Tiny2TrackingModeProfiles &profiles);
+    const Tiny2TrackingModeProfiles &modeProfiles() const {
+        return m_modeProfiles;
+    }
+    TrackingModeProfile modeProfile(int aiMode) const;
+    TrackingState trackingStateForMode(int aiMode) const;
+    void setActiveTrackingProfile(const TrackingModeProfile &profile);
+    TrackingModeProfile activeTrackingProfile() const;
+    void setManualFocusPosition(int position);
+    bool hasTiny2Capabilities() const { return m_tiny2Capabilities; }
     void setAiMode(int mode);
     void setHumanSubMode(int subMode);
     void setAutoZoomEnabled(bool enabled);
@@ -54,6 +68,12 @@ public:
 
 signals:
     void mirrorToggled(bool mirrored);
+    void trackingIntentEdited(
+        const TrackingState &state, bool updateModeProfile);
+    void audioAutoGainIntentEdited(bool enabled);
+    void panTiltIntentEdited(double pan, double tilt);
+    void zoomIntentEdited(double zoom);
+    void focusIntentEdited(int focus);
 
 private slots:
     void onTrackingToggled(bool checked);
@@ -61,9 +81,20 @@ private slots:
     void onHumanSubModeChanged(int index);
     void onAutoZoomToggled(bool checked);
     void onSpeedChanged(int index);
+    void onProfileFocusPolicyChanged(int index);
+    void onProfileFocusPositionChanged(int value);
     void onAudioGainToggled(bool checked);
     void onManualControlToggled(bool checked);
     void onDeskModeToggled(bool checked);
+    void onTrackingIntentStarted(quint64 intentGeneration);
+    void onTrackingStateConfirmationPending(
+        bool trackingEnabled, quint64 intentGeneration);
+    void onTrackingStateConfirmationFailed(
+        bool trackingEnabled, quint64 intentGeneration);
+    void onTrackingStateConfirmationUncertain(quint64 intentGeneration);
+    void onTrackingStateConfirmed(
+        bool trackingEnabled, quint64 intentGeneration);
+    void onTrackingOwnershipObserved(bool trackingEnabled);
 
     // Manual PTZ control slots
     void onXYPadChanged(float x, float y);
@@ -72,17 +103,37 @@ private slots:
 
 private:
     CameraController *m_controller;
+    friend struct TrackingControlWidgetTestAccess;
     QCheckBox *m_trackingCheckBox;
     QComboBox *m_modeCombo;
     QComboBox *m_humanSubModeCombo;
     QCheckBox *m_autoZoomCheckBox;
     QCheckBox *m_deskModeCheckBox;
     QComboBox *m_speedCombo;
+    QComboBox *m_profileFocusPolicyCombo;
+    QSlider *m_profileFocusSlider;
+    QLabel *m_profileFocusLabel;
     QCheckBox *m_audioGainCheckBox;
     QWidget *m_advancedContainer;
     bool m_userInitiated;  // Track if change was user-initiated
+    bool m_manualOverrideActive;  // Explicit operator intent; camera status cannot clear it
+    bool m_manualControlAuthorized;  // True only after AI ownership is known to be off
+    bool m_manualConfirmationPending;
+    bool m_trackingConfirmationPending;
+    // Retained after completion so delayed signals from older intents cannot
+    // mutate the current ownership decision.
+    quint64 m_pendingTrackingIntentGeneration;
+    quint64 m_highestTrackingIntentGeneration;
+    bool m_trackingIntentResolved;
     QTimer *m_commandTimer;  // Debounce timer for command completion
+    QTimer *m_profileFocusTimer;  // Coalesces profile focus slider edits
+    bool m_v4l2Only;  // No SDK ownership confirmation is available
     bool m_tiny2Capabilities; // flag for advanced tracking features
+    int m_lastAcceptedAiMode = Device::AiWorkModeNone;
+    int m_lastAcceptedHumanSubMode = Device::AiSubModeNormal;
+    Tiny2TrackingModeProfiles m_modeProfiles =
+        defaultTiny2TrackingModeProfiles();
+    TrackingModeProfile m_activeTrackingProfile{};
 
     // Manual PTZ controls
     XYPad *m_xyPad;
@@ -108,6 +159,9 @@ private:
     bool m_dirtyFocus = false;
     void flushPendingCommands();
     void scheduleFlush();
+    void submitCurrentTrackingProfile();
+    void persistActiveTrackingIntent(bool updateModeProfile);
+    void storeActiveProfileForCurrentMode();
 
     void updateTiny2Visibility();
     void updatePTZControlsState();

--- a/src/gui/V4l2Backend.cpp
+++ b/src/gui/V4l2Backend.cpp
@@ -16,6 +16,8 @@ V4l2Backend::~V4l2Backend()
 bool V4l2Backend::open(const std::string &devicePath)
 {
     close();
+    if (!isObsbotCaptureDevice(devicePath))
+        return false;
     int fd = ::open(devicePath.c_str(), O_RDWR | O_NONBLOCK);
     if (fd < 0)
         return false;
@@ -38,6 +40,29 @@ int V4l2Backend::openDevice() const
     return ::open(m_devicePath.c_str(), O_RDWR | O_NONBLOCK);
 }
 
+bool V4l2Backend::isObsbotCaptureDevice(const std::string &devicePath)
+{
+    int fd = ::open(devicePath.c_str(), O_RDWR | O_NONBLOCK);
+    if (fd < 0)
+        return false;
+
+    struct v4l2_capability cap{};
+    const bool queried = ioctl(fd, VIDIOC_QUERYCAP, &cap) == 0;
+    ::close(fd);
+    if (!queried)
+        return false;
+
+    const std::string card(reinterpret_cast<const char *>(cap.card));
+    const uint32_t capabilities = (cap.capabilities & V4L2_CAP_DEVICE_CAPS)
+        ? cap.device_caps : cap.capabilities;
+    const bool isVideoCapture =
+        (capabilities & (V4L2_CAP_VIDEO_CAPTURE
+                         | V4L2_CAP_VIDEO_CAPTURE_MPLANE)) != 0;
+    return isVideoCapture
+        && card.find("OBSBOT") != std::string::npos
+        && card.find("Virtual Camera") == std::string::npos;
+}
+
 std::string V4l2Backend::findObsbotDevice()
 {
     DIR *dir = opendir("/dev");
@@ -46,26 +71,15 @@ std::string V4l2Backend::findObsbotDevice()
 
     struct dirent *entry;
     while ((entry = readdir(dir)) != nullptr) {
-        std::string name = entry->d_name;
+        const std::string name = entry->d_name;
         if (name.find("video") != 0)
             continue;
 
-        std::string path = "/dev/" + name;
-        int fd = ::open(path.c_str(), O_RDWR | O_NONBLOCK);
-        if (fd < 0)
-            continue;
-
-        struct v4l2_capability cap{};
-        if (ioctl(fd, VIDIOC_QUERYCAP, &cap) == 0) {
-            std::string card(reinterpret_cast<const char *>(cap.card));
-            bool isVideoCapture = (cap.device_caps & V4L2_CAP_VIDEO_CAPTURE) != 0;
-            if (card.find("OBSBOT") != std::string::npos && isVideoCapture) {
-                ::close(fd);
-                closedir(dir);
-                return path;
-            }
+        const std::string path = "/dev/" + name;
+        if (isObsbotCaptureDevice(path)) {
+            closedir(dir);
+            return path;
         }
-        ::close(fd);
     }
     closedir(dir);
     return {};

--- a/src/gui/V4l2Backend.h
+++ b/src/gui/V4l2Backend.h
@@ -24,6 +24,7 @@ public:
     bool isOpen() const { return m_configured; }
     std::string devicePath() const { return m_devicePath; }
 
+    static bool isObsbotCaptureDevice(const std::string &devicePath);
     static std::string findObsbotDevice();
     std::string cardName() const;
 

--- a/src/gui/VideoEffectsWidget.cpp
+++ b/src/gui/VideoEffectsWidget.cpp
@@ -1,6 +1,7 @@
 #include "VideoEffectsWidget.h"
 
 #include <QCheckBox>
+#include <QComboBox>
 #include <QColorDialog>
 #include <QFormLayout>
 #include <QGroupBox>
@@ -48,6 +49,13 @@ QWidget *createLabeledSlider(const QString &label, QSlider *slider)
 VideoEffectsWidget::VideoEffectsWidget(QWidget *parent)
     : QWidget(parent)
     , m_horizontalFlipCheckBox(nullptr)
+    , m_cropModeCombo(nullptr)
+    , m_cropMarginsContainer(nullptr)
+    , m_cropStatusLabel(nullptr)
+    , m_cropLeftSlider(nullptr)
+    , m_cropTopSlider(nullptr)
+    , m_cropRightSlider(nullptr)
+    , m_cropBottomSlider(nullptr)
     , m_shadowColorButton(nullptr)
     , m_highlightColorButton(nullptr)
 {
@@ -60,12 +68,64 @@ VideoEffectsWidget::VideoEffectsWidget(QWidget *parent)
     infoLabel->setStyleSheet("color: palette(mid); font-size: 11px;");
     rootLayout->addWidget(infoLabel);
 
-    auto addSlider = [&](QVBoxLayout *groupLayout, const QString &label, float min, float max, float initial, std::function<void(float)> setter) {
+    auto addSlider = [&](QVBoxLayout *groupLayout, const QString &label, float min, float max, float initial, std::function<void(float)> setter) -> QSlider * {
         QSlider *slider = createSlider(this);
         slider->setValue(sliderPositionForRange(initial, min, max));
         bindSlider(slider, min, max, std::move(setter), initial);
         groupLayout->addWidget(createLabeledSlider(label, slider));
+        return slider;
     };
+
+    // Paper/document crop
+    QGroupBox *cropGroup = new QGroupBox(tr("Paper Crop"));
+    QVBoxLayout *cropLayout = new QVBoxLayout(cropGroup);
+    cropLayout->setSpacing(6);
+
+    QWidget *modeRow = new QWidget(cropGroup);
+    QHBoxLayout *modeLayout = new QHBoxLayout(modeRow);
+    modeLayout->setContentsMargins(0, 0, 0, 0);
+    modeLayout->addWidget(new QLabel(tr("Mode"), modeRow));
+    m_cropModeCombo = new QComboBox(modeRow);
+    m_cropModeCombo->addItem(tr("Off"), static_cast<int>(PaperCropMode::Off));
+    m_cropModeCombo->addItem(tr("Manual rectangle"), static_cast<int>(PaperCropMode::Manual));
+    m_cropModeCombo->addItem(tr("Automatic paper detection"), static_cast<int>(PaperCropMode::Automatic));
+    modeLayout->addWidget(m_cropModeCombo, 1);
+    cropLayout->addWidget(modeRow);
+
+    m_cropStatusLabel = new QLabel(cropGroup);
+    m_cropStatusLabel->setWordWrap(true);
+    m_cropStatusLabel->setStyleSheet("color: palette(mid); font-size: 11px;");
+    cropLayout->addWidget(m_cropStatusLabel);
+
+    m_cropMarginsContainer = new QWidget(cropGroup);
+    QVBoxLayout *marginLayout = new QVBoxLayout(m_cropMarginsContainer);
+    marginLayout->setContentsMargins(0, 0, 0, 0);
+    marginLayout->setSpacing(6);
+    m_cropLeftSlider = addSlider(marginLayout, tr("Crop left"), 0.0f, 0.45f, m_settings.paperCrop.left, [this](float value) {
+        m_settings.paperCrop.left = value;
+        emitSettingsChanged();
+    });
+    m_cropTopSlider = addSlider(marginLayout, tr("Crop top"), 0.0f, 0.45f, m_settings.paperCrop.top, [this](float value) {
+        m_settings.paperCrop.top = value;
+        emitSettingsChanged();
+    });
+    m_cropRightSlider = addSlider(marginLayout, tr("Crop right"), 0.0f, 0.45f, m_settings.paperCrop.right, [this](float value) {
+        m_settings.paperCrop.right = value;
+        emitSettingsChanged();
+    });
+    m_cropBottomSlider = addSlider(marginLayout, tr("Crop bottom"), 0.0f, 0.45f, m_settings.paperCrop.bottom, [this](float value) {
+        m_settings.paperCrop.bottom = value;
+        emitSettingsChanged();
+    });
+    cropLayout->addWidget(m_cropMarginsContainer);
+
+    connect(m_cropModeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this](int) {
+        m_settings.paperCrop.mode = static_cast<PaperCropMode>(m_cropModeCombo->currentData().toInt());
+        updateCropControls();
+        emitSettingsChanged();
+    });
+    rootLayout->addWidget(cropGroup);
+    updateCropControls();
 
     // Tone adjustments
     QGroupBox *toneGroup = new QGroupBox(tr("Tone"));
@@ -251,9 +311,21 @@ void VideoEffectsWidget::applySettings(const FilterPreviewWidget::VideoEffectsSe
             syncSlider(group, tr("Glow"), 0.0f, 1.0f, m_settings.glow);
             syncSlider(group, tr("Bloom"), 0.0f, 1.0f, m_settings.bloom);
             syncSlider(group, tr("Soft Focus"), 0.0f, 1.0f, m_settings.softFocus);
+        } else if (group->title() == tr("Paper Crop")) {
+            syncSlider(group, tr("Crop left"), 0.0f, 0.45f, m_settings.paperCrop.left);
+            syncSlider(group, tr("Crop top"), 0.0f, 0.45f, m_settings.paperCrop.top);
+            syncSlider(group, tr("Crop right"), 0.0f, 0.45f, m_settings.paperCrop.right);
+            syncSlider(group, tr("Crop bottom"), 0.0f, 0.45f, m_settings.paperCrop.bottom);
         }
     }
 
+    if (m_cropModeCombo) {
+        m_cropModeCombo->blockSignals(true);
+        const int index = m_cropModeCombo->findData(static_cast<int>(m_settings.paperCrop.mode));
+        m_cropModeCombo->setCurrentIndex(index >= 0 ? index : 0);
+        m_cropModeCombo->blockSignals(false);
+        updateCropControls();
+    }
     if (m_horizontalFlipCheckBox) {
         m_horizontalFlipCheckBox->blockSignals(true);
         m_horizontalFlipCheckBox->setChecked(m_settings.horizontalFlip);
@@ -295,6 +367,27 @@ void VideoEffectsWidget::updateColorButton(QPushButton *button, const QColor &co
 {
     const QString css = QStringLiteral("background-color: %1; color: %2;").arg(color.name(), color.lightness() > 128 ? "#111" : "#f0f0f0");
     button->setStyleSheet(css);
+}
+
+void VideoEffectsWidget::updateCropControls()
+{
+    if (!m_cropModeCombo || !m_cropMarginsContainer || !m_cropStatusLabel) {
+        return;
+    }
+
+    const auto mode = static_cast<PaperCropMode>(m_cropModeCombo->currentData().toInt());
+    m_cropMarginsContainer->setEnabled(mode != PaperCropMode::Off);
+    if (mode == PaperCropMode::Automatic) {
+        if (FilterPreviewWidget::automaticPaperCropAvailable()) {
+            m_cropStatusLabel->setText(tr("Detects the paper boundary and corrects perspective. The sliders are used as a fallback when detection is uncertain."));
+        } else {
+            m_cropStatusLabel->setText(tr("Automatic detection is unavailable in this build; the manual rectangle fallback will be used."));
+        }
+    } else if (mode == PaperCropMode::Manual) {
+        m_cropStatusLabel->setText(tr("Crops the preview, snapshots, and virtual-camera output to the saved rectangle."));
+    } else {
+        m_cropStatusLabel->setText(tr("Software crop is disabled."));
+    }
 }
 
 void VideoEffectsWidget::emitSettingsChanged()

--- a/src/gui/VideoEffectsWidget.cpp
+++ b/src/gui/VideoEffectsWidget.cpp
@@ -52,6 +52,7 @@ VideoEffectsWidget::VideoEffectsWidget(QWidget *parent)
     , m_cropModeCombo(nullptr)
     , m_cropMarginsContainer(nullptr)
     , m_cropStatusLabel(nullptr)
+    , m_paperDetected(false)
     , m_cropLeftSlider(nullptr)
     , m_cropTopSlider(nullptr)
     , m_cropRightSlider(nullptr)
@@ -86,6 +87,7 @@ VideoEffectsWidget::VideoEffectsWidget(QWidget *parent)
     modeLayout->setContentsMargins(0, 0, 0, 0);
     modeLayout->addWidget(new QLabel(tr("Mode"), modeRow));
     m_cropModeCombo = new QComboBox(modeRow);
+    m_cropModeCombo->setObjectName(QStringLiteral("paperCropModeCombo"));
     m_cropModeCombo->addItem(tr("Off"), static_cast<int>(PaperCropMode::Off));
     m_cropModeCombo->addItem(tr("Manual rectangle"), static_cast<int>(PaperCropMode::Manual));
     m_cropModeCombo->addItem(tr("Automatic paper detection"), static_cast<int>(PaperCropMode::Automatic));
@@ -93,6 +95,7 @@ VideoEffectsWidget::VideoEffectsWidget(QWidget *parent)
     cropLayout->addWidget(modeRow);
 
     m_cropStatusLabel = new QLabel(cropGroup);
+    m_cropStatusLabel->setObjectName(QStringLiteral("paperCropStatusLabel"));
     m_cropStatusLabel->setWordWrap(true);
     m_cropStatusLabel->setStyleSheet("color: palette(mid); font-size: 11px;");
     cropLayout->addWidget(m_cropStatusLabel);
@@ -104,18 +107,22 @@ VideoEffectsWidget::VideoEffectsWidget(QWidget *parent)
     m_cropLeftSlider = addSlider(marginLayout, tr("Crop left"), 0.0f, 0.45f, m_settings.paperCrop.left, [this](float value) {
         m_settings.paperCrop.left = value;
         emitSettingsChanged();
+        emit paperCropIntentEdited(m_settings.paperCrop);
     });
     m_cropTopSlider = addSlider(marginLayout, tr("Crop top"), 0.0f, 0.45f, m_settings.paperCrop.top, [this](float value) {
         m_settings.paperCrop.top = value;
         emitSettingsChanged();
+        emit paperCropIntentEdited(m_settings.paperCrop);
     });
     m_cropRightSlider = addSlider(marginLayout, tr("Crop right"), 0.0f, 0.45f, m_settings.paperCrop.right, [this](float value) {
         m_settings.paperCrop.right = value;
         emitSettingsChanged();
+        emit paperCropIntentEdited(m_settings.paperCrop);
     });
     m_cropBottomSlider = addSlider(marginLayout, tr("Crop bottom"), 0.0f, 0.45f, m_settings.paperCrop.bottom, [this](float value) {
         m_settings.paperCrop.bottom = value;
         emitSettingsChanged();
+        emit paperCropIntentEdited(m_settings.paperCrop);
     });
     cropLayout->addWidget(m_cropMarginsContainer);
 
@@ -123,6 +130,7 @@ VideoEffectsWidget::VideoEffectsWidget(QWidget *parent)
         m_settings.paperCrop.mode = static_cast<PaperCropMode>(m_cropModeCombo->currentData().toInt());
         updateCropControls();
         emitSettingsChanged();
+        emit paperCropIntentEdited(m_settings.paperCrop);
     });
     rootLayout->addWidget(cropGroup);
     updateCropControls();
@@ -266,7 +274,10 @@ VideoEffectsWidget::VideoEffectsWidget(QWidget *parent)
     // Reset button
     QPushButton *resetButton = new QPushButton(tr("Reset Adjustments"), this);
     resetButton->setObjectName("secondaryAction");
-    connect(resetButton, &QPushButton::clicked, this, &VideoEffectsWidget::reset);
+    connect(resetButton, &QPushButton::clicked, this, [this]() {
+        reset();
+        emit paperCropIntentEdited(m_settings.paperCrop);
+    });
     rootLayout->addWidget(resetButton);
 
     rootLayout->addStretch(1);
@@ -341,6 +352,15 @@ void VideoEffectsWidget::applySettings(const FilterPreviewWidget::VideoEffectsSe
     emitSettingsChanged();
 }
 
+void VideoEffectsWidget::applyPaperCropForScene(const PaperCropSettings &settings)
+{
+    m_paperDetected = false;
+    emit paperDetectionResetRequested();
+    auto sceneSettings = m_settings;
+    sceneSettings.paperCrop = settings;
+    applySettings(sceneSettings);
+}
+
 void VideoEffectsWidget::reset()
 {
     applySettings(FilterPreviewWidget::VideoEffectsSettings::defaults());
@@ -369,6 +389,15 @@ void VideoEffectsWidget::updateColorButton(QPushButton *button, const QColor &co
     button->setStyleSheet(css);
 }
 
+void VideoEffectsWidget::setPaperDetected(bool detected)
+{
+    if (m_paperDetected == detected) {
+        return;
+    }
+    m_paperDetected = detected;
+    updateCropControls();
+}
+
 void VideoEffectsWidget::updateCropControls()
 {
     if (!m_cropModeCombo || !m_cropMarginsContainer || !m_cropStatusLabel) {
@@ -378,10 +407,12 @@ void VideoEffectsWidget::updateCropControls()
     const auto mode = static_cast<PaperCropMode>(m_cropModeCombo->currentData().toInt());
     m_cropMarginsContainer->setEnabled(mode != PaperCropMode::Off);
     if (mode == PaperCropMode::Automatic) {
-        if (FilterPreviewWidget::automaticPaperCropAvailable()) {
-            m_cropStatusLabel->setText(tr("Detects the paper boundary and corrects perspective. The sliders are used as a fallback when detection is uncertain."));
+        if (!PaperCropProcessor::automaticDetectionAvailable()) {
+            m_cropStatusLabel->setText(tr("Automatic detection is unavailable in this build; the manual rectangle fallback is active."));
+        } else if (m_paperDetected) {
+            m_cropStatusLabel->setText(tr("Paper locked — automatic perspective crop is active."));
         } else {
-            m_cropStatusLabel->setText(tr("Automatic detection is unavailable in this build; the manual rectangle fallback will be used."));
+            m_cropStatusLabel->setText(tr("Searching for all four paper edges — the saved manual rectangle fallback is active."));
         }
     } else if (mode == PaperCropMode::Manual) {
         m_cropStatusLabel->setText(tr("Crops the preview, snapshots, and virtual-camera output to the saved rectangle."));

--- a/src/gui/VideoEffectsWidget.h
+++ b/src/gui/VideoEffectsWidget.h
@@ -7,8 +7,11 @@
 #include <functional>
 
 class QCheckBox;
-class QSlider;
+class QComboBox;
+class QLabel;
 class QPushButton;
+class QSlider;
+class QWidget;
 
 class VideoEffectsWidget : public QWidget
 {
@@ -31,9 +34,17 @@ private:
     void bindSlider(QSlider *slider, float min, float max, std::function<void(float)> setter, float initial);
     void updateColorButton(QPushButton *button, const QColor &color);
     void emitSettingsChanged();
+    void updateCropControls();
 
     FilterPreviewWidget::VideoEffectsSettings m_settings;
     QCheckBox *m_horizontalFlipCheckBox;
+    QComboBox *m_cropModeCombo;
+    QWidget *m_cropMarginsContainer;
+    QLabel *m_cropStatusLabel;
+    QSlider *m_cropLeftSlider;
+    QSlider *m_cropTopSlider;
+    QSlider *m_cropRightSlider;
+    QSlider *m_cropBottomSlider;
     QPushButton *m_shadowColorButton;
     QPushButton *m_highlightColorButton;
 };

--- a/src/gui/VideoEffectsWidget.h
+++ b/src/gui/VideoEffectsWidget.h
@@ -24,10 +24,14 @@ public:
 
 signals:
     void effectsChanged(const FilterPreviewWidget::VideoEffectsSettings &settings);
+    void paperCropIntentEdited(const PaperCropSettings &settings);
+    void paperDetectionResetRequested();
 
 public slots:
     void applySettings(const FilterPreviewWidget::VideoEffectsSettings &settings);
+    void applyPaperCropForScene(const PaperCropSettings &settings);
     void reset();
+    void setPaperDetected(bool detected);
 
 private:
     QSlider *createSlider(QWidget *parent) const;
@@ -41,6 +45,7 @@ private:
     QComboBox *m_cropModeCombo;
     QWidget *m_cropMarginsContainer;
     QLabel *m_cropStatusLabel;
+    bool m_paperDetected;
     QSlider *m_cropLeftSlider;
     QSlider *m_cropTopSlider;
     QSlider *m_cropRightSlider;

--- a/src/gui/VirtualCameraStreamer.cpp
+++ b/src/gui/VirtualCameraStreamer.cpp
@@ -59,7 +59,9 @@ bool convertRgbToYuyv(const QImage &image, QByteArray &outBuffer)
 {
     const int width = image.width();
     const int height = image.height();
-    if (width <= 0 || height <= 0) {
+    // YUYV stores pairs of pixels in four bytes; odd widths cannot be
+    // represented without crossing the row buffer boundary.
+    if (width <= 0 || height <= 0 || (width % 2) != 0) {
         return false;
     }
 
@@ -70,8 +72,7 @@ bool convertRgbToYuyv(const QImage &image, QByteArray &outBuffer)
         const uint8_t *src = reinterpret_cast<const uint8_t *>(image.constScanLine(y));
         uint8_t *rowPtr = dst + (y * width * 2);
 
-        int x = 0;
-        for (; x + 1 < width; x += 2) {
+        for (int x = 0; x < width; x += 2) {
             const uint8_t *p0 = src + (x * 3);
             const uint8_t *p1 = src + ((x + 1) * 3);
 
@@ -85,16 +86,6 @@ bool convertRgbToYuyv(const QImage &image, QByteArray &outBuffer)
             rowPtr[(x * 2) + 1] = u;
             rowPtr[(x * 2) + 2] = yuv1.y;
             rowPtr[(x * 2) + 3] = v;
-        }
-
-        if (x < width) {
-            const uint8_t *p0 = src + (x * 3);
-            const YuvComponents yuv0 = rgbToYuv(p0[0], p0[1], p0[2]);
-
-            rowPtr[(x * 2) + 0] = yuv0.y;
-            rowPtr[(x * 2) + 1] = yuv0.u;
-            rowPtr[(x * 2) + 2] = yuv0.y;
-            rowPtr[(x * 2) + 3] = yuv0.v;
         }
     }
 
@@ -141,7 +132,8 @@ public slots:
 
     void setForcedResolution(const QSize &resolution)
     {
-        const QSize normalized = resolution.isValid() ? resolution : QSize();
+        const QSize normalized =
+            VirtualCameraStreamer::normalizedOutputSize(resolution);
         if (normalized == m_forcedResolution) {
             return;
         }
@@ -233,49 +225,8 @@ private:
 
     QImage prepareFrame(const QImage &frame) const
     {
-        if (frame.isNull()) {
-            return QImage();
-        }
-
-        QImage image = frame;
-        if (image.format() != QImage::Format_RGB888) {
-            image = image.convertToFormat(QImage::Format_RGB888);
-            if (image.isNull()) {
-                qCWarning(VirtualCameraLog) << "Failed to convert frame to RGB888 format";
-                return QImage();
-            }
-        }
-
-        QSize targetSize = m_forcedResolution.isValid() ? m_forcedResolution : image.size();
-        if (targetSize.width() <= 0 || targetSize.height() <= 0) {
-            return QImage();
-        }
-
-        if (image.size() != targetSize) {
-            if (m_forcedResolution.isValid()) {
-                QImage scaled = image.scaled(targetSize, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
-                if (scaled.isNull()) {
-                    qCWarning(VirtualCameraLog) << "Failed to scale frame to forced resolution" << targetSize;
-                    return QImage();
-                }
-
-                if (scaled.size() != targetSize) {
-                    const int xOffset = std::max(0, (scaled.width() - targetSize.width()) / 2);
-                    const int yOffset = std::max(0, (scaled.height() - targetSize.height()) / 2);
-                    image = scaled.copy(xOffset, yOffset, targetSize.width(), targetSize.height());
-                } else {
-                    image = scaled;
-                }
-            } else {
-                image = image.scaled(targetSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
-            }
-        }
-
-        if (image.format() != QImage::Format_RGB888) {
-            image = image.convertToFormat(QImage::Format_RGB888);
-        }
-
-        return image;
+        return VirtualCameraStreamer::prepareFrameForOutput(
+            frame, m_forcedResolution);
     }
 
     bool ensureDevice(int width, int height)
@@ -388,6 +339,70 @@ private:
     bool m_processing;
 };
 
+QSize VirtualCameraStreamer::normalizedOutputSize(const QSize &resolution)
+{
+    if (!resolution.isValid()) {
+        return QSize();
+    }
+    QSize normalized = resolution;
+    if ((normalized.width() % 2) != 0) {
+        normalized.setWidth(normalized.width() + 1);
+    }
+    return normalized;
+}
+
+QImage VirtualCameraStreamer::prepareFrameForOutput(
+    const QImage &frame, const QSize &forcedResolution)
+{
+    if (frame.isNull()) {
+        return QImage();
+    }
+
+    QImage image = frame.format() == QImage::Format_RGB888
+        ? frame : frame.convertToFormat(QImage::Format_RGB888);
+    if (image.isNull()) {
+        qCWarning(VirtualCameraLog) << "Failed to convert frame to RGB888 format";
+        return QImage();
+    }
+
+    const QSize targetSize = normalizedOutputSize(
+        forcedResolution.isValid() ? forcedResolution : image.size());
+    if (!targetSize.isValid()) {
+        return QImage();
+    }
+
+    if (image.size() != targetSize) {
+        if (forcedResolution.isValid()) {
+            QImage scaled = image.scaled(
+                targetSize, Qt::KeepAspectRatioByExpanding,
+                Qt::SmoothTransformation);
+            if (scaled.isNull()) {
+                qCWarning(VirtualCameraLog)
+                    << "Failed to scale frame to forced resolution" << targetSize;
+                return QImage();
+            }
+            if (scaled.size() != targetSize) {
+                const int xOffset = std::max(
+                    0, (scaled.width() - targetSize.width()) / 2);
+                const int yOffset = std::max(
+                    0, (scaled.height() - targetSize.height()) / 2);
+                image = scaled.copy(
+                    xOffset, yOffset, targetSize.width(), targetSize.height());
+            } else {
+                image = scaled;
+            }
+        } else {
+            image = image.scaled(
+                targetSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+        }
+    }
+
+    if (image.format() != QImage::Format_RGB888) {
+        image = image.convertToFormat(QImage::Format_RGB888);
+    }
+    return image;
+}
+
 VirtualCameraStreamer::VirtualCameraStreamer(QObject *parent)
     : QObject(parent)
     , m_devicePath(QString::fromLatin1(kDefaultDevicePath))
@@ -450,7 +465,7 @@ void VirtualCameraStreamer::setEnabled(bool enabled)
 
 void VirtualCameraStreamer::setForcedResolution(const QSize &resolution)
 {
-    const QSize normalized = resolution.isValid() ? resolution : QSize();
+    const QSize normalized = normalizedOutputSize(resolution);
     if (normalized == m_forcedResolution) {
         return;
     }

--- a/src/gui/VirtualCameraStreamer.h
+++ b/src/gui/VirtualCameraStreamer.h
@@ -32,6 +32,9 @@ public:
     void setEnabled(bool enabled);
     void setForcedResolution(const QSize &resolution);
     QSize forcedResolution() const { return m_forcedResolution; }
+    static QSize normalizedOutputSize(const QSize &resolution);
+    static QImage prepareFrameForOutput(
+        const QImage &frame, const QSize &forcedResolution = QSize());
 
 public slots:
     void onProcessedFrameReady(const QImage &frame);

--- a/tests/CameraControllerSafetyTest.cpp
+++ b/tests/CameraControllerSafetyTest.cpp
@@ -1,0 +1,70 @@
+#include "CameraController.h"
+
+#include <QCoreApplication>
+#include <iostream>
+
+struct CameraControllerTestAccess
+{
+    static void forceUnconfirmedV4l2Connection(CameraController &controller)
+    {
+        controller.m_connected = true;
+        controller.m_v4l2Only = true;
+    }
+
+    static void forceUnconfirmedSdkConnection(CameraController &controller)
+    {
+        controller.m_connected = true;
+        controller.m_v4l2Only = false;
+        controller.m_manualMovementAuthorized = false;
+        controller.m_device.reset();
+    }
+};
+
+namespace {
+
+bool check(bool condition, const char *message)
+{
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+    }
+    return condition;
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+    QCoreApplication application(argc, argv);
+    CameraController controller;
+    CameraControllerTestAccess::forceUnconfirmedV4l2Connection(controller);
+
+    bool passed = true;
+    passed &= check(!controller.setPanTilt(0.25, -0.25),
+                    "V4L2 fallback rejects pan/tilt without ownership proof");
+    passed &= check(!controller.adjustPan(0.1),
+                    "V4L2 fallback rejects relative pan without ownership proof");
+    passed &= check(!controller.adjustTilt(0.1),
+                    "V4L2 fallback rejects relative tilt without ownership proof");
+    passed &= check(!controller.centerView(),
+                    "V4L2 fallback rejects centering without ownership proof");
+    passed &= check(!controller.setZoom(1.5),
+                    "V4L2 fallback rejects zoom without ownership proof");
+    passed &= check(!controller.setFocusAbsolute(40, false),
+                    "V4L2 fallback rejects manual focus without ownership proof");
+    passed &= check(!controller.setFocusAbsolute(0, true),
+                    "V4L2 fallback rejects autofocus changes without ownership proof");
+
+    CameraControllerTestAccess::forceUnconfirmedSdkConnection(controller);
+    passed &= check(!controller.setPanTilt(-0.4, 0.2),
+                    "SDK pan/tilt rejects unconfirmed tracking ownership");
+    passed &= check(!controller.adjustPan(0.1),
+                    "SDK relative movement rejects unconfirmed tracking ownership");
+    passed &= check(!controller.centerView(),
+                    "SDK centering rejects unconfirmed tracking ownership");
+    passed &= check(!controller.setZoom(1.25),
+                    "SDK optical zoom rejects unconfirmed tracking ownership");
+    passed &= check(!controller.setFocusAbsolute(55, false),
+                    "SDK manual focus rejects unconfirmed tracking ownership");
+
+    return passed ? 0 : 1;
+}

--- a/tests/CliOptionsTest.cpp
+++ b/tests/CliOptionsTest.cpp
@@ -1,0 +1,82 @@
+#include "CliOptions.h"
+
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+CliParseResult parse(std::initializer_list<const char *> arguments)
+{
+    std::vector<std::string> storage;
+    storage.reserve(arguments.size());
+    for (const char *argument : arguments) {
+        storage.emplace_back(argument);
+    }
+
+    std::vector<char *> argv;
+    argv.reserve(storage.size());
+    for (auto &argument : storage) {
+        argv.push_back(argument.data());
+    }
+
+    return parseCliOptions(static_cast<int>(argv.size()), argv.data());
+}
+
+bool check(bool condition, const char *message)
+{
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+    }
+    return condition;
+}
+
+} // namespace
+
+int main()
+{
+    bool passed = true;
+
+    const auto defaults = parse({"obsbot-cli"});
+    passed &= check(defaults.ok(), "default arguments parse");
+    passed &= check(defaults.options.action == CliAction::ApplyConfig, "default action applies config");
+
+    const auto preset = parse({"obsbot-cli", "--preset", "2", "--serial", "ABC123"});
+    passed &= check(preset.ok(), "preset with serial parses");
+    passed &= check(preset.options.action == CliAction::RecallPreset, "preset action selected");
+    passed &= check(preset.options.presetNumber == 2, "preset number retained");
+    passed &= check(preset.options.serial == "ABC123", "serial retained");
+
+    const auto inlinePreset = parse({"obsbot-cli", "--preset=3"});
+    passed &= check(inlinePreset.ok() && inlinePreset.options.presetNumber == 3,
+                    "inline preset syntax parses");
+
+    const auto list = parse({"obsbot-cli", "--list-presets"});
+    passed &= check(list.ok() && list.options.action == CliAction::ListPresets,
+                    "list-presets action parses");
+
+    passed &= check(!parse({"obsbot-cli", "--preset", "0"}).ok(),
+                    "out-of-range preset rejected");
+    passed &= check(!parse({"obsbot-cli", "--preset"}).ok(),
+                    "missing preset value rejected");
+    passed &= check(!parse({"obsbot-cli", "--serial", "--help"}).ok(),
+                    "option token rejected as missing serial value");
+    passed &= check(!parse({"obsbot-cli", "--serial", "--list-presets"}).ok(),
+                    "action token cannot be consumed as a serial value");
+    passed &= check(!parse({"obsbot-cli", "--preset", "1", "--interactive"}).ok(),
+                    "conflicting actions rejected");
+    passed &= check(!parse({"obsbot-cli", "--list-presets", "--serial", "ABC123"}).ok(),
+                    "unused serial rejected for list action");
+    passed &= check(!parse({"obsbot-cli", "--definitely-unknown"}).ok(),
+                    "unknown option rejected");
+
+    const auto help = parse({"obsbot-cli", "--help"});
+    passed &= check(help.ok() && help.options.showHelp, "help flag parses");
+    std::ostringstream usage;
+    printCliUsage(usage, "obsbot-cli");
+    passed &= check(usage.str().find("--preset N") != std::string::npos,
+                    "usage documents preset action");
+
+    return passed ? 0 : 1;
+}

--- a/tests/ConfigPresetValidationTest.cpp
+++ b/tests/ConfigPresetValidationTest.cpp
@@ -5,6 +5,8 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <iterator>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -52,6 +54,21 @@ std::string validConfigWithPreset(const std::string &pan,
         "preset1_paper_crop_bottom=0.10\n";
 }
 
+std::string withSetting(std::string contents,
+                        const std::string &key,
+                        const std::string &value)
+{
+    const std::string marker = key + "=";
+    const size_t markerPos = contents.find(marker);
+    if (markerPos == std::string::npos) {
+        return contents + marker + value + "\n";
+    }
+    const size_t valuePos = markerPos + marker.size();
+    const size_t lineEnd = contents.find('\n', valuePos);
+    contents.replace(valuePos, lineEnd - valuePos, value);
+    return contents;
+}
+
 bool loadConfig(const std::filesystem::path &configPath,
                 const std::string &pan,
                 const std::string &tilt,
@@ -69,6 +86,31 @@ bool loadConfig(const std::filesystem::path &configPath,
         *loadedSettings = config.getSettings();
     }
     return loaded;
+}
+
+bool loadRawConfig(
+    const std::filesystem::path &configPath,
+    const std::string &contents,
+    Config::CameraSettings *loadedSettings = nullptr)
+{
+    std::ofstream file(configPath);
+    file << contents;
+    file.close();
+
+    Config config;
+    std::vector<Config::ValidationError> errors;
+    const bool loaded = config.load(errors);
+    if (loaded && loadedSettings) {
+        *loadedSettings = config.getSettings();
+    }
+    return loaded;
+}
+
+std::string readFile(const std::filesystem::path &path)
+{
+    std::ifstream file(path);
+    return std::string(std::istreambuf_iterator<char>(file),
+                       std::istreambuf_iterator<char>());
 }
 
 bool check(bool condition, const char *message)
@@ -103,10 +145,119 @@ int main()
                     "finite scene preset and crop values are accepted");
     passed &= check(loadedSettings.paperCropMode == 2,
                     "automatic global crop mode is parsed");
+    passed &= check(
+        loadedSettings.panTiltIntentDefined
+        && loadedSettings.zoomIntentDefined
+        && loadedSettings.imageIntentDefined,
+        "legacy configs migrate with their existing camera intent categories defined");
     passed &= check(loadedSettings.presets[0].sceneDefined
                     && !loadedSettings.presets[0].trackingEnabled
                     && loadedSettings.presets[0].paperCropMode == 1,
                     "manual scene state is parsed");
+    std::string legacyOffAutoZoom = withSetting(
+        validConfigWithPreset("0.25", "-0.5", "1.75"),
+        "preset1_auto_zoom", "enabled");
+    passed &= check(loadRawConfig(
+                        configPath, legacyOffAutoZoom, &loadedSettings)
+                    && !loadedSettings.presets[0].autoZoom,
+                    "legacy tracking-off scene auto zoom is safely normalized");
+    passed &= check(
+        loadedSettings.activeTrackingProfile.focusPolicy
+            == TrackingFocusPolicy::Manual
+        && !loadedSettings.activeTrackingProfile.autoZoom,
+        "legacy tracking-off config migrates to a safe manual active profile");
+    passed &= check(
+        loadedSettings.trackingModeProfiles[0].focusPolicy
+            == TrackingFocusPolicy::Face
+        && loadedSettings.trackingModeProfiles[2].focusPolicy
+            == TrackingFocusPolicy::Continuous
+        && loadedSettings.trackingModeProfiles[4].focusPolicy
+            == TrackingFocusPolicy::Continuous,
+        "Group, Hand, and Desk receive approved independent defaults");
+
+    std::string legacyHuman = validConfigWithPreset(
+        "0.25", "-0.5", "1.75");
+    legacyHuman = withSetting(legacyHuman, "face_tracking", "enabled");
+    legacyHuman = withSetting(legacyHuman, "face_focus", "enabled");
+    legacyHuman +=
+        "ai_mode=2\n"
+        "focus=73\n"
+        "auto_zoom=enabled\n"
+        "track_speed=4\n";
+    passed &= check(loadRawConfig(
+                        configPath, legacyHuman, &loadedSettings),
+                    "legacy Human tracking config migrates without profile keys");
+    passed &= check(
+        loadedSettings.activeTrackingProfile.focusPolicy
+            == TrackingFocusPolicy::Face
+        && loadedSettings.activeTrackingProfile.manualFocusPosition == 73
+        && loadedSettings.activeTrackingProfile.autoZoom
+        && loadedSettings.activeTrackingProfile.trackSpeed == 4,
+        "active legacy focus, fallback position, zoom, and speed are retained");
+    passed &= check(
+        loadedSettings.trackingModeProfiles[1]
+            == loadedSettings.activeTrackingProfile,
+        "legacy face and auto-zoom intent seeds the Human profile");
+    passed &= check(
+        loadedSettings.trackingModeProfiles[0].focusPolicy
+            == TrackingFocusPolicy::Face
+        && !loadedSettings.trackingModeProfiles[0].autoZoom
+        && loadedSettings.trackingModeProfiles[2].focusPolicy
+            == TrackingFocusPolicy::Continuous
+        && !loadedSettings.trackingModeProfiles[2].autoZoom
+        && loadedSettings.trackingModeProfiles[2].trackSpeed == 4,
+        "legacy Human choices do not leak into other mode focus/zoom defaults");
+
+    const std::string partialProfile = legacyHuman
+        + "#@tiny2_hand_focus_policy=manual\n"
+          "#@tiny2_hand_manual_focus=81\n"
+          "#@tiny2_hand_auto_zoom=enabled\n"
+          "#@tiny2_hand_track_speed=5\n";
+    passed &= check(loadRawConfig(
+                        configPath, partialProfile, &loadedSettings),
+                    "explicit profile metadata is parsed");
+    passed &= check(
+        loadedSettings.trackingModeProfiles[2]
+            == TrackingModeProfile{
+                TrackingFocusPolicy::Manual, 81, true, 5},
+        "explicit Hand profile overrides migration field-for-field");
+
+    TrackingIntentState humanIntent{
+        true,
+        2,
+        1,
+        loadedSettings.trackingModeProfiles[1]
+    };
+    const TrackingIntentState deskIntent =
+        applyAutomaticPaperCropTrackingPolicy(
+            2, true, humanIntent,
+            loadedSettings.trackingModeProfiles);
+    passed &= check(
+        deskIntent.enabled && deskIntent.aiMode == 5
+        && deskIntent.aiSubMode == 0
+        && deskIntent.profile == loadedSettings.trackingModeProfiles[4],
+        "automatic paper crop deterministically selects the Desk profile");
+    passed &= check(
+        applyAutomaticPaperCropTrackingPolicy(
+            0, true, deskIntent,
+            loadedSettings.trackingModeProfiles) == deskIntent,
+        "turning crop off leaves Desk intent active");
+
+    passed &= check(!loadRawConfig(
+                        configPath,
+                        legacyHuman
+                            + "#@tiny2_hand_focus_policy=FACE\n"),
+                    "unknown focus policy spelling is rejected");
+    passed &= check(!loadRawConfig(
+                        configPath,
+                        legacyHuman
+                            + "#@tiny2_hand_manual_focus=101\n"),
+                    "out-of-range profile focus is rejected");
+    passed &= check(!loadRawConfig(
+                        configPath,
+                        legacyHuman
+                            + "#@tiny2_hnad_track_speed=2\n"),
+                    "misspelled profile metadata is rejected");
     passed &= check(!loadConfig(configPath, "nan", "-0.5", "1.75"),
                     "NaN preset pan is rejected");
     passed &= check(!loadConfig(configPath, "0.25", "inf", "1.75"),
@@ -115,6 +266,219 @@ int main()
                     "partially numeric preset pan is rejected");
     passed &= check(!loadConfig(configPath, "0.25", "-0.5", "1.75garbage"),
                     "partially numeric preset zoom is rejected");
+    const std::string validConfig =
+        validConfigWithPreset("0.25", "-0.5", "1.75");
+    passed &= check(!loadRawConfig(
+                        configPath, withSetting(validConfig, "zoom", "nan")),
+                    "NaN global zoom is rejected");
+    passed &= check(!loadRawConfig(
+                        configPath, withSetting(validConfig, "pan", "-inf")),
+                    "infinite global pan is rejected");
+    passed &= check(!loadRawConfig(
+                        configPath, withSetting(validConfig, "tilt", "0.2junk")),
+                    "partially numeric global tilt is rejected");
+
+    std::string undefinedInvalidPreset =
+        withSetting(validConfig, "preset1_defined", "disabled");
+    undefinedInvalidPreset =
+        withSetting(undefinedInvalidPreset, "preset1_pan", "nan");
+    passed &= check(!loadRawConfig(configPath, undefinedInvalidPreset),
+                    "undefined presets still reject non-finite positions");
+    passed &= check(!loadRawConfig(
+                        configPath,
+                        validConfigWithPreset("0.25", "-0.5", "1.75") + "ai_mode=6\n"),
+                    "transitional AI mode cannot be persisted as an operator mode");
+    passed &= check(!loadRawConfig(configPath, validConfig + "ai_mode=2junk\n"),
+                    "partially numeric AI mode is rejected");
+    passed &= check(!loadRawConfig(configPath, validConfig + "ai_sub_mode=1junk\n"),
+                    "partially numeric AI sub-mode is rejected");
+    passed &= check(!loadRawConfig(configPath, validConfig + "track_speed=2junk\n"),
+                    "partially numeric tracking speed is rejected");
+
+    std::string invalidSubMode = validConfigWithPreset("0.25", "-0.5", "1.75");
+    const std::string validSubMode = "preset1_ai_sub_mode=0";
+    invalidSubMode.replace(invalidSubMode.find(validSubMode), validSubMode.size(),
+                           "preset1_ai_sub_mode=5");
+    passed &= check(!loadRawConfig(configPath, invalidSubMode),
+                    "AI sub-mode sentinel cannot be persisted in a scene");
+    passed &= check(!loadRawConfig(
+                        configPath,
+                        validConfig
+                            + "#@camera_pan_tilt_intent_defined=maybe\n"),
+                    "invalid camera intent metadata is rejected");
+
+    Config profileRoundTrip;
+    auto profileSettings = profileRoundTrip.getSettings();
+    profileSettings.faceTracking = true;
+    profileSettings.aiMode = 5;
+    profileSettings.panTiltIntentDefined = false;
+    profileSettings.zoomIntentDefined = false;
+    profileSettings.imageIntentDefined = false;
+    profileSettings.activeTrackingProfile = {
+        TrackingFocusPolicy::Continuous, 67, false, 3};
+    profileSettings.trackingModeProfiles[4] =
+        profileSettings.activeTrackingProfile;
+    profileSettings.presets[0].defined = true;
+    profileSettings.presets[0].sceneDefined = true;
+    profileSettings.presets[0].trackingEnabled = true;
+    profileSettings.presets[0].aiMode = 5;
+    profileSettings.presets[0].focusPolicy = TrackingFocusPolicy::Continuous;
+    profileSettings.presets[0].manualFocusPosition = 67;
+    profileSettings.presets[0].trackSpeed = 3;
+    profileRoundTrip.setSettings(profileSettings);
+    passed &= check(profileRoundTrip.save(),
+                    "valid mode and scene profiles are serialized");
+    const std::string serializedProfiles = readFile(configPath);
+    passed &= check(
+        serializedProfiles.find(
+            "#@tiny2_desk_focus_policy=continuous")
+            != std::string::npos
+        && serializedProfiles.find(
+            "#@preset1_manual_focus=67")
+            != std::string::npos
+        && serializedProfiles.find(
+            "#@camera_pan_tilt_intent_defined=disabled")
+            != std::string::npos,
+        "profiles use rollback-compatible #@ metadata comments");
+    Config profileReload;
+    std::vector<Config::ValidationError> profileErrors;
+    passed &= check(profileReload.load(profileErrors),
+                    "serialized profiles reload successfully");
+    const auto reloadedProfiles = profileReload.getSettings();
+    passed &= check(
+        reloadedProfiles.activeTrackingProfile
+            == profileSettings.activeTrackingProfile
+        && reloadedProfiles.trackingModeProfiles[4]
+            == profileSettings.trackingModeProfiles[4]
+        && reloadedProfiles.presets[0].focusPolicy
+            == TrackingFocusPolicy::Continuous
+        && reloadedProfiles.presets[0].manualFocusPosition == 67
+        && reloadedProfiles.presets[0].trackSpeed == 3
+        && !reloadedProfiles.panTiltIntentDefined
+        && !reloadedProfiles.zoomIntentDefined
+        && !reloadedProfiles.imageIntentDefined,
+        "active, mode, preset, and camera-bound intent fields round-trip exactly");
+
+    const std::string beforeWriteFailure = readFile(configPath);
+    std::error_code permissionError;
+    const auto originalDirectoryPermissions =
+        std::filesystem::status(configDir, permissionError).permissions();
+    passed &= check(!permissionError,
+                    "config directory permissions can be inspected");
+    if (!permissionError) {
+        std::filesystem::permissions(
+            configDir,
+            std::filesystem::perms::owner_read
+                | std::filesystem::perms::owner_exec,
+            std::filesystem::perm_options::replace,
+            permissionError);
+        passed &= check(!permissionError,
+                        "config directory can be made non-writable for failure testing");
+        bool writeRejected = false;
+        if (!permissionError) {
+            Config blockedSave;
+            auto blockedSettings = blockedSave.getSettings();
+            blockedSettings.startMinimized = true;
+            blockedSave.setSettings(blockedSettings);
+            writeRejected = !blockedSave.save();
+        }
+
+        std::error_code restoreError;
+        std::filesystem::permissions(
+            configDir, originalDirectoryPermissions,
+            std::filesystem::perm_options::replace, restoreError);
+        passed &= check(!restoreError,
+                        "config directory permissions are restored after failure testing");
+        passed &= check(writeRejected,
+                        "I/O failure rejects a configuration save");
+        passed &= check(readFile(configPath) == beforeWriteFailure,
+                        "I/O failure leaves the previous configuration atomically intact");
+    }
+
+    const std::string sentinelContents = "preserve-existing-settings\n";
+    {
+        std::ofstream sentinel(configPath);
+        sentinel << sentinelContents;
+    }
+
+    Config invalidGlobal;
+    auto invalidSettings = invalidGlobal.getSettings();
+    invalidSettings.zoom = std::numeric_limits<double>::quiet_NaN();
+    invalidGlobal.setSettings(invalidSettings);
+    passed &= check(!invalidGlobal.save(),
+                    "in-memory non-finite global settings are not serialized");
+    passed &= check(readFile(configPath) == sentinelContents,
+                    "rejected save leaves the existing settings file untouched");
+
+    Config invalidUndefinedPreset;
+    invalidSettings = invalidUndefinedPreset.getSettings();
+    invalidSettings.presets[0].defined = false;
+    invalidSettings.presets[0].pan =
+        std::numeric_limits<double>::quiet_NaN();
+    invalidUndefinedPreset.setSettings(invalidSettings);
+    passed &= check(!invalidUndefinedPreset.save(),
+                    "invalid undefined preset values are not serialized");
+
+    Config invalidPresetAi;
+    invalidSettings = invalidPresetAi.getSettings();
+    invalidSettings.presets[0].aiMode = 99;
+    invalidPresetAi.setSettings(invalidSettings);
+    passed &= check(!invalidPresetAi.save(),
+                    "invalid in-memory preset AI mode is not serialized");
+
+    Config invalidGlobalCrop;
+    invalidSettings = invalidGlobalCrop.getSettings();
+    invalidSettings.paperCropLeft =
+        std::numeric_limits<double>::quiet_NaN();
+    invalidGlobalCrop.setSettings(invalidSettings);
+    passed &= check(!invalidGlobalCrop.save(),
+                    "invalid in-memory global crop is not serialized");
+
+    Config invalidPresetCrop;
+    invalidSettings = invalidPresetCrop.getSettings();
+    invalidSettings.presets[0].paperCropMode = 3;
+    invalidPresetCrop.setSettings(invalidSettings);
+    passed &= check(!invalidPresetCrop.save(),
+                    "invalid in-memory preset crop is not serialized");
+
+    Config invalidModeProfile;
+    invalidSettings = invalidModeProfile.getSettings();
+    invalidSettings.trackingModeProfiles[2].trackSpeed = 6;
+    invalidModeProfile.setSettings(invalidSettings);
+    passed &= check(!invalidModeProfile.save(),
+                    "invalid mode profile is not serialized");
+
+    Config invalidOffProfile;
+    invalidSettings = invalidOffProfile.getSettings();
+    invalidSettings.activeTrackingProfile.focusPolicy =
+        TrackingFocusPolicy::Continuous;
+    invalidOffProfile.setSettings(invalidSettings);
+    passed &= check(!invalidOffProfile.save(),
+                    "tracking-off active profile must remain manual");
+
+    Config invalidPresetProfile;
+    invalidSettings = invalidPresetProfile.getSettings();
+    invalidSettings.presets[0].manualFocusPosition = 101;
+    invalidPresetProfile.setSettings(invalidSettings);
+    passed &= check(!invalidPresetProfile.save(),
+                    "invalid undefined preset profile is not serialized");
+
+    Config invalidLegacyFocus;
+    invalidSettings = invalidLegacyFocus.getSettings();
+    invalidSettings.focus = 101;
+    invalidLegacyFocus.setSettings(invalidSettings);
+    passed &= check(!invalidLegacyFocus.save(),
+                    "invalid legacy focus compatibility value is rejected");
+
+    const std::filesystem::path missingParent =
+        root / "new-xdg-parent" / "nested";
+    setenv("XDG_CONFIG_HOME", missingParent.c_str(), 1);
+    Config firstSave;
+    passed &= check(
+        firstSave.save()
+        && std::filesystem::exists(
+            missingParent / "obsbot-control" / "settings.conf"),
+        "first save creates the complete missing XDG parent hierarchy");
 
     std::filesystem::remove_all(root);
     return passed ? 0 : 1;

--- a/tests/ConfigPresetValidationTest.cpp
+++ b/tests/ConfigPresetValidationTest.cpp
@@ -1,0 +1,94 @@
+#include "Config.h"
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::string validConfigWithPreset(const std::string &pan,
+                                  const std::string &tilt,
+                                  const std::string &zoom)
+{
+    return
+        "face_tracking=disabled\n"
+        "hdr=disabled\n"
+        "fov=wide\n"
+        "face_ae=disabled\n"
+        "face_focus=disabled\n"
+        "zoom=1.0\n"
+        "pan=0.0\n"
+        "tilt=0.0\n"
+        "brightness_auto=enabled\n"
+        "brightness=128\n"
+        "contrast_auto=enabled\n"
+        "contrast=128\n"
+        "saturation_auto=enabled\n"
+        "saturation=128\n"
+        "white_balance=auto\n"
+        "start_minimized=disabled\n"
+        "preset1_defined=enabled\n"
+        "preset1_pan=" + pan + "\n"
+        "preset1_tilt=" + tilt + "\n"
+        "preset1_zoom=" + zoom + "\n";
+}
+
+bool loadConfig(const std::filesystem::path &configPath,
+                const std::string &pan,
+                const std::string &tilt,
+                const std::string &zoom)
+{
+    std::ofstream file(configPath);
+    file << validConfigWithPreset(pan, tilt, zoom);
+    file.close();
+
+    Config config;
+    std::vector<Config::ValidationError> errors;
+    return config.load(errors);
+}
+
+bool check(bool condition, const char *message)
+{
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+    }
+    return condition;
+}
+
+} // namespace
+
+int main()
+{
+    const char *tmpDir = std::getenv("TMPDIR");
+    if (!tmpDir || tmpDir[0] == '\0') {
+        std::cerr << "FAIL: TMPDIR must be set for scratch-backed tests\n";
+        return 1;
+    }
+
+    const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+    const std::filesystem::path root =
+        std::filesystem::path(tmpDir) / ("obsbot-config-test-" + std::to_string(nonce));
+    const std::filesystem::path configDir = root / "obsbot-control";
+    const std::filesystem::path configPath = configDir / "settings.conf";
+    std::filesystem::create_directories(configDir);
+    setenv("XDG_CONFIG_HOME", root.c_str(), 1);
+
+    bool passed = true;
+    passed &= check(loadConfig(configPath, "0.25", "-0.5", "1.75"),
+                    "finite preset values are accepted");
+    passed &= check(!loadConfig(configPath, "nan", "-0.5", "1.75"),
+                    "NaN preset pan is rejected");
+    passed &= check(!loadConfig(configPath, "0.25", "inf", "1.75"),
+                    "infinite preset tilt is rejected");
+    passed &= check(!loadConfig(configPath, "0.25junk", "-0.5", "1.75"),
+                    "partially numeric preset pan is rejected");
+    passed &= check(!loadConfig(configPath, "0.25", "-0.5", "1.75garbage"),
+                    "partially numeric preset zoom is rejected");
+
+    std::filesystem::remove_all(root);
+    return passed ? 0 : 1;
+}

--- a/tests/ConfigPresetValidationTest.cpp
+++ b/tests/ConfigPresetValidationTest.cpp
@@ -31,16 +31,32 @@ std::string validConfigWithPreset(const std::string &pan,
         "saturation=128\n"
         "white_balance=auto\n"
         "start_minimized=disabled\n"
+        "paper_crop_mode=automatic\n"
+        "paper_crop_left=0.10\n"
+        "paper_crop_top=0.05\n"
+        "paper_crop_right=0.10\n"
+        "paper_crop_bottom=0.05\n"
         "preset1_defined=enabled\n"
         "preset1_pan=" + pan + "\n"
         "preset1_tilt=" + tilt + "\n"
-        "preset1_zoom=" + zoom + "\n";
+        "preset1_zoom=" + zoom + "\n"
+        "preset1_scene_defined=enabled\n"
+        "preset1_tracking_enabled=disabled\n"
+        "preset1_ai_mode=0\n"
+        "preset1_ai_sub_mode=0\n"
+        "preset1_auto_zoom=disabled\n"
+        "preset1_paper_crop_mode=manual\n"
+        "preset1_paper_crop_left=0.15\n"
+        "preset1_paper_crop_top=0.10\n"
+        "preset1_paper_crop_right=0.15\n"
+        "preset1_paper_crop_bottom=0.10\n";
 }
 
 bool loadConfig(const std::filesystem::path &configPath,
                 const std::string &pan,
                 const std::string &tilt,
-                const std::string &zoom)
+                const std::string &zoom,
+                Config::CameraSettings *loadedSettings = nullptr)
 {
     std::ofstream file(configPath);
     file << validConfigWithPreset(pan, tilt, zoom);
@@ -48,7 +64,11 @@ bool loadConfig(const std::filesystem::path &configPath,
 
     Config config;
     std::vector<Config::ValidationError> errors;
-    return config.load(errors);
+    const bool loaded = config.load(errors);
+    if (loaded && loadedSettings) {
+        *loadedSettings = config.getSettings();
+    }
+    return loaded;
 }
 
 bool check(bool condition, const char *message)
@@ -78,8 +98,15 @@ int main()
     setenv("XDG_CONFIG_HOME", root.c_str(), 1);
 
     bool passed = true;
-    passed &= check(loadConfig(configPath, "0.25", "-0.5", "1.75"),
-                    "finite preset values are accepted");
+    Config::CameraSettings loadedSettings{};
+    passed &= check(loadConfig(configPath, "0.25", "-0.5", "1.75", &loadedSettings),
+                    "finite scene preset and crop values are accepted");
+    passed &= check(loadedSettings.paperCropMode == 2,
+                    "automatic global crop mode is parsed");
+    passed &= check(loadedSettings.presets[0].sceneDefined
+                    && !loadedSettings.presets[0].trackingEnabled
+                    && loadedSettings.presets[0].paperCropMode == 1,
+                    "manual scene state is parsed");
     passed &= check(!loadConfig(configPath, "nan", "-0.5", "1.75"),
                     "NaN preset pan is rejected");
     passed &= check(!loadConfig(configPath, "0.25", "inf", "1.75"),

--- a/tests/PTZControlWidgetTest.cpp
+++ b/tests/PTZControlWidgetTest.cpp
@@ -1,0 +1,207 @@
+#include "CameraController.h"
+#include "CameraSettingsWidget.h"
+#include "PTZControlWidget.h"
+#include "TrackingControlWidget.h"
+
+#include <QApplication>
+#include <QCoreApplication>
+#include <iostream>
+#include <vector>
+
+struct PTZControlWidgetTestAccess
+{
+    static PTZControlWidget::PresetState trackingPreset(bool autoZoom = false)
+    {
+        return {
+            true,
+            0.0,
+            0.0,
+            1.0,
+            true,
+            true,
+            Device::AiWorkModeHuman,
+            Device::AiSubModeNormal,
+            autoZoom,
+            TrackingFocusPolicy::Continuous,
+            50,
+            Device::AiTrackSpeedStandard,
+            {}
+        };
+    }
+
+    static void arm(PTZControlWidget &widget,
+                    quint64 recallGeneration,
+                    quint64 trackingIntentGeneration)
+    {
+        widget.m_recallGeneration = recallGeneration;
+        widget.m_completionQueued = false;
+        widget.m_pendingRecall = PTZControlWidget::PendingRecall{
+            trackingPreset(), recallGeneration, trackingIntentGeneration};
+    }
+
+    static bool completionQueued(const PTZControlWidget &widget)
+    {
+        return widget.m_completionQueued;
+    }
+
+    static bool finish(PTZControlWidget &widget,
+                       const PTZControlWidget::PresetState &preset)
+    {
+        return widget.finishPresetRecall(preset);
+    }
+};
+
+namespace {
+
+bool check(bool condition, const char *message)
+{
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+    }
+    return condition;
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+    qputenv("QT_QPA_PLATFORM", QByteArrayLiteral("offscreen"));
+    QApplication application(argc, argv);
+
+    bool passed = true;
+    CameraController controller;
+    PTZControlWidget widget(&controller);
+
+    CameraController::CameraInfo info{};
+    emit controller.cameraConnected(info);
+
+    std::vector<bool> completions;
+    QObject::connect(&widget, &PTZControlWidget::presetRecallFinished,
+                     [&completions](bool success) {
+                         completions.push_back(success);
+                     });
+
+    PTZControlWidgetTestAccess::arm(widget, 10, 100);
+    emit controller.trackingStateConfirmed(true, 100);
+    passed &= check(PTZControlWidgetTestAccess::completionQueued(widget),
+                    "matching confirmation queues scene continuation");
+    QCoreApplication::processEvents();
+    passed &= check(completions.size() == 1 && completions.back(),
+                    "uncancelled continuation completes once");
+    passed &= check(!widget.hasPendingRecall(),
+                    "completed continuation clears pending state");
+
+    PTZControlWidgetTestAccess::arm(widget, 20, 200);
+    emit controller.trackingStateConfirmed(true, 200);
+    passed &= check(PTZControlWidgetTestAccess::completionQueued(widget),
+                    "second matching confirmation queues continuation");
+    widget.cancelPendingRecall();
+    QCoreApplication::processEvents();
+    passed &= check(completions.size() == 1,
+                    "explicit cancellation invalidates queued continuation");
+    passed &= check(!widget.hasPendingRecall(),
+                    "cancellation clears all pending phases");
+
+    PTZControlWidgetTestAccess::arm(widget, 30, 300);
+    emit controller.trackingStateConfirmed(true, 300);
+    emit controller.trackingIntentStarted(301);
+    passed &= check(completions.size() == 2 && !completions.back(),
+                    "newer tracking intent fails the superseded recall");
+    QCoreApplication::processEvents();
+    passed &= check(completions.size() == 2,
+                    "superseded queued callback cannot complete later");
+
+    PTZControlWidgetTestAccess::arm(widget, 40, 350);
+    emit controller.trackingStateConfirmationUncertain(350);
+    passed &= check(completions.size() == 3 && !completions.back(),
+                    "uncertain ownership terminates a pending recall fail-closed");
+    passed &= check(!widget.hasPendingRecall(),
+                    "uncertain confirmation cannot leave D-Bus waiting on a recall");
+
+    PTZControlWidgetTestAccess::arm(widget, 45, 500);
+    emit controller.trackingIntentStarted(499);
+    passed &= check(widget.hasPendingRecall() && completions.size() == 3,
+                    "older tracking start cannot cancel a newer pending recall");
+    emit controller.trackingStateConfirmed(true, 500);
+    QCoreApplication::processEvents();
+    passed &= check(completions.size() == 4 && completions.back(),
+                    "pending recall still completes under its matching generation");
+
+    TrackingControlWidget tracking(&controller);
+    widget.setTrackingControlWidget(&tracking);
+    tracking.setAiMode(Device::AiWorkModeHuman);
+    tracking.setHumanSubMode(Device::AiSubModeNormal);
+    tracking.setAutoZoomEnabled(false);
+    tracking.setActiveTrackingProfile({
+        TrackingFocusPolicy::Continuous,
+        50,
+        false,
+        Device::AiTrackSpeedStandard
+    });
+    tracking.setTrackingEnabled(true);
+    emit controller.trackingIntentStarted(400);
+    emit controller.trackingStateConfirmed(true, 400);
+
+    int sceneIntentCount = 0;
+    bool sceneTracking = false;
+    bool scenePositionApplied = true;
+    TrackingModeProfile sceneProfile;
+    PaperCropSettings sceneCrop;
+    QObject::connect(
+        &widget, &PTZControlWidget::sceneIntentApplied,
+        [&sceneIntentCount, &sceneTracking, &scenePositionApplied,
+         &sceneProfile, &sceneCrop](
+            const TrackingIntentState &trackingState,
+            bool positionApplied, double, double, double,
+            const PaperCropSettings &paperCrop) {
+            ++sceneIntentCount;
+            sceneTracking = trackingState.enabled;
+            scenePositionApplied = positionApplied;
+            sceneProfile = trackingState.profile;
+            sceneCrop = paperCrop;
+        });
+
+    auto matching = PTZControlWidgetTestAccess::trackingPreset(false);
+    matching.paperCrop.mode = PaperCropMode::Manual;
+    matching.paperCrop.left = 0.1f;
+    passed &= check(PTZControlWidgetTestAccess::finish(widget, matching),
+                    "exact confirmed tracking scene can finish");
+    passed &= check(sceneIntentCount == 1 && sceneTracking
+                        && !scenePositionApplied
+                        && sceneProfile == tracking.activeTrackingProfile()
+                        && sceneCrop == matching.paperCrop,
+                    "successful scene emits one complete profile+crop intent without unapplied PTZ");
+
+    auto wrongAutoZoom = matching;
+    wrongAutoZoom.autoZoom = true;
+    passed &= check(!PTZControlWidgetTestAccess::finish(widget, wrongAutoZoom),
+                    "auto-zoom mismatch blocks scene completion");
+
+    auto wrongFocusPolicy = matching;
+    wrongFocusPolicy.focusPolicy = TrackingFocusPolicy::Face;
+    passed &= check(
+        !PTZControlWidgetTestAccess::finish(widget, wrongFocusPolicy),
+        "focus-policy mismatch blocks scene completion");
+
+    auto wrongMode = matching;
+    wrongMode.aiMode = Device::AiWorkModeDesk;
+    passed &= check(!PTZControlWidgetTestAccess::finish(widget, wrongMode),
+                    "AI-mode mismatch blocks scene completion");
+    passed &= check(sceneIntentCount == 1,
+                    "failed scene checks emit no persisted intent");
+
+    CameraSettingsWidget cameraSettings(&controller);
+    bool hdrIntent = false;
+    int hdrIntentCount = 0;
+    QObject::connect(&cameraSettings, &CameraSettingsWidget::hdrIntentEdited,
+                     [&hdrIntent, &hdrIntentCount](bool enabled) {
+                         hdrIntent = enabled;
+                         ++hdrIntentCount;
+                     });
+    const bool invoked = QMetaObject::invokeMethod(
+        &cameraSettings, "onHDRToggled", Q_ARG(bool, true));
+    passed &= check(invoked && hdrIntentCount == 1 && hdrIntent,
+                    "camera settings expose exact requested values for persistence");
+
+    return passed ? 0 : 1;
+}

--- a/tests/PaperCropProcessorTest.cpp
+++ b/tests/PaperCropProcessorTest.cpp
@@ -3,7 +3,10 @@
 #include <QColor>
 #include <QImage>
 #include <QPainter>
+#include <QPainterPath>
 #include <QPolygon>
+#include <array>
+#include <cmath>
 #include <iostream>
 
 namespace {
@@ -14,6 +17,74 @@ bool check(bool condition, const char *message)
         std::cerr << "FAIL: " << message << '\n';
     }
     return condition;
+}
+
+QImage texturedPage(const QPolygon &polygon)
+{
+    QImage image(640, 480, QImage::Format_RGBA8888);
+    image.fill(Qt::black);
+
+    QPainter painter(&image);
+    QPainterPath pagePath;
+    pagePath.addPolygon(polygon);
+    painter.setClipPath(pagePath);
+    painter.fillRect(image.rect(), Qt::white);
+
+    const std::array<QColor, 4> colors = {
+        QColor(Qt::red), QColor(Qt::green),
+        QColor(Qt::blue), QColor(Qt::yellow)
+    };
+    QPoint center;
+    for (const QPoint &point : polygon) {
+        center += point;
+    }
+    center /= 4;
+    painter.setPen(Qt::NoPen);
+    for (int i = 0; i < 4; ++i) {
+        const QPoint vector = polygon[i] - center;
+        const QPoint marker = center + QPoint(
+            vector.x() * 3 / 4, vector.y() * 3 / 4);
+        painter.setBrush(colors[static_cast<size_t>(i)]);
+        painter.drawEllipse(marker, 35, 35);
+    }
+    return image;
+}
+
+double sampledColorDifference(const QImage &left, const QImage &right)
+{
+    long long difference = 0;
+    long long channels = 0;
+    for (int y = 0; y < left.height(); y += 4) {
+        for (int x = 0; x < left.width(); x += 4) {
+            const QColor a = left.pixelColor(x, y);
+            const QColor b = right.pixelColor(x, y);
+            difference += std::abs(a.red() - b.red());
+            difference += std::abs(a.green() - b.green());
+            difference += std::abs(a.blue() - b.blue());
+            channels += 3;
+        }
+    }
+    return channels > 0
+        ? static_cast<double>(difference) / static_cast<double>(channels)
+        : 0.0;
+}
+
+bool containsApproximateColor(const QImage &image,
+                              const QRect &region,
+                              const QColor &target)
+{
+    const QRect bounded = region.intersected(image.rect());
+    for (int y = bounded.top(); y <= bounded.bottom(); y += 2) {
+        for (int x = bounded.left(); x <= bounded.right(); x += 2) {
+            const QColor color = image.pixelColor(x, y);
+            if (std::abs(color.red() - target.red()) < 80
+                && std::abs(color.green() - target.green()) < 80
+                && std::abs(color.blue() - target.blue()) < 80) {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 } // namespace
@@ -64,6 +135,289 @@ int main()
                         "automatic crop preserves the output frame size");
         passed &= check(automaticallyCropped.pixelColor(320, 240).lightness() > 200,
                         "automatic crop centers the detected paper");
+
+        QImage occludedDocument = document;
+        QPainter occlusionPainter(&occludedDocument);
+        occlusionPainter.setPen(Qt::NoPen);
+        occlusionPainter.setBrush(Qt::black);
+        occlusionPainter.drawRect(QRect(285, 40, 70, 125));
+        occlusionPainter.end();
+
+        PaperCropProcessor occlusionProcessor;
+        const QImage occlusionCrop = occlusionProcessor.process(occludedDocument, automatic);
+        passed &= check(occlusionProcessor.paperDetected(),
+                        "automatic mode tolerates a bounded hand-like edge occlusion");
+        passed &= check(occlusionCrop.size() == occludedDocument.size(),
+                        "occlusion-tolerant crop preserves the output frame size");
+        passed &= check(occlusionCrop.pixelColor(320, 240).lightness() > 200,
+                        "occlusion recovery keeps the paper centered");
+
+        QImage diamond(640, 480, QImage::Format_RGBA8888);
+        diamond.fill(Qt::black);
+        QPainter diamondPainter(&diamond);
+        diamondPainter.setPen(Qt::NoPen);
+        diamondPainter.setBrush(Qt::white);
+        diamondPainter.drawPolygon(QPolygon({
+            QPoint(320, 45), QPoint(555, 240),
+            QPoint(320, 435), QPoint(85, 240)
+        }));
+        diamondPainter.end();
+        PaperCropProcessor diamondProcessor;
+        diamondProcessor.process(diamond, automatic);
+        passed &= check(diamondProcessor.paperDetected(),
+                        "automatic mode detects a symmetrically rotated page");
+
+        const QPolygon beforeCornerTransition({
+            QPoint(320, 50), QPoint(560, 230),
+            QPoint(330, 430), QPoint(90, 250)
+        });
+        const QPolygon afterCornerTransition({
+            QPoint(290, 45), QPoint(560, 230),
+            QPoint(330, 430), QPoint(90, 250)
+        });
+        PaperCropProcessor continuityProcessor;
+        const QImage beforeCrop = continuityProcessor.process(
+            texturedPage(beforeCornerTransition), automatic);
+        QImage afterCrop;
+        for (int frame = 0; frame < 10; ++frame) {
+            afterCrop = continuityProcessor.process(
+                texturedPage(afterCornerTransition), automatic);
+        }
+        passed &= check(continuityProcessor.paperDetected(),
+                        "rotating textured page remains detected across corner transition");
+        passed &= check(sampledColorDifference(beforeCrop, afterCrop) < 30.0,
+                        "cyclic corner alignment prevents a 90-degree crop jump");
+
+        QImage concaveDistractor(640, 480, QImage::Format_RGBA8888);
+        concaveDistractor.fill(Qt::black);
+        QPainter distractorPainter(&concaveDistractor);
+        distractorPainter.setPen(Qt::NoPen);
+        distractorPainter.setBrush(Qt::white);
+        distractorPainter.drawPolygon(QPolygon({
+            QPoint(80, 50), QPoint(560, 50), QPoint(560, 430),
+            QPoint(420, 430), QPoint(420, 130), QPoint(220, 130),
+            QPoint(220, 430), QPoint(80, 430)
+        }));
+        distractorPainter.end();
+        PaperCropProcessor distractorProcessor;
+        distractorProcessor.process(concaveDistractor, automatic);
+        passed &= check(!distractorProcessor.paperDetected(),
+                        "large concave non-document is not promoted by its convex hull");
+
+        QImage borderClipped(640, 480, QImage::Format_RGBA8888);
+        borderClipped.fill(Qt::black);
+        QPainter borderPainter(&borderClipped);
+        borderPainter.setPen(Qt::NoPen);
+        borderPainter.setBrush(Qt::white);
+        borderPainter.drawPolygon(QPolygon({
+            QPoint(100, 60), QPoint(540, 80),
+            QPoint(610, 479), QPoint(20, 479)
+        }));
+        borderPainter.end();
+        PaperCropProcessor borderProcessor;
+        borderProcessor.process(borderClipped, automatic);
+        passed &= check(!borderProcessor.paperDetected(),
+                        "automatic mode rejects a page whose corners leave the frame");
+
+        const QPolygon fullHeightPage({
+            QPoint(190, 0), QPoint(430, 0),
+            QPoint(500, 479), QPoint(140, 479)
+        });
+        QImage clippedPrintedPage(640, 480, QImage::Format_RGBA8888);
+        clippedPrintedPage.fill(Qt::black);
+        QPainter clippedPainter(&clippedPrintedPage);
+        QPainterPath clippedPath;
+        clippedPath.addPolygon(fullHeightPage);
+        clippedPainter.setClipPath(clippedPath);
+        clippedPainter.fillRect(clippedPrintedPage.rect(), Qt::white);
+        clippedPainter.setPen(QPen(Qt::black, 3));
+        for (int y = 70; y < 440; y += 24) {
+            clippedPainter.drawLine(225, y, 430, y);
+        }
+        clippedPainter.setPen(Qt::NoPen);
+        clippedPainter.setBrush(Qt::red);
+        clippedPainter.drawEllipse(QPoint(215, 45), 18, 18);
+        clippedPainter.setBrush(Qt::green);
+        clippedPainter.drawEllipse(QPoint(405, 45), 18, 18);
+        clippedPainter.setBrush(Qt::blue);
+        clippedPainter.drawEllipse(QPoint(455, 430), 18, 18);
+        clippedPainter.setBrush(Qt::yellow);
+        clippedPainter.drawEllipse(QPoint(175, 430), 18, 18);
+        clippedPainter.setPen(Qt::NoPen);
+        clippedPainter.setBrush(Qt::black);
+        clippedPainter.drawEllipse(QPoint(170, 205), 32, 40);
+        clippedPainter.drawEllipse(QPoint(470, 300), 34, 42);
+        clippedPainter.end();
+
+        PaperCropProcessor clippedPrintedProcessor;
+        clippedPrintedProcessor.process(clippedPrintedPage, automatic);
+        passed &= check(!clippedPrintedProcessor.paperDetected(),
+                        "one line-only candidate does not acquire a crop lock");
+        clippedPrintedProcessor.process(clippedPrintedPage, automatic);
+        passed &= check(!clippedPrintedProcessor.paperDetected(),
+                        "two line-only candidates remain below acquisition hysteresis");
+        const QImage clippedPrintedCrop =
+            clippedPrintedProcessor.process(clippedPrintedPage, automatic);
+        passed &= check(clippedPrintedProcessor.paperDetected(),
+                        "three consistent line recoveries lock a frame-clipped printed page");
+        passed &= check(clippedPrintedCrop.size() == clippedPrintedPage.size(),
+                        "frame-clipped paper recovery preserves output size");
+        passed &= check(containsApproximateColor(
+                            clippedPrintedCrop, QRect(0, 0, 320, 240), Qt::red)
+                        && containsApproximateColor(
+                            clippedPrintedCrop, QRect(320, 0, 320, 240), Qt::green)
+                        && containsApproximateColor(
+                            clippedPrintedCrop, QRect(320, 240, 320, 240), Qt::blue)
+                        && containsApproximateColor(
+                            clippedPrintedCrop, QRect(0, 240, 320, 240), Qt::yellow),
+                        "frame-clipped warp retains all four page-corner landmarks");
+
+        QImage shiftedPrintedPage(640, 480, QImage::Format_RGBA8888);
+        shiftedPrintedPage.fill(Qt::black);
+        QPainter shiftPainter(&shiftedPrintedPage);
+        shiftPainter.drawImage(110, 0, clippedPrintedPage);
+        shiftPainter.end();
+
+        PaperCropProcessor relocationProcessor;
+        for (int frame = 0; frame < 3; ++frame) {
+            relocationProcessor.process(clippedPrintedPage, automatic);
+        }
+        QImage beforeScheduledRelocation;
+        for (int frame = 1; frame <= 7; ++frame) {
+            beforeScheduledRelocation =
+                relocationProcessor.process(shiftedPrintedPage, automatic);
+        }
+        const QImage rejectedRelocation =
+            relocationProcessor.process(shiftedPrintedPage, automatic);
+        passed &= check(relocationProcessor.paperDetected()
+                        && rejectedRelocation == beforeScheduledRelocation,
+                        "abrupt valid replacement keeps the retained crop unchanged");
+
+        for (int frame = 9; frame <= 30; ++frame) {
+            relocationProcessor.process(shiftedPrintedPage, automatic);
+        }
+        passed &= check(relocationProcessor.paperDetected(),
+                        "abrupt replacement holds the prior crop for 30 full frames");
+        relocationProcessor.process(shiftedPrintedPage, automatic);
+        passed &= check(!relocationProcessor.paperDetected(),
+                        "stale crop expires after persistent abrupt relocation");
+
+        relocationProcessor.process(shiftedPrintedPage, automatic);
+        relocationProcessor.process(shiftedPrintedPage, automatic);
+        const QImage reacquiredRelocation =
+            relocationProcessor.process(shiftedPrintedPage, automatic);
+        passed &= check(relocationProcessor.paperDetected(),
+                        "relocated page reacquires after three fresh consistent detections");
+        passed &= check(containsApproximateColor(
+                            reacquiredRelocation, QRect(0, 0, 320, 240), Qt::red)
+                        && containsApproximateColor(
+                            reacquiredRelocation, QRect(320, 0, 320, 240), Qt::green)
+                        && containsApproximateColor(
+                            reacquiredRelocation, QRect(320, 240, 320, 240), Qt::blue)
+                        && containsApproximateColor(
+                            reacquiredRelocation, QRect(0, 240, 320, 240), Qt::yellow),
+                        "relocated crop retains all four oriented landmarks");
+
+        QImage plainClippedPanel(640, 480, QImage::Format_RGBA8888);
+        plainClippedPanel.fill(Qt::black);
+        QPainter panelPainter(&plainClippedPanel);
+        panelPainter.setPen(Qt::NoPen);
+        panelPainter.setBrush(Qt::white);
+        panelPainter.drawPolygon(fullHeightPage);
+        panelPainter.end();
+        PaperCropProcessor panelProcessor;
+        panelProcessor.process(plainClippedPanel, automatic);
+        passed &= check(!panelProcessor.paperDetected(),
+                        "line recovery rejects an untextured frame-clipped panel");
+
+        QImage texturedDisplay(640, 480, QImage::Format_RGBA8888);
+        texturedDisplay.fill(Qt::black);
+        const QPolygon displayBezel({
+            QPoint(170, 0), QPoint(450, 0),
+            QPoint(520, 479), QPoint(120, 479)
+        });
+        const QPolygon displaySurface({
+            QPoint(195, 0), QPoint(425, 0),
+            QPoint(485, 479), QPoint(155, 479)
+        });
+        QPainter displayPainter(&texturedDisplay);
+        displayPainter.setPen(Qt::NoPen);
+        displayPainter.setBrush(QColor(45, 45, 45));
+        displayPainter.drawPolygon(displayBezel);
+        QPainterPath displayPath;
+        displayPath.addPolygon(displaySurface);
+        displayPainter.setClipPath(displayPath);
+        displayPainter.fillRect(texturedDisplay.rect(), QColor(230, 230, 230));
+        displayPainter.setPen(QPen(QColor(70, 70, 70), 3));
+        for (int y = 50; y < 460; y += 25) {
+            displayPainter.drawLine(190, y, 460, y);
+        }
+        for (int x = 230; x < 430; x += 50) {
+            displayPainter.drawLine(x, 20, x, 460);
+        }
+        displayPainter.end();
+
+        PaperCropProcessor displayProcessor;
+        for (int frame = 0; frame < 3; ++frame) {
+            displayProcessor.process(texturedDisplay, automatic);
+        }
+        passed &= check(!displayProcessor.paperDetected(),
+                        "line recovery rejects a textured display inside a dark bezel");
+
+        QImage wideRectangle(640, 480, QImage::Format_RGBA8888);
+        wideRectangle.fill(Qt::black);
+        QPainter widePainter(&wideRectangle);
+        widePainter.fillRect(QRect(50, 175, 540, 130), Qt::white);
+        widePainter.end();
+        PaperCropProcessor wideProcessor;
+        wideProcessor.process(wideRectangle, automatic);
+        passed &= check(!wideProcessor.paperDetected(),
+                        "automatic mode rejects implausibly wide rectangular distractors");
+
+        PaperCropSettings automaticWithFallback = automatic;
+        automaticWithFallback.left = 0.25f;
+        PaperCropProcessor retentionProcessor;
+        retentionProcessor.process(document, automaticWithFallback);
+        passed &= check(retentionProcessor.paperDetected(),
+                        "retention test starts from a confirmed paper lock");
+
+        QImage fallbackFrame(640, 480, QImage::Format_RGBA8888);
+        fallbackFrame.fill(Qt::red);
+        for (int frame = 1; frame <= 30; ++frame) {
+            retentionProcessor.process(fallbackFrame, automaticWithFallback);
+            passed &= check(retentionProcessor.paperDetected(),
+                            "last good paper boundary is retained for 30 full frames");
+        }
+        const QImage fallbackOutput =
+            retentionProcessor.process(fallbackFrame, automaticWithFallback);
+        passed &= check(!retentionProcessor.paperDetected(),
+                        "paper lock expires on the 31st missed frame");
+
+        PaperCropSettings manualFallback = automaticWithFallback;
+        manualFallback.mode = PaperCropMode::Manual;
+        PaperCropProcessor manualFallbackProcessor;
+        const QImage expectedFallback =
+            manualFallbackProcessor.process(fallbackFrame, manualFallback);
+        passed &= check(fallbackOutput == expectedFallback,
+                        "expired automatic lock uses the saved manual rectangle");
+
+        retentionProcessor.reset();
+        passed &= check(!retentionProcessor.paperDetected(),
+                        "explicit reset clears a retained paper boundary");
+    } else {
+        PaperCropSettings automaticFallback;
+        automaticFallback.mode = PaperCropMode::Automatic;
+        automaticFallback.left = 0.25f;
+        const QImage automaticOutput = processor.process(gradient, automaticFallback);
+
+        PaperCropSettings manualFallback = automaticFallback;
+        manualFallback.mode = PaperCropMode::Manual;
+        PaperCropProcessor manualProcessor;
+        const QImage manualOutput = manualProcessor.process(gradient, manualFallback);
+        passed &= check(automaticOutput == manualOutput,
+                        "no-OpenCV automatic mode uses the manual fallback");
+        passed &= check(!processor.paperDetected(),
+                        "no-OpenCV fallback never reports an automatic lock");
     }
 
     return passed ? 0 : 1;

--- a/tests/PaperCropProcessorTest.cpp
+++ b/tests/PaperCropProcessorTest.cpp
@@ -1,0 +1,70 @@
+#include "PaperCropProcessor.h"
+
+#include <QColor>
+#include <QImage>
+#include <QPainter>
+#include <QPolygon>
+#include <iostream>
+
+namespace {
+
+bool check(bool condition, const char *message)
+{
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+    }
+    return condition;
+}
+
+} // namespace
+
+int main()
+{
+    bool passed = true;
+    PaperCropProcessor processor;
+
+    QImage gradient(100, 100, QImage::Format_RGBA8888);
+    for (int y = 0; y < gradient.height(); ++y) {
+        for (int x = 0; x < gradient.width(); ++x) {
+            gradient.setPixelColor(x, y, QColor(x * 255 / 99, y * 255 / 99, 0));
+        }
+    }
+
+    PaperCropSettings manual;
+    manual.mode = PaperCropMode::Manual;
+    manual.left = 0.25f;
+    const QImage manuallyCropped = processor.process(gradient, manual);
+    passed &= check(manuallyCropped.size() == gradient.size(),
+                    "manual crop preserves the output frame size");
+    passed &= check(manuallyCropped.pixelColor(0, 50) == QColor(Qt::black),
+                    "manual crop letterboxes mismatched aspect ratios");
+    passed &= check(manuallyCropped.pixelColor(50, 50).red() > 130,
+                    "manual crop removes the requested left margin");
+
+    if (PaperCropProcessor::automaticDetectionAvailable()) {
+        QImage document(640, 480, QImage::Format_RGBA8888);
+        document.fill(Qt::black);
+        QPainter painter(&document);
+        painter.setPen(Qt::NoPen);
+        painter.setBrush(Qt::white);
+        painter.drawPolygon(QPolygon({
+            QPoint(120, 70),
+            QPoint(530, 95),
+            QPoint(575, 405),
+            QPoint(75, 420)
+        }));
+        painter.end();
+
+        PaperCropSettings automatic;
+        automatic.mode = PaperCropMode::Automatic;
+        const QImage automaticallyCropped = processor.process(document, automatic);
+        passed &= check(processor.paperDetected(),
+                        "automatic mode detects a high-contrast paper quadrilateral");
+        passed &= check(automaticallyCropped.size() == document.size(),
+                        "automatic crop preserves the output frame size");
+        passed &= check(automaticallyCropped.pixelColor(320, 240).lightness() > 200,
+                        "automatic crop centers the detected paper");
+    }
+
+    return passed ? 0 : 1;
+}

--- a/tests/TrackingControlWidgetTest.cpp
+++ b/tests/TrackingControlWidgetTest.cpp
@@ -1,0 +1,358 @@
+#include "CameraController.h"
+#include "TrackingControlWidget.h"
+
+#include <QApplication>
+#include <QCheckBox>
+#include <QComboBox>
+#include <QGroupBox>
+#include <QSlider>
+#include <QTimer>
+#include <iostream>
+
+struct TrackingControlWidgetTestAccess
+{
+    static void setTiny2Capabilities(TrackingControlWidget &widget, bool enabled)
+    {
+        widget.m_tiny2Capabilities = enabled;
+        widget.updateTiny2Visibility();
+    }
+
+    static void selectMode(TrackingControlWidget &widget, int mode)
+    {
+        const int index = widget.m_modeCombo->findData(mode);
+        if (index >= 0) {
+            widget.m_modeCombo->setCurrentIndex(index);
+        }
+    }
+
+    static void selectHumanSubMode(TrackingControlWidget &widget, int subMode)
+    {
+        const int index = widget.m_humanSubModeCombo->findData(subMode);
+        if (index >= 0) {
+            widget.m_humanSubModeCombo->setCurrentIndex(index);
+        }
+    }
+
+    static void setPendingGeneration(TrackingControlWidget &widget,
+                                     quint64 generation,
+                                     bool resolved)
+    {
+        widget.m_pendingTrackingIntentGeneration = generation;
+        widget.m_trackingIntentResolved = resolved;
+    }
+};
+
+namespace {
+
+bool check(bool condition, const char *message)
+{
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+    }
+    return condition;
+}
+
+QGroupBox *manualGroup(TrackingControlWidget &widget)
+{
+    return widget.findChild<QGroupBox *>(QStringLiteral("manualControlGroup"));
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+    qputenv("QT_QPA_PLATFORM", QByteArrayLiteral("offscreen"));
+    QApplication application(argc, argv);
+
+    bool passed = true;
+    CameraController controller;
+    TrackingControlWidget widget(&controller);
+
+    int trackingIntentCount = 0;
+    bool lastTrackingIntent = true;
+    bool lastModeProfileUpdate = false;
+    TrackingModeProfile lastProfile;
+    QObject::connect(
+        &widget, &TrackingControlWidget::trackingIntentEdited,
+        [&trackingIntentCount, &lastTrackingIntent,
+         &lastModeProfileUpdate, &lastProfile](
+            const TrackingControlWidget::TrackingState &state,
+            bool updateModeProfile) {
+            ++trackingIntentCount;
+            lastTrackingIntent = state.enabled;
+            lastModeProfileUpdate = updateModeProfile;
+            lastProfile = state.profile;
+        });
+
+    auto *manual = widget.findChild<QCheckBox *>(QStringLiteral("manualControlCheckBox"));
+    auto *tracking = widget.findChild<QCheckBox *>(QStringLiteral("trackingCheckBox"));
+    auto *guard = widget.findChild<QTimer *>(QStringLiteral("trackingCommandTimer"));
+    auto *controls = manualGroup(widget);
+    passed &= check(manual && tracking && guard && controls,
+                    "tracking controls expose stable test identities");
+    if (!manual || !tracking || !guard || !controls) {
+        return 1;
+    }
+
+    widget.setTrackingEnabled(true);
+    manual->setChecked(true);
+    passed &= check(trackingIntentCount >= 1 && !lastTrackingIntent,
+                    "manual toggle emits exact tracking-off persistence intent");
+    passed &= check(!widget.isManualControlEnabled() && widget.isTrackingEnabled(),
+                    "failed tracking-off request rolls the UI back");
+    passed &= check(!controls->isEnabled(),
+                    "failed tracking-off request keeps manual controls disabled");
+
+    // Configured/UI intent alone must not authorize movement. A fresh camera
+    // confirmation is the only transition that unlocks manual controls.
+    widget.setTrackingEnabled(false);
+    passed &= check(!widget.isManualControlEnabled() && !widget.isTrackingEnabled(),
+                    "unconfirmed manual intent keeps movement locked");
+    passed &= check(!controls->isEnabled(),
+                    "manual controls remain disabled before confirmation");
+
+    emit controller.trackingIntentStarted(1);
+    emit controller.trackingStateConfirmationPending(false, 1);
+    emit controller.trackingStateConfirmed(false, 1);
+    passed &= check(widget.isManualControlEnabled() && !widget.isTrackingEnabled(),
+                    "fresh tracking-off confirmation enables manual positioning");
+    passed &= check(controls->isEnabled(),
+                    "confirmed off state authorizes PTZ, zoom, and focus");
+
+    CameraController::CameraState staleTrackingState{};
+    staleTrackingState.autoFramingEnabled = true;
+    staleTrackingState.aiMode = Device::AiWorkModeHuman;
+    staleTrackingState.aiSubMode = Device::AiSubModeUpperBody;
+    staleTrackingState.zoom = 1.4;
+    staleTrackingState.manualFocusValue = 55;
+    staleTrackingState.pan = 0.25;
+    staleTrackingState.tilt = -0.2;
+
+    // Expire the UI guard, then deliver repeated stale tracking/PTZ emissions.
+    // The first update clears m_userInitiated; the following updates exercise
+    // the persistent manual-intent latch.
+    guard->stop();
+    widget.updateFromState(staleTrackingState);
+    widget.updateFromState(staleTrackingState);
+    staleTrackingState.zoom = 1.6;
+    staleTrackingState.manualFocusValue = 60;
+    staleTrackingState.pan = -0.3;
+    widget.updateFromState(staleTrackingState);
+
+    passed &= check(widget.isManualControlEnabled() && !widget.isTrackingEnabled(),
+                    "stale tracking status cannot clear explicit manual intent");
+    passed &= check(controls->isEnabled(),
+                    "PTZ, zoom, and focus emissions leave manual controls enabled");
+
+    emit controller.trackingIntentStarted(2);
+    emit controller.trackingStateConfirmationPending(false, 2);
+    emit controller.trackingStateConfirmationUncertain(2);
+    passed &= check(!widget.isManualControlEnabled() && !widget.isTrackingEnabled(),
+                    "temporary confirmation loss keeps manual intent but locks movement");
+    passed &= check(!controls->isEnabled(),
+                    "unknown AI ownership fails closed");
+    emit controller.trackingOwnershipObserved(false);
+    passed &= check(!widget.isManualControlEnabled() && !controls->isEnabled(),
+                    "AI-off telemetry cannot clear current rollback uncertainty");
+    emit controller.trackingStateConfirmed(false, 2);
+    passed &= check(widget.isManualControlEnabled(),
+                    "later fresh confirmation recovers the pending manual intent");
+
+    emit controller.trackingIntentStarted(3);
+    emit controller.trackingStateConfirmationPending(false, 3);
+    emit controller.trackingStateConfirmationFailed(true, 3);
+    passed &= check(!widget.isTrackingEnabled() && !widget.isManualControlEnabled(),
+                    "failed manual confirmation keeps the manual latch fail-closed");
+    passed &= check(!controls->isEnabled(),
+                    "failed manual confirmation disables controls that AI still owns");
+
+    emit controller.trackingIntentStarted(4);
+    emit controller.trackingStateConfirmationPending(false, 4);
+    emit controller.trackingStateConfirmed(false, 4);
+    passed &= check(!widget.isTrackingEnabled() && widget.isManualControlEnabled(),
+                    "a later fresh tracking-off confirmation safely restores manual control");
+    passed &= check(controls->isEnabled(),
+                    "fresh off confirmation authorizes PTZ, zoom, and focus");
+
+    emit controller.trackingOwnershipObserved(true);
+    passed &= check(!widget.isTrackingEnabled() && !widget.isManualControlEnabled(),
+                    "fresh external tracking-on evidence revokes manual movement only");
+    passed &= check(!controls->isEnabled(),
+                    "external AI ownership locks PTZ without clearing manual intent");
+    emit controller.trackingOwnershipObserved(false);
+    passed &= check(!widget.isTrackingEnabled() && widget.isManualControlEnabled(),
+                    "fresh external tracking-off evidence restores latched manual control");
+
+    emit controller.trackingIntentStarted(5);
+    emit controller.trackingStateConfirmationPending(true, 5);
+    emit controller.trackingStateConfirmed(true, 5);
+    passed &= check(widget.isTrackingEnabled() && !widget.isManualControlEnabled(),
+                    "a newer confirmed tracking intent can end manual control");
+    passed &= check(!controls->isEnabled(),
+                    "confirmed tracking state disables manual controls");
+
+    CameraController::CameraState staleOffState{};
+    staleOffState.autoFramingEnabled = false;
+    staleOffState.aiMode = Device::AiWorkModeNone;
+    staleOffState.zoom = 1.0;
+    guard->stop();
+    widget.updateFromState(staleOffState);
+    widget.updateFromState(staleOffState);
+    passed &= check(widget.isTrackingEnabled() && !widget.isManualControlEnabled(),
+                    "lagging tracking-off telemetry cannot replace a resolved tracking intent");
+    passed &= check(!controls->isEnabled(),
+                    "generic off telemetry never grants manual movement");
+
+    // Older and duplicate terminal signals cannot rewrite the latest resolved
+    // ownership decision.
+    emit controller.trackingStateConfirmationPending(false, 4);
+    emit controller.trackingStateConfirmationUncertain(4);
+    emit controller.trackingStateConfirmationFailed(false, 4);
+    emit controller.trackingStateConfirmed(false, 4);
+    emit controller.trackingStateConfirmed(false, 5);
+    emit controller.trackingIntentStarted(4);
+    emit controller.trackingStateConfirmed(false, 4);
+    passed &= check(widget.isTrackingEnabled() && !widget.isManualControlEnabled(),
+                    "stale starts or replayed confirmations cannot re-authorize movement");
+    passed &= check(!controls->isEnabled(),
+                    "stale generations keep manual controls locked");
+
+    // Even if a failed command tries to restore an older pending token, the
+    // strict generation high-water mark prevents it from becoming current.
+    emit controller.trackingIntentStarted(6);
+    TrackingControlWidgetTestAccess::setPendingGeneration(widget, 5, false);
+    emit controller.trackingStateConfirmed(false, 5);
+    passed &= check(widget.isTrackingEnabled() && !widget.isManualControlEnabled(),
+                    "a superseded generation cannot become current after rollback");
+    TrackingControlWidgetTestAccess::setPendingGeneration(widget, 6, false);
+    emit controller.trackingStateConfirmed(true, 6);
+
+    // Original Tiny and Meet-off protocols confirm synchronously without a
+    // separate pending phase; the exact started generation must still unlock.
+    emit controller.trackingIntentStarted(7);
+    emit controller.trackingStateConfirmed(false, 7);
+    passed &= check(!widget.isTrackingEnabled() && widget.isManualControlEnabled(),
+                    "matching synchronous tracking-off confirmation unlocks manual control");
+
+    // A rejected Tiny 2 mode or sub-mode command must not leave a selection
+    // visible that the disconnected controller did not accept.
+    TrackingControlWidgetTestAccess::setTiny2Capabilities(widget, true);
+    auto modeProfiles = defaultTiny2TrackingModeProfiles();
+    modeProfiles[2] = {
+        TrackingFocusPolicy::Manual, 77, false,
+        Device::AiTrackSpeedFast};
+    widget.setModeProfiles(modeProfiles);
+    const auto handState =
+        widget.trackingStateForMode(Device::AiWorkModeHand);
+    passed &= check(
+        handState.enabled
+        && handState.aiMode == Device::AiWorkModeHand
+        && handState.profile == modeProfiles[2],
+        "each Tiny 2 mode exposes its independent complete profile");
+
+    widget.setActiveTrackingProfile(modeProfiles[1]);
+    widget.setAiMode(Device::AiWorkModeHuman);
+    widget.setHumanSubMode(Device::AiSubModeNormal);
+    widget.setTrackingEnabled(true);
+    TrackingControlWidgetTestAccess::selectMode(widget, Device::AiWorkModeDesk);
+    passed &= check(widget.currentAiMode() == Device::AiWorkModeHuman,
+                    "failed AI-mode command restores the last accepted mode");
+    TrackingControlWidgetTestAccess::selectHumanSubMode(
+        widget, Device::AiSubModeUpperBody);
+    passed &= check(widget.currentHumanSubMode() == Device::AiSubModeNormal,
+                    "failed human sub-mode command restores the last accepted value");
+
+    auto *focusPolicy = widget.findChild<QComboBox *>(
+        QStringLiteral("trackingFocusPolicyCombo"));
+    auto *profileFocus = widget.findChild<QSlider *>(
+        QStringLiteral("trackingProfileFocusSlider"));
+    passed &= check(focusPolicy && profileFocus,
+                    "profile focus controls expose stable test identities");
+    if (focusPolicy && profileFocus) {
+        focusPolicy->setCurrentIndex(focusPolicy->findData(
+            static_cast<int>(TrackingFocusPolicy::Manual)));
+        profileFocus->setValue(82);
+        passed &= check(
+            lastModeProfileUpdate
+            && lastProfile.focusPolicy == TrackingFocusPolicy::Manual
+            && lastProfile.manualFocusPosition == 82
+            && widget.modeProfile(Device::AiWorkModeHuman)
+                .manualFocusPosition == 82,
+            "focus edits update and emit only the active mode profile");
+        passed &= check(
+            widget.modeProfile(Device::AiWorkModeHand) == modeProfiles[2],
+            "editing Human focus leaves Hand profile unchanged");
+    }
+
+    modeProfiles[1] = {
+        TrackingFocusPolicy::Face, 82, false,
+        Device::AiTrackSpeedStandard};
+    widget.setModeProfiles(modeProfiles);
+    widget.setTrackingStatePresentation({
+        false,
+        Device::AiWorkModeHuman,
+        Device::AiSubModeNormal,
+        {
+            TrackingFocusPolicy::Manual, 17, false,
+            Device::AiTrackSpeedStandard
+        }
+    });
+    auto *autoZoom = widget.findChild<QCheckBox *>(
+        QStringLiteral("trackingAutoZoomCheckBox"));
+    passed &= check(autoZoom != nullptr,
+                    "auto zoom exposes a stable profile test identity");
+    if (autoZoom) {
+        const int emissionsBeforeOffEdit = trackingIntentCount;
+        autoZoom->setChecked(true);
+        const auto activeOff = widget.trackingState();
+        passed &= check(
+            trackingIntentCount == emissionsBeforeOffEdit + 1
+            && lastModeProfileUpdate
+            && lastProfile.focusPolicy == TrackingFocusPolicy::Face
+            && lastProfile.manualFocusPosition == 82
+            && lastProfile.autoZoom
+            && widget.modeProfile(Device::AiWorkModeHuman).autoZoom,
+            "tracking-off profile edit persists the retained Human profile");
+        passed &= check(
+            !activeOff.enabled
+            && activeOff.profile.focusPolicy
+                == TrackingFocusPolicy::Manual
+            && activeOff.profile.manualFocusPosition == 17
+            && !activeOff.profile.autoZoom,
+            "tracking-off camera intent remains separate and manual");
+    }
+
+    widget.setTrackingStatePresentation({
+        false,
+        Device::AiWorkModeNone,
+        0,
+        {
+            TrackingFocusPolicy::Manual, 17, false,
+            Device::AiTrackSpeedStandard
+        }
+    });
+    passed &= check(
+        autoZoom && !autoZoom->isEnabled()
+        && focusPolicy && !focusPolicy->isEnabled()
+        && profileFocus && !profileFocus->isEnabled(),
+        "profile controls are disabled when no AI mode owns their edits");
+    if (autoZoom) {
+        const int emissionsBeforeInvalidOffEdit = trackingIntentCount;
+        autoZoom->setChecked(true);
+        passed &= check(
+            !autoZoom->isChecked()
+            && trackingIntentCount == emissionsBeforeInvalidOffEdit,
+            "programmatic Off-mode profile edit is rolled back without persistence");
+    }
+
+    widget.setV4l2Mode(true);
+    passed &= check(!widget.isManualControlEnabled() && !controls->isEnabled(),
+                    "V4L2 fallback cannot authorize movement without tracking confirmation");
+    passed &= check(!manual->isEnabled(),
+                    "V4L2 fallback disables the unsupported ownership toggle");
+    widget.setV4l2Mode(false);
+    passed &= check(manual->isEnabled() && !widget.isManualControlEnabled(),
+                    "returning to SDK mode requires a fresh ownership confirmation");
+
+    return passed ? 0 : 1;
+}

--- a/tests/VideoEffectsWidgetTest.cpp
+++ b/tests/VideoEffectsWidgetTest.cpp
@@ -1,0 +1,71 @@
+#include "VideoEffectsWidget.h"
+
+#include <QApplication>
+#include <QComboBox>
+#include <iostream>
+
+namespace {
+
+bool check(bool condition, const char *message)
+{
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+    }
+    return condition;
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+    qputenv("QT_QPA_PLATFORM", QByteArrayLiteral("offscreen"));
+    QApplication application(argc, argv);
+    bool passed = true;
+
+    VideoEffectsWidget widget;
+    int resetRequests = 0;
+    int effectChanges = 0;
+    int cropIntentChanges = 0;
+    QObject::connect(&widget, &VideoEffectsWidget::paperDetectionResetRequested,
+                     [&resetRequests]() { ++resetRequests; });
+    QObject::connect(&widget, &VideoEffectsWidget::effectsChanged,
+                     [&effectChanges](const auto &) { ++effectChanges; });
+    QObject::connect(&widget, &VideoEffectsWidget::paperCropIntentEdited,
+                     [&cropIntentChanges](const auto &) {
+                         ++cropIntentChanges;
+                     });
+
+    PaperCropSettings sceneCrop;
+    sceneCrop.mode = PaperCropMode::Automatic;
+    sceneCrop.left = 0.1f;
+    sceneCrop.top = 0.05f;
+    sceneCrop.right = 0.08f;
+    sceneCrop.bottom = 0.12f;
+
+    widget.applyPaperCropForScene(sceneCrop);
+    widget.applyPaperCropForScene(sceneCrop);
+
+    passed &= check(resetRequests == 2,
+                    "identical scene recalls each reset the old paper lock");
+    passed &= check(effectChanges == 2,
+                    "identical scene recalls each publish their crop settings");
+    passed &= check(cropIntentChanges == 0,
+                    "programmatic scene crops never impersonate user intent");
+    passed &= check(widget.settings().paperCrop == sceneCrop,
+                    "scene recall preserves the requested crop settings");
+
+    auto *modeCombo = widget.findChild<QComboBox *>(
+        QStringLiteral("paperCropModeCombo"));
+    passed &= check(modeCombo != nullptr,
+                    "paper crop mode exposes a stable test identity");
+    if (modeCombo) {
+        modeCombo->setCurrentIndex(modeCombo->findData(
+            static_cast<int>(PaperCropMode::Off)));
+        modeCombo->setCurrentIndex(modeCombo->findData(
+            static_cast<int>(PaperCropMode::Automatic)));
+        passed &= check(cropIntentChanges == 2,
+                        "each user crop-mode edit emits one intent");
+    }
+
+    return passed ? 0 : 1;
+}

--- a/tests/VirtualCameraStreamerTest.cpp
+++ b/tests/VirtualCameraStreamerTest.cpp
@@ -1,0 +1,59 @@
+#include "VirtualCameraStreamer.h"
+
+#include <QCoreApplication>
+#include <QSize>
+#include <iostream>
+
+namespace {
+
+bool check(bool condition, const char *message)
+{
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+    }
+    return condition;
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+    QCoreApplication application(argc, argv);
+    bool passed = true;
+
+    passed &= check(
+        !VirtualCameraStreamer::normalizedOutputSize(QSize()).isValid(),
+        "match-mode sentinel remains invalid");
+    passed &= check(
+        VirtualCameraStreamer::normalizedOutputSize(QSize(640, 481))
+            == QSize(640, 481),
+        "even YUYV widths remain unchanged");
+    passed &= check(
+        VirtualCameraStreamer::normalizedOutputSize(QSize(641, 481))
+            == QSize(642, 481),
+        "odd match-preview widths are normalized to an even YUYV width");
+
+    QImage oddMatchFrame(641, 481, QImage::Format_RGBA8888);
+    oddMatchFrame.fill(Qt::red);
+    const QImage preparedMatch =
+        VirtualCameraStreamer::prepareFrameForOutput(oddMatchFrame);
+    passed &= check(preparedMatch.size() == QSize(642, 481),
+                    "match-mode frame preparation normalizes an odd input width");
+    passed &= check(preparedMatch.format() == QImage::Format_RGB888,
+                    "prepared match-mode frame is ready for YUYV conversion");
+
+    const QImage preparedForced = VirtualCameraStreamer::prepareFrameForOutput(
+        oddMatchFrame, QSize(321, 241));
+    passed &= check(preparedForced.size() == QSize(322, 241),
+                    "forced odd width is normalized in the actual frame path");
+
+    VirtualCameraStreamer streamer;
+    streamer.setForcedResolution(QSize(641, 481));
+    passed &= check(streamer.forcedResolution() == QSize(642, 481),
+                    "public forced resolution reports the normalized size");
+    streamer.setForcedResolution(QSize());
+    passed &= check(!streamer.forcedResolution().isValid(),
+                    "match-preview mode clears the forced resolution");
+
+    return passed ? 0 : 1;
+}


### PR DESCRIPTION
## What does this change?

- Adds an explicit **Enable manual positioning (turns tracking off)** control so pan/tilt/zoom become usable without fighting AI tracking.
- Upgrades the three persisted slots from PTZ-only positions to scenes that restore tracking/manual mode, AI mode, auto-zoom, PTZ/zoom, and paper-crop settings.
- Adds `Ctrl+1`–`Ctrl+3` in-app scene recall and routes `obsbot-cli --preset N` through the running GUI over the user session D-Bus, so software crop state is included in global shortcuts.
- Adds a clear Tiny 2 **Desk mode** switch for automatic paper framing in the direct physical camera feed.
- Adds software paper crop for preview, snapshots, and virtual-camera output:
  - automatic paper-boundary detection and perspective correction when optional OpenCV 4 is available;
  - saved manual crop margins as a deterministic fallback;
  - stable output dimensions with aspect-preserving letterboxing.
- Preserves backward compatibility with existing config files and treats legacy PTZ presets as manual scenes on recall.
- Rejects undefined/invalid presets and propagates camera/connection failures instead of reporting false success.

## Why?

Issue #61 asks for a quick normal-view ↔ paper/table-view workflow. PTZ shortcuts alone were incomplete because tracking disabled manual controls, and optical zoom was incorrectly described as cropping. This revision addresses both gaps explicitly.

Closes #61.

## How to test

1. Build: `./build.sh build --confirm`.
2. Run: `ctest --test-dir build --output-on-failure`.
3. In **Tracking**, enable manual positioning and confirm PTZ/zoom become active and tracking turns off.
4. Configure **Creative FX → Paper Crop** (automatic or manual), then save a table scene.
5. Re-enable face tracking, disable crop, and save a normal scene.
6. Recall both scenes with their buttons and `Ctrl+N`.
7. With the GUI running, run `obsbot-cli --preset N`; confirm scene recall is routed through the GUI.
8. To test processed output, enable preview + virtual-camera output and select OBSBOT Virtual Camera in the consuming application.
9. On Tiny 2-family hardware, test Desk mode for the direct physical feed.

## Validation performed

- Clean OpenCV-enabled build.
- CTest: 3/3 passing, including synthetic quadrilateral detection/perspective crop.
- Separate no-OpenCV build and CTest: 3/3 passing; automatic mode safely falls back to the manual rectangle.
- Existing config fixture and new scene/crop schema validation pass.
- Live Tiny 2 camera preset recall passed.
- Live D-Bus scene recall through a running GUI passed.
- Independent read-only review confirmed the Tiny 2 media-mode and D-Bus false-success fixes.

## Important output boundary

Software crop cannot rewrite the camera's raw `/dev/video*` feed. For that direct feed, the app exposes Tiny 2 Desk mode and physical PTZ/zoom. Automatic document detection/perspective correction is delivered through the app preview, snapshots, and OBSBOT Virtual Camera.

## Checklist

- [x] Builds cleanly: `./build.sh build --confirm`
- [x] Tests pass with and without optional OpenCV
- [x] Tested with OBSBOT Tiny 2 (camera + D-Bus recall)
- [ ] Real-paper automatic detection visually tuned on hardware (synthetic detector test passes; operator test requested)
