### PR TITLE
Strip the build-tree RUNPATH out of the shipped binaries

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -17,6 +17,8 @@ depends=(
 makedepends=(
     'cmake'
     'git'
+    # For stripping RUNPATH out of the binaries and the vendored SDK library.
+    'patchelf'
 )
 optdepends=(
     'v4l2loopback-dkms: Kernel module for optional virtual camera output'
@@ -54,6 +56,19 @@ package() {
     install -Dm755 sdk/lib/libdev.so.1.0.2 "${pkgdir}/usr/lib/libdev.so.1.0.2"
     ln -s libdev.so.1.0.2 "${pkgdir}/usr/lib/libdev.so.1"
     ln -s libdev.so.1.0.2 "${pkgdir}/usr/lib/libdev.so"
+
+    # Both binaries link with a RUNPATH pointing at the build tree, and the
+    # vendored libdev.so carries one pointing at an OBSBOT developer's machine
+    # (/home/qy/workspace/...). Neither path exists on an installed system, and
+    # a RUNPATH naming a directory that does not exist is one someone else can
+    # create: the loader would search it before /usr/lib.
+    #
+    # Nothing is lost by removing them. libdev.so.1.0.2 is installed to
+    # /usr/lib, which the loader searches by default, so the RUNPATH was never
+    # what made this work on a user's machine.
+    patchelf --remove-rpath "${pkgdir}/usr/bin/obsbot-gui"
+    patchelf --remove-rpath "${pkgdir}/usr/bin/obsbot-cli"
+    patchelf --remove-rpath "${pkgdir}/usr/lib/libdev.so.1.0.2"
 
     # Install desktop file
     install -Dm644 obsbot-control.desktop \

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Aaron Bockelie <aaronsb@gmail.com>
 pkgname=obsbot-camera-control
-pkgver=1.3.0
+pkgver=1.3.1
 pkgrel=1
 pkgdesc="Native Linux control app for OBSBOT cameras with PTZ, auto-framing, presets, and live preview"
 arch=('x86_64')


### PR DESCRIPTION
`namcap` on the built package:

```
E: Insecure RUNPATH '/__w/arch-repo/arch-repo/PKGBUILDs/obsbot-camera-control/src/obsbot-camera-control/sdk/lib' in file ('usr/bin/obsbot-cli')
E: Insecure RUNPATH '/__w/arch-repo/arch-repo/PKGBUILDs/obsbot-camera-control/src/obsbot-camera-control/sdk/lib' in file ('usr/bin/obsbot-gui')
E: Insecure RUNPATH '/home/qy/workspace/obsbot_device_new/obsbot_device/build/rundir/RelWithDebInfo/lib' in file ('usr/lib/libdev.so.1.0.2')
```

## Why it matters

Neither directory exists on an installed system. A RUNPATH naming a directory that doesn't exist is one **someone else can create**, and the loader searches it *before* `/usr/lib`. Anyone able to write at that path chooses which `libdev.so` gets loaded.

## Why removing it is safe

Verified rather than assumed:

- `sdk/` contains only `libdev.so` (plus headers and a sample), so the binaries' RUNPATH into `sdk/lib` existed solely to find it — and `package()` installs it to `/usr/lib`.
- `readelf -d libdev.so.1.0.2` shows it NEEDs only `libstdc++.so.6`, `libgcc_s.so.1`, `libc.so.6`. All are in `/usr/lib`.

So the loader finds everything by default search path. The RUNPATH was never what made this work on a user's machine.

## What this does *not* fix

It removes the vendor's build path as a **loader search path**. It does not remove it from the binary — `strings` still finds `/home/qy/workspace/…` 105 times, because the blob ships unstripped with full debug symbols. That's cosmetic; the security property is the loader no longer searching a path an attacker could create.

It also doesn't touch anything in #39 — the statically bundled bzip2 1.0.6 (CVE-2019-12900), the unidentifiable TLS stack, or the absent SDK licence. Those are properties of the blob, not of how it's packaged.

## How it surfaced

Building on a developer's machine hides this: there the build tree really is where the RUNPATH says, so everything resolves. It shows up the first time the package is built somewhere else — which `aaronsb/arch-repo` now does, in a clean container, on every change.